### PR TITLE
fix: yearly series not working

### DIFF
--- a/src/event-series/services/recurrence-pattern.service.spec.ts
+++ b/src/event-series/services/recurrence-pattern.service.spec.ts
@@ -62,6 +62,20 @@ describe('RecurrencePatternService', () => {
       expect(occurrences[2]).toBe('2023-02-01T10:00:00.000Z');
     });
 
+    it('should generate yearly occurrences', () => {
+      const startDate = new Date('2023-01-19T14:00:00Z');
+      const rule = {
+        frequency: RecurrenceFrequency.YEARLY,
+        interval: 1,
+      };
+      const occurrences = service.generateOccurrences(startDate, rule, {
+        count: 2,
+      });
+      expect(occurrences).toHaveLength(2);
+      expect(occurrences[0]).toBe('2023-01-19T14:00:00.000Z');
+      expect(occurrences[1]).toBe('2024-01-19T14:00:00.000Z');
+    });
+
     it('should handle DST transitions correctly', () => {
       const startDate = new Date('2023-03-10T10:00:00Z');
       const rule = {

--- a/src/event-series/services/recurrence-pattern.service.ts
+++ b/src/event-series/services/recurrence-pattern.service.ts
@@ -473,6 +473,8 @@ export class RecurrencePatternService {
         return RecurrenceFrequency.WEEKLY;
       case 'MONTHLY':
         return RecurrenceFrequency.MONTHLY;
+      case 'YEARLY':
+        return RecurrenceFrequency.YEARLY;
       default:
         return RecurrenceFrequency.DAILY;
     }
@@ -491,6 +493,8 @@ export class RecurrencePatternService {
         return Frequency.WEEKLY;
       case RecurrenceFrequency.MONTHLY:
         return Frequency.MONTHLY;
+      case RecurrenceFrequency.YEARLY:
+        return Frequency.YEARLY;
       default:
         return Frequency.DAILY;
     }

--- a/src/event-series/services/recurrence-pattern.service.ts
+++ b/src/event-series/services/recurrence-pattern.service.ts
@@ -188,10 +188,12 @@ export class RecurrencePatternService {
     // Determine the date range for generation
     const effectiveStartDate =
       startAfterDate instanceof Date ? startAfterDate : dtstartDateObject;
+    // For yearly patterns, we need a longer window to see future occurrences
+    const yearsToLookAhead = rule.frequency === 'YEARLY' ? 5 : 1;
     const effectiveEndDate =
       rruleOptions.until instanceof Date
         ? rruleOptions.until
-        : addYears(effectiveStartDate, 1); // Changed from 10 years to 1 year to limit maximum occurrences
+        : addYears(effectiveStartDate, yearsToLookAhead);
 
     this.logger.debug('[generateOccurrences] Generating between', {
       start: effectiveStartDate.toISOString(),


### PR DESCRIPTION
missing support for
  YEARLY frequency. When a yearly recurrence was requested, it would default to DAILY, causing events to appear daily instead of yearly