### PR TITLE
fix: handle token expiration before checking isPublic decorator

### DIFF
--- a/src/auth/auth.guard.spec.ts
+++ b/src/auth/auth.guard.spec.ts
@@ -2,8 +2,10 @@
 import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { TokenExpiredError } from '@nestjs/jwt';
-import { Test } from '@nestjs/testing';
+import { Test, TestingModule } from '@nestjs/testing';
 import { JWTAuthGuard } from './auth.guard';
+import { AuthGuard } from '@nestjs/passport';
+import { IS_PUBLIC_KEY } from '../core/constants/constant';
 
 describe('JWTAuthGuard', () => {
   let guard: JWTAuthGuard;
@@ -66,6 +68,70 @@ describe('JWTAuthGuard', () => {
         TokenExpiredError,
       );
     });
+
+    it('should attempt token validation when auth header exists, regardless of public route', async () => {
+      const contextWithAuth = {
+        ...mockContext,
+        switchToHttp: () => ({
+          getRequest: () => ({
+            headers: { authorization: 'Bearer token' },
+            user: null,
+          }),
+        }),
+      } as ExecutionContext;
+
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true); // public route
+      const superCanActivateSpy = jest.spyOn(guard, 'canActivate').mockResolvedValue(true);
+
+      await guard.canActivate(contextWithAuth);
+
+      expect(superCanActivateSpy).toHaveBeenCalled();
+    });
+
+    it('should clear auth header and throw when token is expired on public route', async () => {
+      const request = {
+        headers: { authorization: 'Bearer expired-token' },
+        user: null,
+      };
+      const contextWithExpiredToken = {
+        ...mockContext,
+        switchToHttp: () => ({
+          getRequest: () => request,
+        }),
+      } as ExecutionContext;
+
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true); // public route
+      
+      // Mock the parent class's canActivate method
+      jest.spyOn(AuthGuard('jwt').prototype, 'canActivate').mockRejectedValueOnce(
+        new TokenExpiredError('jwt expired', new Date())
+      );
+
+      await expect(guard.canActivate(contextWithExpiredToken)).rejects.toThrow(
+        UnauthorizedException
+      );
+      expect(request.headers.authorization).toBeUndefined();
+    });
+
+    it('should skip token validation when no auth header exists on public route', async () => {
+      const contextWithoutAuth = {
+        ...mockContext,
+        switchToHttp: () => ({
+          getRequest: () => ({
+            headers: {},
+            user: null,
+          }),
+        }),
+      } as ExecutionContext;
+
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true);
+      const superCanActivateSpy = jest.spyOn(guard, 'canActivate');
+
+      const result = await guard.canActivate(contextWithoutAuth);
+
+      expect(result).toBe(true);
+      expect(superCanActivateSpy).toHaveBeenCalledTimes(1); // Only called once by our test
+    });
   });
 
   describe('handleRequest', () => {
@@ -96,6 +162,49 @@ describe('JWTAuthGuard', () => {
       expect(() => guard.handleRequest(null, null, null, mockContext)).toThrow(
         UnauthorizedException,
       );
+    });
+
+    it('should clear auth and return null for public routes with invalid token', () => {
+      const request = {
+        headers: { authorization: 'Bearer invalid-token' },
+        user: null,
+      };
+      const contextWithInvalidToken = {
+        ...mockContext,
+        switchToHttp: () => ({
+          getRequest: () => request,
+        }),
+      } as ExecutionContext;
+
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true);
+
+      const result = guard.handleRequest(new Error(), null, null, contextWithInvalidToken);
+
+      expect(result).toBeNull();
+      expect(request.headers.authorization).toBeUndefined();
+      expect(request.user).toBeNull();
+    });
+
+    it('should preserve valid token and user for public routes', () => {
+      const user = { id: 1 };
+      const request = {
+        headers: { authorization: 'Bearer valid-token' },
+        user: null,
+      };
+      const contextWithValidToken = {
+        ...mockContext,
+        switchToHttp: () => ({
+          getRequest: () => request,
+        }),
+      } as ExecutionContext;
+
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true);
+
+      const result = guard.handleRequest(null, user, null, contextWithValidToken);
+
+      expect(result).toBe(user);
+      expect(request.headers.authorization).toBe('Bearer valid-token');
+      expect(request.user).toBe(user);
     });
   });
 });

--- a/src/logger/audit-logger.provider.ts
+++ b/src/logger/audit-logger.provider.ts
@@ -1,7 +1,6 @@
 import { Injectable, LoggerService } from '@nestjs/common';
 import { stringify } from 'safe-stable-stringify';
 
-
 @Injectable()
 export class AuditLoggerService implements LoggerService {
   private static instance: AuditLoggerService;

--- a/src/shared/guard/visibility.guard.spec.ts
+++ b/src/shared/guard/visibility.guard.spec.ts
@@ -126,46 +126,6 @@ describe('VisibilityGuard', () => {
       await expect(guard.canActivate(context)).resolves.toBe(true);
       expect(eventService.findEventBySlug).toHaveBeenCalledWith('header-event');
     });
-
-    it('should clear authorization header when token exists but user is null', async () => {
-      const context = mockContext({
-        headers: {
-          'x-event-slug': 'test-event',
-          authorization: 'Bearer some-token',
-        },
-        user: null,
-      });
-
-      jest.spyOn(eventService, 'findEventBySlug').mockResolvedValue({
-        id: 1,
-        visibility: EventVisibility.Public,
-      } as unknown as EventEntity);
-
-      await guard.canActivate(context);
-      expect(
-        context.switchToHttp().getRequest().headers.authorization,
-      ).toBeUndefined();
-    });
-
-    it('should preserve authorization header when both token and user exist', async () => {
-      const context = mockContext({
-        headers: {
-          'x-event-slug': 'test-event',
-          authorization: 'Bearer valid-token',
-        },
-        user: { id: 1 },
-      });
-
-      jest.spyOn(eventService, 'findEventBySlug').mockResolvedValue({
-        id: 1,
-        visibility: EventVisibility.Public,
-      } as unknown as EventEntity);
-
-      await guard.canActivate(context);
-      expect(context.switchToHttp().getRequest().headers.authorization).toBe(
-        'Bearer valid-token',
-      );
-    });
   });
 
   describe('canActivate - Groups', () => {

--- a/src/shared/guard/visibility.guard.spec.ts
+++ b/src/shared/guard/visibility.guard.spec.ts
@@ -126,6 +126,46 @@ describe('VisibilityGuard', () => {
       await expect(guard.canActivate(context)).resolves.toBe(true);
       expect(eventService.findEventBySlug).toHaveBeenCalledWith('header-event');
     });
+
+    it('should clear authorization header when token exists but user is null', async () => {
+      const context = mockContext({
+        headers: {
+          'x-event-slug': 'test-event',
+          authorization: 'Bearer some-token',
+        },
+        user: null,
+      });
+
+      jest.spyOn(eventService, 'findEventBySlug').mockResolvedValue({
+        id: 1,
+        visibility: EventVisibility.Public,
+      } as unknown as EventEntity);
+
+      await guard.canActivate(context);
+      expect(
+        context.switchToHttp().getRequest().headers.authorization,
+      ).toBeUndefined();
+    });
+
+    it('should preserve authorization header when both token and user exist', async () => {
+      const context = mockContext({
+        headers: {
+          'x-event-slug': 'test-event',
+          authorization: 'Bearer valid-token',
+        },
+        user: { id: 1 },
+      });
+
+      jest.spyOn(eventService, 'findEventBySlug').mockResolvedValue({
+        id: 1,
+        visibility: EventVisibility.Public,
+      } as unknown as EventEntity);
+
+      await guard.canActivate(context);
+      expect(context.switchToHttp().getRequest().headers.authorization).toBe(
+        'Bearer valid-token',
+      );
+    });
   });
 
   describe('canActivate - Groups', () => {

--- a/src/shared/guard/visibility.guard.ts
+++ b/src/shared/guard/visibility.guard.ts
@@ -24,16 +24,11 @@ export class VisibilityGuard implements CanActivate {
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
+
     const eventSlug = request.headers['x-event-slug'] as string;
     const groupSlug = request.headers['x-group-slug'] as string;
-    const user = request.user;
-    const token = request.headers.authorization?.split(' ')[1];
 
-    // If there's a token but no user, it means token is expired and refresh failed
-    // We should treat this as an unauthenticated request
-    if (token && !user) {
-      request.headers.authorization = undefined;
-    }
+    const user = request.user;
 
     if (eventSlug) {
       const event = await this.eventService.findEventBySlug(eventSlug);
@@ -45,22 +40,28 @@ export class VisibilityGuard implements CanActivate {
         case EventVisibility.Public:
           return true;
         case EventVisibility.Authenticated:
+          if (!user) {
+            throw new ForbiddenException(
+              'VisibilityGuard: This event is not public',
+            );
+          }
+          break;
         case EventVisibility.Private:
           if (!user) {
             throw new ForbiddenException(
               'VisibilityGuard: This event is not public',
             );
           }
-          if (event.visibility === EventVisibility.Private) {
-            const eventAttendee = await this.eventAttendeeService.findEventAttendeeByUserId(
+          // Check if user is an attendee of the private event
+          const eventAttendee =
+            await this.eventAttendeeService.findEventAttendeeByUserId(
               event.id,
               user.id,
             );
-            if (!eventAttendee) {
-              throw new ForbiddenException(
-                'VisibilityGuard: You do not have permission to view this private event',
-              );
-            }
+          if (!eventAttendee) {
+            throw new ForbiddenException(
+              'VisibilityGuard: You do not have permission to view this private event',
+            );
           }
           break;
         default:

--- a/src/shared/guard/visibility.guard.ts
+++ b/src/shared/guard/visibility.guard.ts
@@ -4,6 +4,7 @@ import {
   Injectable,
   ForbiddenException,
   NotFoundException,
+  Logger,
 } from '@nestjs/common';
 import { EventService } from '../../event/event.service';
 import {
@@ -12,14 +13,14 @@ import {
 } from '../../core/constants/constant';
 import { EventAttendeeService } from '../../event-attendee/event-attendee.service';
 import { GroupService } from '../../group/group.service';
-import { GroupMemberService } from '../../group-member/group-member.service';
+
 @Injectable()
 export class VisibilityGuard implements CanActivate {
+  private readonly logger = new Logger(VisibilityGuard.name);
   constructor(
     private readonly eventService: EventService,
     private readonly eventAttendeeService: EventAttendeeService,
     private readonly groupService: GroupService,
-    private readonly groupMemberService: GroupMemberService,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {


### PR DESCRIPTION
The auth guard now validates tokens (if present) before checking if a route is public. This ensures proper token refresh flow even on public routes.

- Modified JWTAuthGuard to validate tokens regardless of route publicity
- Clear invalid tokens from request headers
- Added tests for token expiration handling
- Ensures visibility guard receives correct authentication state

This fixes an issue where expired tokens on public routes weren't getting a chance to refresh, leading to visibility guard errors for private or authenticated groups/events.