### PR TITLE
Add Timezone to Events

### DIFF
--- a/src/database/migrations/1747413187416-AddTimeZoneToEvent.ts
+++ b/src/database/migrations/1747413187416-AddTimeZoneToEvent.ts
@@ -1,0 +1,59 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddTimeZoneToEvent1747413187416 implements MigrationInterface {
+  name = 'AddTimeZoneToEvent1747413187416';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const schema = queryRunner.connection.options.name || 'public';
+    console.log('Running AddTimeZoneToEvent migration...');
+
+    // Add the timeZone column if it does not exist
+    const columnExists = await queryRunner.query(`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_schema = '${schema}'
+        AND table_name = 'events'
+        AND column_name = 'timeZone';
+    `);
+
+    if (columnExists && columnExists.length > 0) {
+      // If the column exists but is nullable or has no default, alter it
+      await queryRunner.query(`
+        ALTER TABLE "${schema}"."events"
+        ALTER COLUMN "timeZone" SET DEFAULT 'UTC',
+        ALTER COLUMN "timeZone" SET NOT NULL;
+      `);
+      console.log('Ensured timeZone column is NOT NULL with default UTC');
+    } else {
+      await queryRunner.query(`
+        ALTER TABLE "${schema}"."events"
+        ADD COLUMN "timeZone" VARCHAR(100) NOT NULL DEFAULT 'UTC';
+      `);
+      console.log(
+        'Added timeZone column to events table as NOT NULL with default UTC',
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const schema = queryRunner.connection.options.name || 'public';
+    console.log('Reverting AddTimeZoneToEvent migration...');
+
+    // Remove the timeZone column if it exists
+    const columnExists = await queryRunner.query(`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_schema = '${schema}'
+        AND table_name = 'events'
+        AND column_name = 'timeZone';
+    `);
+
+    if (columnExists && columnExists.length > 0) {
+      await queryRunner.query(`
+        ALTER TABLE "${schema}"."events"
+        DROP COLUMN "timeZone";
+      `);
+      console.log('Dropped timeZone column from events table');
+    } else {
+      console.log('Column timeZone does not exist on events table, skipping');
+    }
+  }
+} 

--- a/src/database/migrations/1747413187416-AddTimeZoneToEvent.ts
+++ b/src/database/migrations/1747413187416-AddTimeZoneToEvent.ts
@@ -56,4 +56,4 @@ export class AddTimeZoneToEvent1747413187416 implements MigrationInterface {
       console.log('Column timeZone does not exist on events table, skipping');
     }
   }
-} 
+}

--- a/src/event-series/event-management-series-integration.spec.ts
+++ b/src/event-series/event-management-series-integration.spec.ts
@@ -323,15 +323,16 @@ describe('EventManagementService Integration with EventSeriesService', () => {
 
     // Create event with series
     const eventData: CreateEventDto = {
-      name: 'Test Event',
-      description: 'Test event description',
-      startDate: new Date(),
-      endDate: new Date(),
+      name: 'Series Event 1',
+      description: 'Description for series event 1',
+      startDate: new Date('2024-01-15T10:00:00Z'),
+      endDate: new Date('2024-01-15T12:00:00Z'),
       type: EventType.InPerson,
-      locationOnline: 'false',
+      locationOnline: 'http://test.com',
       categories: [],
-      maxAttendees: 20,
+      maxAttendees: 50,
       seriesSlug: 'test-series',
+      timeZone: 'UTC',
     };
 
     const result = await managementService.create(eventData, 1);

--- a/src/event-series/event-series-integration.spec.ts
+++ b/src/event-series/event-series-integration.spec.ts
@@ -110,17 +110,18 @@ describe('EventSeries Module Integration', () => {
   describe('createEvent', () => {
     it('should create an event with series', async () => {
       const data: CreateEventDto = {
-        name: 'Test Event',
-        description: 'Test event description',
-        startDate: new Date('2023-01-01T00:00:00Z'),
-        endDate: new Date('2023-01-01T01:00:00Z'),
+        name: 'Test Event Series',
+        description: 'Test Description',
+        startDate: new Date('2024-01-01T10:00:00Z'),
+        endDate: new Date('2024-01-01T12:00:00Z'),
         type: EventType.InPerson,
-        locationOnline: 'false',
+        locationOnline: 'http://test.com',
         categories: [],
-        maxAttendees: 20,
-        lat: 40.7128,
-        lon: -74.006,
-        seriesSlug: 'test-series',
+        maxAttendees: 100,
+        lat: 0,
+        lon: 0,
+        seriesSlug: 'test-event-series',
+        timeZone: 'UTC',
       };
 
       await eventManagementService.create(data, 1);

--- a/src/event-series/services/event-series.service.ts
+++ b/src/event-series/services/event-series.service.ts
@@ -713,6 +713,7 @@ export class EventSeriesService {
                   allowWaitlist: templateEvent.allowWaitlist,
                   categories: templateEvent.categories.map((cat) => cat.id),
                   seriesSlug: series.slug,
+                  timeZone: templateEvent.timeZone || series.timeZone || 'UTC',
                 },
                 userId,
                 series.slug,

--- a/src/event/dto/create-event.dto.ts
+++ b/src/event/dto/create-event.dto.ts
@@ -260,13 +260,12 @@ export class CreateEventDto implements SourceFields {
   group?: { id: number } | GroupEntity;
 
   // Recurrence fields
-  @ApiPropertyOptional({
+  @ApiProperty({
     description: 'Timezone identifier (e.g., "America/New_York")',
     example: 'America/New_York',
   })
-  @IsOptional()
   @IsString()
-  timeZone?: string;
+  timeZone: string;
 
   @ApiPropertyOptional({
     description: 'Recurrence rule following RFC 5545 standards',

--- a/src/event/dto/event-response.dto.ts
+++ b/src/event/dto/event-response.dto.ts
@@ -96,8 +96,11 @@ export class EventResponseDto {
   lastSyncedAt?: Date | null;
 
   // Recurring event fields
-  @ApiPropertyOptional()
-  timeZone?: string;
+  @ApiProperty({
+    description: 'Timezone identifier (e.g., "America/New_York")',
+    example: 'America/New_York',
+  })
+  timeZone: string;
 
   @ApiPropertyOptional()
   recurrenceRule?: RecurrenceRuleDto;

--- a/src/event/event.controller.spec.ts
+++ b/src/event/event.controller.spec.ts
@@ -14,7 +14,6 @@ import {
   mockEvent,
   mockEventAttendee,
   mockEventAttendeeService,
-  mockGroup,
   mockGroupMemberService,
   mockGroupService,
   mockUser,
@@ -37,16 +36,17 @@ import { EventSeriesOccurrenceService } from '../event-series/services/event-ser
 const createEventDto: CreateEventDto = {
   name: 'Test Event',
   description: 'Test Description',
-  startDate: new Date(),
-  endDate: new Date(),
-  group: { id: mockGroup.id },
-  type: 'in_person',
+  startDate: new Date('2024-01-01T10:00:00Z'),
+  endDate: new Date('2024-01-01T12:00:00Z'),
+  group: { id: 1 },
+  type: 'Test Type',
   location: 'Test Location',
-  locationOnline: 'Test Location Online',
+  locationOnline: 'http://test.com',
   maxAttendees: 100,
-  categories: [mockCategory.id],
+  categories: [1, 2],
   lat: 0,
   lon: 0,
+  timeZone: 'UTC',
 };
 
 const mockAuthService = {
@@ -205,7 +205,7 @@ describe('EventController', () => {
       const result = await controller.create(createEventDto, mockUser, {
         user: mockUser,
         headers: {},
-        body: createEventDto,
+        body: { ...createEventDto, timeZone: 'UTC' },
       } as unknown as Request);
 
       expect(result).toEqual(mockEvent);
@@ -223,7 +223,7 @@ describe('EventController', () => {
         controller.create(createEventDto, mockUser, {
           user: mockUser,
           headers: {},
-          body: createEventDto,
+          body: { ...createEventDto, timeZone: 'UTC' },
         } as unknown as Request),
       ).rejects.toThrow('Database error');
     });
@@ -544,6 +544,7 @@ describe('EventController', () => {
         categories: [mockCategory.id],
         lat: 0,
         lon: 0,
+        timeZone: 'UTC',
       };
 
       beforeEach(() => {
@@ -579,7 +580,7 @@ describe('EventController', () => {
         const result = await controller.create(createEventDto, mockUser, {
           user: mockUser,
           headers: {},
-          body: createEventDto,
+          body: { ...createEventDto, timeZone: 'UTC' },
         } as unknown as Request);
         expect(result).toEqual(createdEvent);
       });

--- a/src/event/infrastructure/persistence/relational/entities/event.entity.ts
+++ b/src/event/infrastructure/persistence/relational/entities/event.entity.ts
@@ -230,6 +230,12 @@ export class EventEntity
   @Column({ nullable: true, type: 'jsonb' })
   conferenceData: Record<string, any>;
 
+  /**
+   * IANA time zone identifier for the event (e.g., "America/New_York").
+   */
+  @Column({ type: 'varchar', length: 100, nullable: false, default: 'UTC' })
+  timeZone: string;
+
   @BeforeInsert()
   generateUlid() {
     if (!this.ulid) {

--- a/src/event/services/event-management.service.spec.ts
+++ b/src/event/services/event-management.service.spec.ts
@@ -316,6 +316,7 @@ describe('EventManagementService', () => {
         categories: [1, 2],
         lat: 1,
         lon: 1,
+        timeZone: 'UTC',
       };
 
       const mockAttendees = [
@@ -394,6 +395,7 @@ describe('EventManagementService', () => {
           categories: [],
           locationOnline: '', // Required field
           group: 'NaN' as any, // Force string "NaN" as group value
+          timeZone: 'UTC',
         };
 
         // Create a spy to check what's passed to repository.create
@@ -426,6 +428,7 @@ describe('EventManagementService', () => {
           categories: [],
           locationOnline: '', // Required field
           group: '2' as any, // Force string "2" as group value
+          timeZone: 'UTC',
         };
 
         // Create a spy to check what's passed to repository.create
@@ -458,6 +461,7 @@ describe('EventManagementService', () => {
           categories: [],
           locationOnline: '', // Required field
           group: { id: NaN }, // JavaScript NaN in group.id
+          timeZone: 'UTC',
         };
 
         // Create a spy to check what's passed to repository.create
@@ -490,6 +494,7 @@ describe('EventManagementService', () => {
           categories: [],
           locationOnline: '', // Required field
           group: 'null' as any, // Force string "null" as group value
+          timeZone: 'UTC',
         };
 
         // Create a spy to check what's passed to repository.create
@@ -799,6 +804,7 @@ describe('EventManagementService', () => {
         maxAttendees: 100,
         lat: 0,
         lon: 0,
+        timeZone: 'UTC',
       };
 
       const result = await service.createSeriesOccurrence(
@@ -873,7 +879,7 @@ describe('EventManagementService', () => {
           count: 5,
           byweekday: ['MO', 'WE', 'FR'],
         },
-        timeZone: 'America/New_York',
+        timeZone: 'UTC',
       };
 
       // Call the createRecurringEvent method

--- a/src/event/services/event-management.service.ts
+++ b/src/event/services/event-management.service.ts
@@ -613,6 +613,7 @@ export class EventManagementService {
       resources: updateEventDto.resources,
       blocksTime: updateEventDto.blocksTime,
       isAllDay: updateEventDto.isAllDay,
+      timeZone: updateEventDto.timeZone || 'UTC',
     };
 
     // Handle sourceType and sourceId

--- a/test/event-attendees/events-attendees.e2e-spec.ts
+++ b/test/event-attendees/events-attendees.e2e-spec.ts
@@ -52,6 +52,7 @@ describe('EventAttendeeController (e2e)', () => {
         lat: 40.7128,
         lon: -74.006,
         status: 'published', // Make sure it's published
+        timeZone: 'UTC',
         ...eventData,
       });
 

--- a/test/event-series/event-occurrences.e2e-spec.ts
+++ b/test/event-series/event-occurrences.e2e-spec.ts
@@ -37,6 +37,7 @@ describe('EventOccurrencesService (e2e)', () => {
       lon: 0.0,
       status: 'published',
       group: null,
+      timeZone: 'UTC',
     };
 
     const templateResponse = await request(TESTING_APP_URL)

--- a/test/event-series/event-series.e2e-spec.ts
+++ b/test/event-series/event-series.e2e-spec.ts
@@ -60,6 +60,7 @@ describe('EventSeriesController (e2e)', () => {
       categories: [],
       requireApproval: false,
       allowWaitlist: true,
+      timeZone: 'UTC',
     };
 
     // Create the event
@@ -181,6 +182,7 @@ describe('EventSeriesController (e2e)', () => {
       categories: [],
       requireApproval: false,
       allowWaitlist: true,
+      timeZone: 'UTC',
     };
 
     // Create the template event
@@ -304,6 +306,7 @@ describe('EventSeriesController (e2e)', () => {
       categories: [],
       requireApproval: false,
       allowWaitlist: false,
+      timeZone: 'UTC',
     };
 
     const createTemplateResponse = await request(TESTING_APP_URL)
@@ -455,6 +458,7 @@ describe('EventSeriesController (e2e)', () => {
       startDate: new Date(Date.now() + oneDay).toISOString(),
       endDate: new Date(Date.now() + oneDay + 3600000).toISOString(),
       categories: [],
+      timeZone: 'UTC',
     };
 
     const templateEventResponse = await request(TESTING_APP_URL)
@@ -532,6 +536,7 @@ describe('EventSeriesController (e2e)', () => {
       categories: [],
       requireApproval: false,
       allowWaitlist: false,
+      timeZone: 'UTC',
     };
 
     const templateEventResponse = await request(TESTING_APP_URL)
@@ -642,6 +647,7 @@ describe('EventSeriesController (e2e)', () => {
       categories: [],
       requireApproval: false,
       allowWaitlist: true,
+      timeZone: 'UTC',
     };
 
     // Create the event

--- a/test/event/event-nan-group-int-error.e2e-spec.ts
+++ b/test/event/event-nan-group-int-error.e2e-spec.ts
@@ -1,0 +1,855 @@
+import request from 'supertest';
+import { TESTING_APP_URL, TESTING_TENANT_ID } from '../utils/constants';
+import { loginAsTester } from '../utils/functions';
+
+// Set a global timeout for all tests in this file
+jest.setTimeout(60000);
+
+describe('Event Creation with NaN Integer Error (e2e)', () => {
+  let token;
+
+  // Before all tests, log in as the test user
+  beforeAll(async () => {
+    // Use loginAsTester to get a token
+    token = await loginAsTester();
+  });
+
+  /**
+   * This test is specifically designed to reproduce the error:
+   * "invalid input syntax for type integer: 'NaN'"
+   * that occurs during event creation
+   */
+  it('should reproduce the integer NaN SQL error from log', async () => {
+    // Create an event based on the exact payload from the logs
+    const eventData = {
+      name: 'Weekly Discussion',
+      description: 'Topical Conversation',
+      startDate: '2025-05-11T19:30:00.000Z',
+      type: 'in-person',
+      maxAttendees: 0,
+      visibility: 'public',
+      categories: [5],
+      sourceType: null,
+      sourceId: null,
+      sourceUrl: null,
+      sourceData: null,
+      lastSyncedAt: null,
+      timeZone: 'Pacific/Honolulu',
+      // Using the group from the logs, but converting to NaN to trigger the error
+      group: NaN, // This should become "NaN" in the query parameter and cause error
+      endDate: '2025-05-11T21:00:00.000Z',
+      lat: 19.6439006,
+      lon: -156.0091339,
+      location:
+        'Old Kona Airport State Recreation Area, Laniakea, Kailua, Hawaiʻi County, Hawaii, United States',
+      status: 'published',
+      // Add blocksTime which might be a cause of the issue
+      blocksTime: true,
+    };
+
+    // console.log('Sending event creation payload:', eventData);
+
+    // Attempt to create the event - we expect a 500 error with NaN message
+    try {
+      const response = await request(TESTING_APP_URL)
+        .post('/api/events')
+        .set('Authorization', `Bearer ${token}`)
+        .set('x-tenant-id', TESTING_TENANT_ID)
+        .send(eventData);
+
+      // console.log(`Response status: ${response.status}`);
+      // console.log(`Response body:`, response.body);
+
+      expect([500, 400, 422, 201]).toContain(response.status);
+
+      // If we get a 201, this test is NOT successfully reproducing the error
+      if (response.status === 201) {
+        // Clean up the created event
+        await request(TESTING_APP_URL)
+          .delete(`/api/events/${response.body.slug}`)
+          .set('Authorization', `Bearer ${token}`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+      }
+
+      // Check for our specific error message
+      if (response.status === 500) {
+        const errorMessage = response.body?.message || '';
+        expect(errorMessage).toContain(
+          'invalid input syntax for type integer: "NaN"',
+        );
+        console.log('Successfully reproduced the NaN integer error!');
+      }
+    } catch (error) {
+      console.error('Error during test:', error);
+      throw error;
+    }
+  });
+
+  /**
+   * Another test variation with group ID as an object with NaN value
+   */
+  it('should reproduce the error using group object with NaN id', async () => {
+    // Create event with group as object with NaN id
+    const eventData = {
+      name: 'Weekly Discussion Object',
+      description: 'Topical Conversation',
+      startDate: '2025-05-11T19:30:00.000Z',
+      type: 'in-person',
+      maxAttendees: 0,
+      visibility: 'public',
+      categories: [5],
+      timeZone: 'Pacific/Honolulu',
+      // Using group as object with NaN id
+      group: {
+        id: NaN, // This should become "NaN" in the query parameter
+      },
+      endDate: '2025-05-11T21:00:00.000Z',
+      lat: 19.6439006,
+      lon: -156.0091339,
+      location: 'Old Kona Airport State Recreation Area, Kailua, Hawaii',
+      status: 'published',
+    };
+
+    console.log(
+      'Sending event creation with group object containing NaN id:',
+      eventData,
+    );
+
+    // Attempt to create the event
+    const response = await request(TESTING_APP_URL)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', TESTING_TENANT_ID)
+      .send(eventData);
+
+    console.log(`Response status: ${response.status}`);
+    console.log(`Response body:`, response.body);
+
+    // Expect successful creation (201) as the service now handles NaN group IDs gracefully
+    expect(response.status).toBe(201);
+
+    // Verify that the group is null or undefined in the response
+    expect(response.body.group).toBeUndefined(); // Or .toBeUndefined(), adjust based on actual API behavior
+
+    console.log(
+      'NaN in group.id was handled gracefully, event created with null group.',
+    );
+
+    // Clean up the created event
+    if (response.body && response.body.slug) {
+      await request(TESTING_APP_URL)
+        .delete(`/api/events/${response.body.slug}`)
+        .set('Authorization', `Bearer ${token}`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+    }
+  });
+
+  /**
+   * Test for string "NaN" as group ID value (direct reproduction of the error from logs)
+   */
+  it('should reproduce the exact error by bypassing normal processing', async () => {
+    // This test attempts to bypass any TypeScript validation and directly pass a "NaN" string to the API
+    // We're mimicking what happens when the JSON is stringified and sent to the server
+
+    const rawJsonPayload = JSON.stringify({
+      name: 'Test Exact NaN Reproduction',
+      description: 'This payload mimics the exact error conditions',
+      startDate: '2025-05-11T19:30:00.000Z',
+      type: 'in-person',
+      visibility: 'public',
+      categories: [5],
+      timeZone: 'Pacific/Honolulu',
+      lat: 19.6439006,
+      lon: -156.0091339,
+      location: 'Old Kona Airport State Recreation Area, Hawaii',
+      status: 'published',
+      // Force the group value to be parsed as NaN string in the low-level processing
+      // by using a string replacement trick to prevent TypeScript from converting it
+      group: 'NaN', // This should become a string "NaN" in the request
+    });
+
+    // Use string replacement to force NaN string (not native NaN)
+    // We're doing this because when sending NaN in JavaScript, it often gets
+    // converted to null or lost in transit
+    const forcedPayload = rawJsonPayload.replace(
+      '"group":"NaN"',
+      '"group":"NaN"',
+    );
+
+    console.log('Sending raw payload with forced string NaN:', forcedPayload);
+
+    // Attempt to create the event using the raw payload
+    try {
+      const response = await request(TESTING_APP_URL)
+        .post('/api/events')
+        .set('Authorization', `Bearer ${token}`)
+        .set('x-tenant-id', TESTING_TENANT_ID)
+        .set('Content-Type', 'application/json')
+        .send(forcedPayload);
+
+      console.log(`Raw NaN test - Response status: ${response.status}`);
+
+      if (response.status === 500) {
+        const errorMessage = response.body?.message || '';
+        console.log(`Error message: ${errorMessage}`);
+
+        if (
+          errorMessage.includes('invalid input syntax for type integer: "NaN"')
+        ) {
+          console.log('SUCCESS! Reproduced the exact error from the logs!');
+        }
+      } else if (response.status === 201) {
+        console.log('Event was created successfully - NaN was handled');
+
+        // Clean up the created event
+        await request(TESTING_APP_URL)
+          .delete(`/api/events/${response.body.slug}`)
+          .set('Authorization', `Bearer ${token}`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+      }
+    } catch (error) {
+      console.error('Error during test:', error.message);
+    }
+  });
+
+  /**
+   * Test specifically for NaN in priority field
+   */
+  it('should test event creation with priority set to NaN', async () => {
+    // Create event with priority explicitly set to NaN
+    const eventData = {
+      name: 'Test Priority NaN',
+      description: 'Event with NaN priority value',
+      startDate: '2025-05-11T19:30:00.000Z',
+      endDate: '2025-05-11T21:00:00.000Z',
+      type: 'in-person',
+      maxAttendees: 10,
+      visibility: 'public',
+      categories: [5],
+      timeZone: 'Pacific/Honolulu',
+      lat: 19.6439006,
+      lon: -156.0091339,
+      location: 'Old Kona Airport State Recreation Area, Hawaii',
+      status: 'published',
+      priority: NaN, // Explicitly set priority to NaN
+    };
+
+    console.log('Sending event creation with priority=NaN:', eventData);
+
+    // Attempt to create the event
+    const response = await request(TESTING_APP_URL)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', TESTING_TENANT_ID)
+      .send(eventData);
+
+    console.log(`Priority NaN test - Response status: ${response.status}`);
+
+    if (response.body) {
+      console.log('Response body:', {
+        priority: response.body.priority,
+        groupId: response.body.group?.id,
+        id: response.body.id,
+        slug: response.body.slug,
+      });
+    }
+
+    // If we get a 500 with our specific error, we've reproduced the issue
+    if (response.status === 500) {
+      const errorMessage = response.body?.message || '';
+
+      if (
+        errorMessage.includes('invalid input syntax for type integer: "NaN"')
+      ) {
+        console.log('Successfully reproduced the NaN integer error!');
+      } else {
+        console.log(
+          `Got 500 error, but not our target error. Message: ${errorMessage}`,
+        );
+      }
+    }
+    // If we get a 201, check how the NaN was handled
+    else if (response.status === 201) {
+      console.log('Event was created successfully - NaN priority was handled');
+      console.log(
+        `The priority value was converted to: ${response.body.priority}`,
+      );
+
+      // Clean up the created event
+      await request(TESTING_APP_URL)
+        .delete(`/api/events/${response.body.slug}`)
+        .set('Authorization', `Bearer ${token}`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+    }
+  });
+
+  /**
+   * Test using the exact parameters from the failed SQL query in the logs
+   */
+  it('should reproduce the error using the exact parameters from logs', async () => {
+    // The failing SQL query parameters:
+    // "01jts5b09ndgy5kx67zgkr2y9q","Weekly Discussion","weekly-discussion-q0b7nl","in-person",
+    // "Topical Conversation","2025-05-11T19:30:00.000Z","2025-05-11T21:00:00.000Z",0,
+    // "{\"type\":\"Point\",\"coordinates\":[-156.0091339,19.6439006]}",
+    // "Old Kona Airport State Recreation Area, Laniakea, Kailua, Hawaiʻi County, Hawaii, United States",
+    // 19.6439006,-156.0091339,"published","public",true,70,null
+
+    // Create an event closely matching the failing query parameters
+    const eventData = {
+      name: 'Weekly Discussion',
+      description: 'Topical Conversation',
+      startDate: '2025-05-11T19:30:00.000Z',
+      endDate: '2025-05-11T21:00:00.000Z',
+      type: 'in-person',
+      maxAttendees: 0,
+      visibility: 'public',
+      categories: [5],
+      timeZone: 'Pacific/Honolulu',
+      // Using the group ID from the logs (70) - but this needs to be transformed to NaN somehow
+      group: 17, // ID from the log, should be stringified correctly
+      lat: 19.6439006,
+      lon: -156.0091339,
+      location:
+        'Old Kona Airport State Recreation Area, Laniakea, Kailua, Hawaiʻi County, Hawaii, United States',
+      status: 'published',
+      blocksTime: true,
+      // Try some other fields that might get converted to NaN
+      priority: NaN,
+      // Include a pre-built locationPoint matching the one in the query
+      locationPoint: {
+        type: 'Point',
+        coordinates: [-156.0091339, 19.6439006],
+      },
+    };
+
+    // console.log(
+    //   'Sending event creation with exact parameters from logs:',
+    //   eventData,
+    // );
+
+    // Attempt to create the event
+    const response = await request(TESTING_APP_URL)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', TESTING_TENANT_ID)
+      .send(eventData);
+
+    console.log(`Response status: ${response.status}`);
+    console.log(`Response body:`, response.body);
+
+    if (response.status === 201) {
+      // Clean up the created event
+      await request(TESTING_APP_URL)
+        .delete(`/api/events/${response.body.slug}`)
+        .set('Authorization', `Bearer ${token}`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+    }
+    // expect(response.status).not.toBe(500);
+  });
+
+  /**
+   * Test specific integer fields one by one to isolate the issue
+   */
+  it('should test each integer field individually to isolate the NaN problem', async () => {
+    // We'll try a series of test cases for different fields that might be causing the problem
+    const testCases = [
+      {
+        name: 'group_id_as_nan',
+        data: {
+          group: { id: NaN },
+          otherFields: true,
+        },
+      },
+      {
+        name: 'group_id_as_string_nan',
+        data: {
+          group: { id: 'NaN' }, // String "NaN" for group.id
+          otherFields: true,
+        },
+      },
+      {
+        name: 'group_as_string_nan',
+        data: {
+          group: 'NaN',
+          otherFields: true,
+        },
+      },
+      {
+        name: 'group_id_as_null',
+        data: {
+          group: { id: null },
+          otherFields: true,
+        },
+      },
+      {
+        name: 'group_as_null',
+        data: {
+          group: null,
+          otherFields: true,
+        },
+      },
+      {
+        name: 'priority_as_nan',
+        data: {
+          priority: NaN,
+          otherFields: true,
+        },
+      },
+      {
+        name: 'max_attendees_as_nan',
+        data: {
+          maxAttendees: NaN,
+          otherFields: true,
+        },
+      },
+    ];
+
+    // Run each test case
+    for (const testCase of testCases) {
+      console.log(`\nRunning test case: ${testCase.name}`);
+
+      // Create base event data with specific fields for test case
+      const eventData: any = {
+        name: `Test ${testCase.name}`,
+        description: 'Test for NaN errors',
+        startDate: '2025-05-11T19:30:00.000Z',
+        endDate: '2025-05-11T21:00:00.000Z',
+        type: 'in-person',
+        maxAttendees: 0,
+        visibility: 'public',
+        categories: [5],
+        timeZone: 'Pacific/Honolulu',
+        lat: 19.6439006,
+        lon: -156.0091339,
+        location: 'Old Kona Airport State Recreation Area, Kailua, Hawaii',
+        status: 'published',
+        // Now apply the specific test case fields
+        ...testCase.data,
+      };
+
+      // Remove otherFields flag if present
+      if ('otherFields' in eventData) {
+        delete eventData.otherFields;
+      }
+
+      console.log('Sending payload:', eventData);
+
+      // Attempt to create the event
+      const response = await request(TESTING_APP_URL)
+        .post('/api/events')
+        .set('Authorization', `Bearer ${token}`)
+        .set('x-tenant-id', TESTING_TENANT_ID)
+        .send(eventData);
+
+      console.log(`${testCase.name} - Response status: ${response.status}`);
+
+      if (response.status === 500) {
+        const errorMessage = response.body?.message || '';
+        console.log(`${testCase.name} - Error message: ${errorMessage}`);
+
+        if (
+          errorMessage.includes('invalid input syntax for type integer: "NaN"')
+        ) {
+          console.log(`${testCase.name} - FOUND OUR ERROR!`);
+          console.log(
+            `The field causing the "NaN" error is from test case: ${testCase.name}`,
+          );
+        }
+      } else if (response.status === 201) {
+        console.log(`${testCase.name} - Event created successfully (no error)`);
+
+        // Clean up the created event
+        await request(TESTING_APP_URL)
+          .delete(`/api/events/${response.body.slug}`)
+          .set('Authorization', `Bearer ${token}`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+      } else {
+        console.log(
+          `${testCase.name} - Got validation response: ${response.status}`,
+        );
+      }
+    }
+  });
+
+  /**
+   * Test with direct JSON string containing "null" as group value
+   */
+  it('should test event creation with raw JSON containing string null for group', async () => {
+    // Create a raw JSON string with "null" as group value (not JavaScript null)
+    const rawJsonPayload = JSON.stringify({
+      name: 'Test Raw JSON with String Null Group',
+      description: 'Using raw JSON with string "null" for group',
+      startDate: '2025-05-11T19:30:00.000Z',
+      endDate: '2025-05-11T21:00:00.000Z',
+      type: 'in-person',
+      visibility: 'public',
+      categories: [5],
+      timeZone: 'Pacific/Honolulu',
+      lat: 19.6439006,
+      lon: -156.0091339,
+      location: 'Old Kona Airport State Recreation Area, Hawaii',
+      status: 'published',
+      // This will become a string in JSON, but we want to preserve it as "null" string
+      group: 'null',
+    });
+
+    // Replace the correctly quoted "null" with a string "null" to ensure it's not processed as null
+    const forcedPayload = rawJsonPayload.replace(
+      '"group":"null"',
+      '"group":"null"',
+    );
+
+    console.log(
+      'Sending raw payload with string null for group:',
+      forcedPayload,
+    );
+
+    // Attempt to create the event using the raw payload
+    try {
+      const response = await request(TESTING_APP_URL)
+        .post('/api/events')
+        .set('Authorization', `Bearer ${token}`)
+        .set('x-tenant-id', TESTING_TENANT_ID)
+        .set('Content-Type', 'application/json')
+        .send(forcedPayload);
+
+      console.log(
+        `Raw string "null" test - Response status: ${response.status}`,
+      );
+
+      if (response.status === 500) {
+        const errorMessage = response.body?.message || '';
+        console.log(`Error message: ${errorMessage}`);
+      } else if (response.status === 201) {
+        console.log(
+          'Event was created successfully - string "null" was handled',
+        );
+        console.log('Response group value:', response.body.group);
+
+        // Clean up the created event
+        await request(TESTING_APP_URL)
+          .delete(`/api/events/${response.body.slug}`)
+          .set('Authorization', `Bearer ${token}`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+      } else {
+        console.log('Validation response:', response.body);
+      }
+    } catch (error) {
+      console.error('Error during test:', error.message);
+    }
+  });
+
+  /**
+   * Standalone test with string "null" for groupId
+   */
+  it('should test event creation with string "null" for groupId', async () => {
+    // Create event with string "null" for group ID
+    const eventData = {
+      name: 'Test String Null Group ID',
+      description: 'Event with "null" string for group ID',
+      startDate: '2025-05-11T19:30:00.000Z',
+      endDate: '2025-05-11T21:00:00.000Z',
+      type: 'in-person',
+      maxAttendees: 10,
+      visibility: 'public',
+      categories: [5],
+      timeZone: 'Pacific/Honolulu',
+      lat: 19.6439006,
+      lon: -156.0091339,
+      location: 'Old Kona Airport State Recreation Area, Hawaii',
+      status: 'published',
+      group: { id: 'null' }, // Explicitly set group.id to string "null"
+    };
+
+    console.log(
+      'Sending event creation with string "null" for group ID:',
+      eventData,
+    );
+
+    // Attempt to create the event
+    const response = await request(TESTING_APP_URL)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', TESTING_TENANT_ID)
+      .send(eventData);
+
+    console.log(
+      `String "null" groupId test - Response status: ${response.status}`,
+    );
+
+    if (response.body) {
+      console.log('Response body:', {
+        group: response.body.group,
+        id: response.body.id,
+        slug: response.body.slug,
+      });
+    }
+
+    // If we get a 500, check if it's our NaN error
+    if (response.status === 500) {
+      const errorMessage = response.body?.message || '';
+      console.log(`Got 500 error. Message: ${errorMessage}`);
+    }
+    // If we get a 201, the string "null" was handled successfully
+    else if (response.status === 201) {
+      console.log(
+        'Event was created successfully - string "null" group.id was handled',
+      );
+      console.log(`The group value in response:`, response.body.group);
+
+      // Clean up the created event
+      await request(TESTING_APP_URL)
+        .delete(`/api/events/${response.body.slug}`)
+        .set('Authorization', `Bearer ${token}`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+    }
+    // If we get validation errors, log them
+    else if ([400, 422].includes(response.status)) {
+      console.log(
+        'Validation caught the issue - did not reach the database layer',
+      );
+      console.log('Validation errors:', response.body);
+    }
+  });
+
+  /**
+   * Test with direct SQL-like string approach for "NaN" group value
+   */
+  it('should test SQL error when directly passing NaN string', async () => {
+    // This is a more direct approach to try to reproduce the SQL error
+    // We'll specifically attempt to bypass any validation or conversion
+    const directSqlPayload = `{
+      "name": "SQL NaN Test",
+      "description": "Attempt to directly pass NaN to SQL layer",
+      "startDate": "2025-05-11T19:30:00.000Z",
+      "endDate": "2025-05-11T21:00:00.000Z", 
+      "type": "in-person",
+      "maxAttendees": 10,
+      "visibility": "public",
+      "categories": [5],
+      "timeZone": "Pacific/Honolulu",
+      "lat": 19.6439006,
+      "lon": -156.0091339,
+      "location": "Old Kona Airport State Recreation Area, Hawaii",
+      "status": "published",
+      "group": "NaN"
+    }`;
+
+    console.log('Sending direct SQL-like payload with NaN:', directSqlPayload);
+
+    // Attempt to create the event using the direct payload
+    try {
+      const response = await request(TESTING_APP_URL)
+        .post('/api/events')
+        .set('Authorization', `Bearer ${token}`)
+        .set('x-tenant-id', TESTING_TENANT_ID)
+        .set('Content-Type', 'application/json')
+        .send(directSqlPayload);
+
+      console.log(`Direct SQL NaN test - Response status: ${response.status}`);
+
+      if (response.status === 500) {
+        const errorMessage = response.body?.message || '';
+        console.log(`SQL Error message: ${errorMessage}`);
+
+        if (errorMessage.includes('invalid input syntax for type integer')) {
+          console.log('SUCCESS! Reproduced the exact SQL error!');
+        }
+      } else if (response.status === 201) {
+        console.log(
+          'Event was created successfully - NaN was handled at service layer',
+        );
+        console.log('Response group value:', response.body.group);
+
+        // Clean up the created event
+        await request(TESTING_APP_URL)
+          .delete(`/api/events/${response.body.slug}`)
+          .set('Authorization', `Bearer ${token}`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+      } else {
+        console.log('Validation response:', response.body);
+      }
+    } catch (error) {
+      console.error('Error during test:', error.message);
+    }
+  });
+
+  /**
+   * Standalone test with null groupId
+   */
+  it('should test event creation with explicitly null groupId', async () => {
+    // Create event with null group ID
+    const eventData = {
+      name: 'Test Null Group ID',
+      description: 'Event with null group ID value',
+      startDate: '2025-05-11T19:30:00.000Z',
+      endDate: '2025-05-11T21:00:00.000Z',
+      type: 'in-person',
+      maxAttendees: 10,
+      visibility: 'public',
+      categories: [5],
+      timeZone: 'Pacific/Honolulu',
+      lat: 19.6439006,
+      lon: -156.0091339,
+      location: 'Old Kona Airport State Recreation Area, Hawaii',
+      status: 'published',
+      group: { id: null }, // Explicitly set group.id to null
+    };
+
+    console.log('Sending event creation with null group ID:', eventData);
+
+    // Attempt to create the event
+    const response = await request(TESTING_APP_URL)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', TESTING_TENANT_ID)
+      .send(eventData);
+
+    console.log(`Null groupId test - Response status: ${response.status}`);
+
+    if (response.body) {
+      console.log('Response body:', {
+        group: response.body.group,
+        id: response.body.id,
+        slug: response.body.slug,
+      });
+    }
+
+    // If we get a 500, check if it's our NaN error
+    if (response.status === 500) {
+      const errorMessage = response.body?.message || '';
+      console.log(`Got 500 error. Message: ${errorMessage}`);
+    }
+    // If we get a 201, the null was handled successfully
+    else if (response.status === 201) {
+      console.log('Event was created successfully - null group.id was handled');
+      console.log(`The group value in response:`, response.body.group);
+
+      // Clean up the created event
+      await request(TESTING_APP_URL)
+        .delete(`/api/events/${response.body.slug}`)
+        .set('Authorization', `Bearer ${token}`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+    }
+    // If we get validation errors, log them
+    else if ([400, 422].includes(response.status)) {
+      console.log(
+        'Validation caught the issue - did not reach the database layer',
+      );
+      console.log('Validation errors:', response.body);
+    }
+  });
+
+  /**
+   * Test with string numeric value for group
+   */
+  it('should test event creation with string "2" for group', async () => {
+    // This test checks if the service handles string numeric values properly
+    const directSqlPayload = `{
+      "name": "String Numeric Group Test",
+      "description": "Testing group value as string number",
+      "startDate": "2025-05-11T19:30:00.000Z",
+      "endDate": "2025-05-11T21:00:00.000Z", 
+      "type": "in-person",
+      "maxAttendees": 10,
+      "visibility": "public",
+      "categories": [5],
+      "timeZone": "Pacific/Honolulu",
+      "lat": 19.6439006,
+      "lon": -156.0091339,
+      "location": "Old Kona Airport State Recreation Area, Hawaii",
+      "status": "published",
+      "group": "2"
+    }`;
+
+    console.log('Sending payload with string "2" as group:', directSqlPayload);
+
+    // Attempt to create the event using the direct payload
+    try {
+      const response = await request(TESTING_APP_URL)
+        .post('/api/events')
+        .set('Authorization', `Bearer ${token}`)
+        .set('x-tenant-id', TESTING_TENANT_ID)
+        .set('Content-Type', 'application/json')
+        .send(directSqlPayload);
+
+      console.log(
+        `String "2" group test - Response status: ${response.status}`,
+      );
+
+      if (response.status === 500) {
+        const errorMessage = response.body?.message || '';
+        console.log(`Error message: ${errorMessage}`);
+
+        if (errorMessage.includes('invalid input syntax for type integer')) {
+          console.log('Got SQL error with string "2" for group!');
+        }
+      } else if (response.status === 201) {
+        console.log('Event was created successfully - string "2" was handled');
+        console.log('Response group value:', response.body.group);
+
+        // Clean up the created event
+        await request(TESTING_APP_URL)
+          .delete(`/api/events/${response.body.slug}`)
+          .set('Authorization', `Bearer ${token}`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+      } else {
+        console.log('Validation response:', response.body);
+      }
+    } catch (error) {
+      console.error('Error during test:', error.message);
+    }
+  });
+
+  /**
+   * Test for NaN in group.id
+   */
+  it('should test event creation with NaN in group.id', async () => {
+    // Create event with NaN in group.id
+    const eventData = {
+      name: 'Test NaN in group.id',
+      description: 'Event with NaN in group.id',
+      startDate: '2025-05-11T19:30:00.000Z',
+      endDate: '2025-05-11T21:00:00.000Z',
+      type: 'in-person',
+      maxAttendees: 10,
+      visibility: 'public',
+      categories: [5],
+      timeZone: 'Pacific/Honolulu',
+      lat: 19.6439006,
+      lon: -156.0091339,
+      location: 'Old Kona Airport State Recreation Area, Hawaii',
+      status: 'published',
+      group: { id: NaN }, // Explicitly set group.id to NaN
+    };
+
+    console.log('Sending event creation with NaN in group.id:', eventData);
+
+    // Attempt to create the event
+    const response = await request(TESTING_APP_URL)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', TESTING_TENANT_ID)
+      .send(eventData);
+
+    console.log(`Response status: ${response.status}`);
+    console.log(`Response body:`, response.body);
+
+    // Expect successful creation (201)
+    expect(response.status).toBe(201);
+
+    // Verify that the group is null or undefined in the response, as NaN should be handled gracefully
+    expect(response.body.group).toBeUndefined(); // Or .toBeUndefined() depending on API behavior
+
+    // If the test reaches here, it means NaN was handled correctly.
+    console.log('NaN in group.id was handled gracefully, event created.');
+
+    // Clean up the created event
+    if (response.body && response.body.slug) {
+      await request(TESTING_APP_URL)
+        .delete(`/api/events/${response.body.slug}`)
+        .set('Authorization', `Bearer ${token}`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+    }
+  });
+});

--- a/test/event/event-nan-location.e2e-spec.ts
+++ b/test/event/event-nan-location.e2e-spec.ts
@@ -1,0 +1,440 @@
+import request from 'supertest';
+import { TESTING_APP_URL, TESTING_TENANT_ID } from '../utils/constants';
+import { loginAsTester } from '../utils/functions';
+import { EventStatus, EventType } from '../../src/core/constants/constant';
+
+// Set a global timeout for all tests in this file
+jest.setTimeout(60000);
+
+describe('Event Location Validation (e2e)', () => {
+  let token;
+
+  // Before all tests, log in as the test user
+  beforeAll(async () => {
+    // Use loginAsTester to get a token
+    token = await loginAsTester();
+  });
+
+  it('should properly handle validation of "NaN" string values in coordinates', async () => {
+    // Create event with "NaN" string in coordinates directly
+    const timestamp = Date.now();
+    const eventData = {
+      name: `Test Event with NaN String ${timestamp}`,
+      description: 'Test event with "NaN" string as coordinates',
+      type: EventType.InPerson,
+      startDate: new Date().toISOString(),
+      endDate: new Date(new Date().getTime() + 3600000).toISOString(),
+      maxAttendees: 10,
+      status: EventStatus.Published,
+      categories: [],
+      lat: 'NaN', // Explicitly passing "NaN" as a string to trigger validation
+      lon: 'NaN', // Explicitly passing "NaN" as a string to trigger validation
+      location: 'Test Location',
+      visibility: 'public',
+    };
+
+    const response = await request(TESTING_APP_URL)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', TESTING_TENANT_ID)
+      .send(eventData);
+
+    // After our fix, we expect validation to catch this with a 422
+    expect(response.status).toBe(422);
+
+    // Accept any error message (standard validation message is fine)
+    expect(response.body).toHaveProperty('message');
+  });
+
+  it('should correctly reproduce and then handle the SQL error with NaN values', async () => {
+    // We're specifically trying to reproduce the SQL error:
+    // "invalid input syntax for type integer: 'NaN'"
+
+    // To bypass typical validation checks, we need to construct an event object
+    // that will pass initial validation but trigger the database error
+    const timestamp = Date.now();
+
+    try {
+      // This data structure is designed to more directly hit the database layer
+      // by bypassing as much validation as possible
+      const eventData = {
+        name: `Weekly ${timestamp}`,
+        slug: `weekly-${timestamp}`,
+        description: 'Conversation',
+        type: EventType.InPerson,
+        startDate: new Date('2025-05-11T19:30:00.000Z').toISOString(),
+        maxAttendees: 0,
+        // Try different formats that might bypass validation but fail at SQL level
+        lat: 'NaN', // The literal string "NaN" should cause SQL type error
+        lon: 'NaN',
+        // Try with a real location to ensure we get to the database
+        location:
+          'Old Kona Airport State Recreation Area, Laniakea, Kailua, Hawaiʻi County, Hawaii, United States',
+        status: 'published',
+        visibility: 'public',
+        blocksTime: true,
+      };
+
+      // This should either:
+      // 1. With the fix: Be rejected with 400/422 (validation error)
+      // 2. Without the fix: Make it to the database and fail with 500 (SQL error)
+      const response = await request(TESTING_APP_URL)
+        .post('/api/events')
+        .set('Authorization', `Bearer ${token}`)
+        .set('x-tenant-id', TESTING_TENANT_ID)
+        .send(eventData);
+
+      console.log(`SQL Error Test - Response status: ${response.status}`);
+
+      if (response.body && response.body.message) {
+        console.log(`SQL Error Test - Message: ${response.body.message}`);
+      }
+
+      // With our fix properly implemented, we should get a validation error (400/422)
+      // not a server error (500) from the SQL layer
+      expect([400, 422, 500]).toContain(response.status);
+
+      // For debugging/verification only - if we get a 500, we know we've reproduced the original error
+      // This is actually what we're trying to fix, so it would fail without our fix
+      if (response.status === 500) {
+        console.log(
+          'Successfully reproduced the SQL error (500) - our fix is not active',
+        );
+
+        // If we get here, the test should fail to enforce that our fix is working
+        expect(response.status).not.toBe(500);
+      }
+
+      // If it somehow created the event, clean it up
+      if (response.status === 201) {
+        await request(TESTING_APP_URL)
+          .delete(`/api/events/${eventData.slug}`)
+          .set('Authorization', `Bearer ${token}`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+      }
+    } catch (error) {
+      console.error('Test error:', error.message);
+      throw error;
+    }
+  });
+
+  // Test with NaN in the priority field (which is an integer in the database)
+  it('should properly handle NaN values in integer fields like priority', async () => {
+    // Create event with NaN in priority field
+    const timestamp = Date.now();
+    const eventData = {
+      name: `Test Event with NaN priority ${timestamp}`,
+      description: 'Test event with NaN in priority field',
+      type: EventType.InPerson,
+      startDate: new Date().toISOString(),
+      endDate: new Date(new Date().getTime() + 3600000).toISOString(),
+      maxAttendees: 10,
+      status: EventStatus.Published,
+      categories: [],
+      lat: 40.7128, // Valid coordinates (New York)
+      lon: -74.006,
+      location: 'New York, NY',
+      visibility: 'public',
+      priority: NaN, // This should be serialized to "NaN" and cause validation error
+    };
+
+    const response = await request(TESTING_APP_URL)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', TESTING_TENANT_ID)
+      .send(eventData);
+
+    // Accept either validation error (422) or successful creation (201) since the NaN might be filtered or converted to null/0
+    expect([201, 400, 422, 500]).toContain(response.status);
+
+    // If it's an error, it should have an error message
+    if (response.status !== 201) {
+      expect(response.body).toHaveProperty('message');
+    }
+
+    // If the event was created, clean it up
+    if (response.status === 201) {
+      console.log(
+        'NaN in priority was handled (likely converted to null or 0)',
+      );
+      await request(TESTING_APP_URL)
+        .delete(`/api/events/${response.body.slug}`)
+        .set('Authorization', `Bearer ${token}`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+    }
+  });
+
+  // Test location search with NaN coordinates - this should target the ST_SetSRID functionality
+  it('should properly handle NaN values in event location search', async () => {
+    // This test specifically targets the event-query.service.ts showAllEvents method,
+    // which uses ST_SetSRID(ST_MakePoint(:lon, :lat), ${PostgisSrid.SRID}) in a query
+
+    // First, create a valid event to have something in the database
+    const timestamp = Date.now();
+    const validEventData = {
+      name: `Valid Test Event ${timestamp}`,
+      description: 'Test event with valid coordinates',
+      type: EventType.InPerson,
+      startDate: new Date().toISOString(),
+      endDate: new Date(new Date().getTime() + 3600000).toISOString(),
+      maxAttendees: 10,
+      status: EventStatus.Published,
+      categories: [],
+      lat: 40.7128, // Valid coordinates (New York)
+      lon: -74.006,
+      location: 'New York, NY',
+      visibility: 'public',
+      timeZone: 'UTC',
+    };
+
+    // Create the event
+    const createResponse = await request(TESTING_APP_URL)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', TESTING_TENANT_ID)
+      .send(validEventData);
+
+    expect(createResponse.status).toBe(201);
+
+    // Now try to query events with NaN coordinates
+    // This should target the showAllEvents method in the event-query service
+    const searchResponse = await request(TESTING_APP_URL)
+      .get('/api/events')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', TESTING_TENANT_ID)
+      .query({
+        lat: NaN, // This will be serialized to "NaN" in the query string
+        lon: NaN, // This will be serialized to "NaN" in the query string
+        radius: 10, // 10 miles radius
+        page: 1,
+        limit: 10,
+      });
+
+    console.log(
+      `Location search test - Response status: ${searchResponse.status}`,
+    );
+    if (searchResponse.body && searchResponse.body.message) {
+      console.log(
+        `Location search test - Message: ${searchResponse.body.message}`,
+      );
+    }
+
+    // We expect either a validation error (400/422) or an empty result set (200), not a 500 error
+    expect([200, 400, 422]).toContain(searchResponse.status);
+
+    // If we get a 500 error with the specific "invalid input syntax for type integer: 'NaN'" message,
+    // this test should fail because that's the exact error we're trying to prevent
+    if (searchResponse.status === 500) {
+      const errorMessage = searchResponse.body.message || '';
+      const isNaNSqlError = errorMessage.includes(
+        "invalid input syntax for type integer: 'NaN'",
+      );
+
+      if (isNaNSqlError) {
+        fail(
+          'Found the "invalid input syntax for type integer: \'NaN\'" error - our validation is not working',
+        );
+      }
+    }
+
+    // Clean up the created event
+    if (createResponse.status === 201) {
+      const eventSlug = createResponse.body.slug;
+      await request(TESTING_APP_URL)
+        .delete(`/api/events/${eventSlug}`)
+        .set('Authorization', `Bearer ${token}`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+    }
+  });
+
+  // Test group service location search with NaN coordinates - similar to the event search
+  it('should properly handle NaN values in group location search', async () => {
+    // This test targets the group.service.ts showAll method,
+    // which uses ST_SetSRID(ST_MakePoint(:lon, :lat), ${PostgisSrid.SRID}) in a query
+
+    // Try to query groups with NaN coordinates
+    const searchResponse = await request(TESTING_APP_URL)
+      .get('/api/groups')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', TESTING_TENANT_ID)
+      .query({
+        lat: NaN, // This will be serialized to "NaN" in the query string
+        lon: NaN, // This will be serialized to "NaN" in the query string
+        radius: 10, // 10 km radius
+        page: 1,
+        limit: 10,
+      });
+
+    console.log(
+      `Group location search test - Response status: ${searchResponse.status}`,
+    );
+    if (searchResponse.body && searchResponse.body.message) {
+      console.log(
+        `Group location search test - Message: ${searchResponse.body.message}`,
+      );
+    }
+
+    // We expect either a validation error (400/422) or an empty result set (200), not a 500 error
+    expect([200, 400, 422]).toContain(searchResponse.status);
+
+    // If we get a 500 error with the specific "invalid input syntax for type integer: 'NaN'" message,
+    // this test should fail because that's the exact error we're trying to prevent
+    if (searchResponse.status === 500) {
+      const errorMessage = searchResponse.body.message || '';
+      const isNaNSqlError = errorMessage.includes(
+        "invalid input syntax for type integer: 'NaN'",
+      );
+
+      if (isNaNSqlError) {
+        fail(
+          'Found the "invalid input syntax for type integer: \'NaN\'" error in group search - our validation is not working',
+        );
+      }
+    }
+  });
+
+  // Test directly targeting the locationPoint GeoJSON field
+  it('should properly handle NaN values inside GeoJSON locationPoint coordinates', async () => {
+    // This tests handling of NaN values inside the GeoJSON object that is processed with ST_GeomFromGeoJSON
+
+    const timestamp = Date.now();
+    const eventData = {
+      name: `GeoJSON NaN Test ${timestamp}`,
+      description: 'Test with NaN in GeoJSON coordinates',
+      type: EventType.InPerson,
+      startDate: new Date().toISOString(),
+      endDate: new Date(new Date().getTime() + 3600000).toISOString(),
+      maxAttendees: 10,
+      status: EventStatus.Published,
+      categories: [],
+      // Valid lat/lon fields
+      lat: 40.7128,
+      lon: -74.006,
+      // But a GeoJSON with NaN in coordinates
+      locationPoint: {
+        type: 'Point',
+        coordinates: [NaN, NaN], // This should be transformed to ["NaN", "NaN"] during JSON serialization
+      },
+      location: 'New York, NY',
+      visibility: 'public',
+    };
+
+    const response = await request(TESTING_APP_URL)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', TESTING_TENANT_ID)
+      .send(eventData);
+
+    console.log(`GeoJSON NaN test - Response status: ${response.status}`);
+    if (response.body && response.body.message) {
+      console.log(`GeoJSON NaN test - Message: ${response.body.message}`);
+    }
+
+    // We're observing that the system is handling NaN values in GeoJSON coordinates
+    // by either successful validation, conversion, or filtering
+    expect([200, 201, 400, 422]).toContain(response.status);
+
+    // If we get a 500 error with the specific NaN SQL error, this is a validation issue
+    if (response.status === 500) {
+      const errorMessage = response.body.message || '';
+      const isNaNSqlError = errorMessage.includes(
+        'invalid input syntax for type',
+      );
+
+      if (isNaNSqlError) {
+        fail('SQL error with NaN in GeoJSON - our validation is not working');
+      }
+    }
+
+    // If it somehow created the event, clean it up
+    if (response.status === 201) {
+      const eventSlug = response.body.slug;
+      await request(TESTING_APP_URL)
+        .delete(`/api/events/${eventSlug}`)
+        .set('Authorization', `Bearer ${token}`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+    }
+  });
+
+  // Test with exact failing query parameters
+  it('should reject the exact parameters from the failing SQL query', async () => {
+    // Using the exact parameters from the failing query:
+    // ["01jtkn984hzrzsg4s0ya5j4ger","Weekly","weekly-t1fq9","in-person","Conversation","2025-05-11T19:30:00.000Z",0,
+    // "{\"type\":\"Point\",\"coordinates\":[-156.0091339,19.6439006]}","Old Kona Airport State Recreation Area, Laniakea, Kailua, Hawaiʻi County, Hawaii, United States",
+    // 19.6439006,-156.0091339,"published","public",true,70,null]
+
+    // Create a test case that matches the exact parameters from the failing query
+    const eventData = {
+      // These fields are auto-generated, but included for reference
+      // ulid: "01jtkn984hzrzsg4s0ya5j4ger",
+      // slug: "weekly-t1fq9",
+      name: 'Weekly',
+      type: 'in-person',
+      description: 'Conversation',
+      startDate: '2025-05-11T19:30:00.000Z',
+      maxAttendees: 0,
+      // Specify the locationPoint as it appears in the query parameters
+      locationPoint: {
+        type: 'Point',
+        coordinates: [-156.0091339, 19.6439006],
+      },
+      location:
+        'Old Kona Airport State Recreation Area, Laniakea, Kailua, Hawaiʻi County, Hawaii, United States',
+      lat: 19.6439006,
+      lon: -156.0091339,
+      status: 'published',
+      visibility: 'public',
+      blocksTime: true,
+      categories: [],
+      // Add a suspicious field that might be serialized as NaN
+      priority: NaN,
+      // Try to inject a NaN as a number field that should be integer
+      someNumberField: 'NaN',
+    };
+
+    const response = await request(TESTING_APP_URL)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', TESTING_TENANT_ID)
+      .send(eventData);
+
+    // Log the response for debugging
+    console.log(`Exact parameters test - Response status: ${response.status}`);
+    if (response.body && response.body.message) {
+      console.log(`Exact parameters test - Message: ${response.body.message}`);
+    }
+
+    // Check if we're hitting the validation (422) or still getting the SQL error (500)
+    if (response.status === 500) {
+      // If we get a 500 error, check if it's the NaN SQL error
+      const errorMessage = response.body && response.body.message;
+      const isNaNSqlError =
+        errorMessage &&
+        errorMessage.includes("invalid input syntax for type integer: 'NaN'");
+
+      if (isNaNSqlError) {
+        console.log(
+          'Successfully reproduced the SQL error (500) - our fix is not active',
+        );
+        // This test should fail if we're still seeing the NaN SQL error
+        fail('The NaN SQL error is still occurring - fix is not working');
+      }
+    }
+
+    // If the response is 201 (success), the fix might be working or we didn't trigger the issue
+    if (response.status === 201) {
+      console.log(
+        'Event created successfully - NaN was either filtered or converted properly',
+      );
+      // Clean up the created event
+      await request(TESTING_APP_URL)
+        .delete(`/api/events/${response.body.slug}`)
+        .set('Authorization', `Bearer ${token}`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+    } else {
+      // We expect validation to catch this with a 422
+      expect([400, 422]).toContain(response.status);
+      expect(response.body).toHaveProperty('message');
+    }
+  });
+});

--- a/test/event/event.e2e-spec.ts
+++ b/test/event/event.e2e-spec.ts
@@ -512,6 +512,7 @@ describe('EventController (e2e)', () => {
       lon: 0.0,
       status: 'published',
       group: null,
+      timeZone: 'UTC',
     };
 
     // Create the template event
@@ -564,7 +565,7 @@ describe('EventController (e2e)', () => {
       status: 'published',
       group: null,
       isRecurring: false,
-      recurrenceRule: undefined,
+      timeZone: 'UTC',
     };
 
     const eventResponse = await request(TESTING_APP_URL)
@@ -675,6 +676,7 @@ describe('EventController (e2e)', () => {
       lon: 0.0,
       status: 'published',
       group: null,
+      timeZone: 'UTC',
     };
 
     // Create the template event
@@ -726,7 +728,7 @@ describe('EventController (e2e)', () => {
       status: 'published',
       group: null,
       isRecurring: false,
-      recurrenceRule: undefined,
+      timeZone: 'UTC',
     };
 
     const independentEventResponse = await request(TESTING_APP_URL)

--- a/test/utils/functions.ts
+++ b/test/utils/functions.ts
@@ -70,6 +70,7 @@ export async function createGroupsAndEvents(
     lon: 0,
     status: EventStatus.Published,
     group: group.id,
+    timeZone: 'UTC',
   };
 
   const event = await createEvent(app, authToken, eventData);
@@ -129,11 +130,16 @@ async function createCategory(app, token, categoryData) {
 async function createEvent(app: string, authToken: string, eventData: any) {
   // console.log('Creating event with data:', JSON.stringify(eventData, null, 2));
 
+  const payload = {
+    timeZone: 'UTC', // Default timezone
+    ...eventData, // Spread incoming eventData, potentially overriding the default timeZone if provided
+  };
+
   const response = await request(app)
     .post('/api/events')
     .set('Authorization', `Bearer ${authToken}`)
     .set('x-tenant-id', TESTING_TENANT_ID)
-    .send(eventData);
+    .send(payload);
 
   // console.log('Create event response:', {
   //  status: response.status,


### PR DESCRIPTION
Add timezone to the event table for recurrence support.  Time is stored as UTC time in the DB, and this field allows us to track the originating timezone of the event. 