### PR TITLE
Add chat message redaction functionality with role-based permissions, cleanup found issues

### DIFF
--- a/src/chat/adapters/matrix-chat-provider.adapter.ts
+++ b/src/chat/adapters/matrix-chat-provider.adapter.ts
@@ -243,4 +243,29 @@ export class MatrixChatProviderAdapter implements ChatProviderInterface {
       throw new Error(`Failed to send typing notification: ${error.message}`);
     }
   }
+
+  @Trace('matrix-chat-provider.redactMessage')
+  async redactMessage(options: {
+    roomId: string;
+    eventId: string;
+    reason?: string;
+    userSlug: string;
+    tenantId: string;
+  }): Promise<string> {
+    try {
+      return await this.matrixMessageService.redactMessage({
+        roomId: options.roomId,
+        eventId: options.eventId,
+        reason: options.reason,
+        userSlug: options.userSlug,
+        tenantId: options.tenantId,
+      });
+    } catch (error) {
+      this.logger.error(
+        `Failed to redact message: ${error.message}`,
+        error.stack,
+      );
+      throw new Error(`Failed to redact message: ${error.message}`);
+    }
+  }
 }

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -47,11 +48,19 @@ export class ChatController {
     @Param('slug') slug: string,
     @Body() body: { message: string },
     @AuthUser() user: User,
+    @Req() request: any,
   ): Promise<{ id: string }> {
+    // Pass the tenant ID explicitly from the request
+    const tenantId = request.tenantId;
+    if (!tenantId) {
+      throw new BadRequestException('Tenant ID is required');
+    }
+
     return await this.discussionService.sendEventDiscussionMessage(
       slug,
       user.id,
       body,
+      tenantId, // Pass tenant ID explicitly
     );
   }
 
@@ -65,14 +74,22 @@ export class ChatController {
   async getEventMessages(
     @Param('slug') slug: string,
     @AuthUser() user: User,
+    @Req() request: any,
     @Query('limit') limit?: number,
     @Query('from') from?: string,
   ): Promise<DiscussionMessagesResponseDto> {
+    // Pass the tenant ID explicitly from the request
+    const tenantId = request.tenantId;
+    if (!tenantId) {
+      throw new BadRequestException('Tenant ID is required');
+    }
+
     return await this.discussionService.getEventDiscussionMessages(
       slug,
       user.id,
       limit,
       from,
+      tenantId, // Pass tenant ID explicitly
     );
   }
 
@@ -182,7 +199,7 @@ export class ChatController {
     // Pass the tenant ID explicitly from the request
     const tenantId = request.tenantId;
     if (!tenantId) {
-      throw new Error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
     }
 
     // Use the discussion service with explicit tenant ID
@@ -220,7 +237,7 @@ export class ChatController {
     // Pass the tenant ID explicitly from the request
     const tenantId = request.tenantId;
     if (!tenantId) {
-      throw new Error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
     }
 
     // Use the discussion service with optional userId for unauthenticated users
@@ -251,7 +268,7 @@ export class ChatController {
     // Pass the tenant ID explicitly from the request
     const tenantId = request.tenantId;
     if (!tenantId) {
-      throw new Error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
     }
 
     try {
@@ -322,7 +339,7 @@ export class ChatController {
     // Pass the tenant ID explicitly from the request
     const tenantId = request.tenantId;
     if (!tenantId) {
-      throw new Error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
     }
 
     return await this.discussionService.addMemberToGroupDiscussionBySlug(
@@ -343,7 +360,7 @@ export class ChatController {
     // Pass the tenant ID explicitly from the request
     const tenantId = request.tenantId;
     if (!tenantId) {
-      throw new Error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
     }
 
     return await this.discussionService.removeMemberFromGroupDiscussionBySlug(
@@ -644,4 +661,5 @@ export class ChatController {
       };
     }
   }
+
 }

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -354,6 +354,99 @@ export class ChatController {
   }
 
   /**
+   * Message redaction endpoints
+   */
+  @Delete('event/:slug/message/:messageEventId')
+  @ApiOperation({ summary: 'Redact a message from an event discussion' })
+  async redactEventMessage(
+    @Param('slug') eventSlug: string,
+    @Param('messageEventId') messageEventId: string,
+    @Body() body: { reason?: string },
+    @AuthUser() user: User,
+    @Req() request: any,
+  ): Promise<{
+    success: boolean;
+    redactionEventId?: string;
+    message?: string;
+  }> {
+    const tenantId = request.tenantId;
+    if (!tenantId) {
+      throw new Error('Tenant ID is required');
+    }
+
+    try {
+      const redactionEventId =
+        await this.discussionService.redactEventDiscussionMessage(
+          eventSlug,
+          messageEventId,
+          user.slug,
+          tenantId,
+          body.reason,
+        );
+
+      return {
+        success: true,
+        redactionEventId,
+      };
+    } catch (error) {
+      this.logger.error(
+        `Error redacting message ${messageEventId} for event ${eventSlug}: ${error.message}`,
+        error.stack,
+      );
+
+      return {
+        success: false,
+        message: error.message || 'Failed to redact message',
+      };
+    }
+  }
+
+  @Delete('group/:slug/message/:messageEventId')
+  @ApiOperation({ summary: 'Redact a message from a group discussion' })
+  async redactGroupMessage(
+    @Param('slug') groupSlug: string,
+    @Param('messageEventId') messageEventId: string,
+    @Body() body: { reason?: string },
+    @AuthUser() user: User,
+    @Req() request: any,
+  ): Promise<{
+    success: boolean;
+    redactionEventId?: string;
+    message?: string;
+  }> {
+    const tenantId = request.tenantId;
+    if (!tenantId) {
+      throw new Error('Tenant ID is required');
+    }
+
+    try {
+      const redactionEventId =
+        await this.discussionService.redactGroupDiscussionMessage(
+          groupSlug,
+          messageEventId,
+          user.slug,
+          tenantId,
+          body.reason,
+        );
+
+      return {
+        success: true,
+        redactionEventId,
+      };
+    } catch (error) {
+      this.logger.error(
+        `Error redacting message ${messageEventId} for group ${groupSlug}: ${error.message}`,
+        error.stack,
+      );
+
+      return {
+        success: false,
+        message: error.message || 'Failed to redact message',
+      };
+    }
+  }
+
+  /**
    * Direct message endpoints (placeholders for future implementation)
    */
   @Post('direct/:recipientId/message')

--- a/src/chat/chat.module.ts
+++ b/src/chat/chat.module.ts
@@ -12,6 +12,8 @@ import { EventModule } from '../event/event.module';
 import { GroupModule } from '../group/group.module';
 import { ChatListener } from './chat.listener';
 import { ChatRoomService } from './rooms/chat-room.service';
+import { ChatPermissionListener } from './listeners/chat-permission.listener';
+import { ChatPermissionEmitterService } from './services/chat-permission-emitter.service';
 import { ChatRoomEntity } from './infrastructure/persistence/relational/entities/chat-room.entity';
 import { GroupMemberModule } from '../group-member/group-member.module';
 import { EventAttendeeModule } from '../event-attendee/event-attendee.module';
@@ -52,6 +54,8 @@ import { ElastiCacheModule } from '../elasticache/elasticache.module';
     },
     MatrixChatServiceAdapter,
     ChatListener,
+    ChatPermissionListener,
+    ChatPermissionEmitterService,
   ],
   exports: [
     DiscussionService,
@@ -62,6 +66,7 @@ import { ElastiCacheModule } from '../elasticache/elasticache.module';
     'CHAT_SERVICE',
     MatrixChatServiceAdapter,
     ChatRoomService,
+    ChatPermissionEmitterService,
     TypeOrmModule,
   ],
 })

--- a/src/chat/events/chat-permission.events.ts
+++ b/src/chat/events/chat-permission.events.ts
@@ -1,0 +1,47 @@
+/**
+ * Events for chat permission management
+ * These events are emitted when user roles change and need Matrix permission sync
+ */
+
+export interface ChatPermissionSyncEvent {
+  userId: number;
+  userSlug: string;
+  matrixUserId: string;
+  entityId: number;
+  entitySlug: string;
+  entityType: 'event' | 'group';
+  newRole: string;
+  oldRole?: string;
+  tenantId: string;
+  action: 'granted' | 'revoked' | 'updated';
+}
+
+export interface ChatRoomCreatedEvent {
+  roomId: string;
+  entityId: number;
+  entitySlug: string;
+  entityType: 'event' | 'group';
+  creatorUserId: number;
+  creatorMatrixUserId: string;
+  tenantId: string;
+}
+
+export interface UserJoinedChatEvent {
+  userId: number;
+  userSlug: string;
+  matrixUserId: string;
+  roomId: string;
+  entityId: number;
+  entitySlug: string;
+  entityType: 'event' | 'group';
+  userRole: string;
+  tenantId: string;
+}
+
+// Event names as constants
+export const CHAT_EVENTS = {
+  PERMISSION_SYNC_REQUIRED: 'chat.permission.sync.required',
+  ROOM_CREATED: 'chat.room.created',
+  USER_JOINED: 'chat.user.joined',
+  USER_ROLE_CHANGED: 'chat.user.role.changed',
+} as const;

--- a/src/chat/interfaces/chat-provider.interface.ts
+++ b/src/chat/interfaces/chat-provider.interface.ts
@@ -173,4 +173,17 @@ export interface ChatProviderInterface {
     isTyping: boolean,
     deviceId?: string,
   ): Promise<void>;
+
+  /**
+   * Redact (delete) a message from a room
+   * @param options Redaction options containing roomId, eventId, reason, userSlug, and tenantId
+   * @returns The ID of the redaction event
+   */
+  redactMessage(options: {
+    roomId: string;
+    eventId: string;
+    reason?: string;
+    userSlug: string;
+    tenantId: string;
+  }): Promise<string>;
 }

--- a/src/chat/listeners/chat-permission.listener.ts
+++ b/src/chat/listeners/chat-permission.listener.ts
@@ -1,0 +1,223 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { ChatRoomService } from '../rooms/chat-room.service';
+import { GroupMemberService } from '../../group-member/group-member.service';
+import { EventAttendeeService } from '../../event-attendee/event-attendee.service';
+import { UserService } from '../../user/user.service';
+import { Trace } from '../../utils/trace.decorator';
+import {
+  ChatPermissionSyncEvent,
+  UserJoinedChatEvent,
+  CHAT_EVENTS,
+} from '../events/chat-permission.events';
+
+/**
+ * Listener service for chat permission events
+ * Handles automatic Matrix permission synchronization when user roles change
+ */
+@Injectable()
+export class ChatPermissionListener {
+  private readonly logger = new Logger(ChatPermissionListener.name);
+
+  constructor(
+    private readonly chatRoomService: ChatRoomService,
+    private readonly groupMemberService: GroupMemberService,
+    private readonly eventAttendeeService: EventAttendeeService,
+    private readonly userService: UserService,
+  ) {}
+
+  /**
+   * Handle permission sync requirements when user roles change
+   */
+  @OnEvent(CHAT_EVENTS.PERMISSION_SYNC_REQUIRED)
+  @Trace('chat-permission.handlePermissionSync')
+  async handlePermissionSyncRequired(
+    event: ChatPermissionSyncEvent,
+  ): Promise<void> {
+    try {
+      this.logger.log(
+        `Permission sync required: User ${event.userSlug} role ${event.action} for ${event.entityType} ${event.entitySlug}`,
+      );
+
+      // Get chat rooms for the entity
+      const chatRooms =
+        event.entityType === 'event'
+          ? await this.chatRoomService.getEventChatRooms(event.entityId)
+          : await this.chatRoomService.getGroupChatRooms(event.entityId);
+
+      if (!chatRooms || chatRooms.length === 0) {
+        this.logger.debug(
+          `No chat rooms found for ${event.entityType} ${event.entitySlug}`,
+        );
+        return;
+      }
+
+      // Update Matrix permissions for each chat room
+      for (const room of chatRooms) {
+        await this.syncUserPermissionsInRoom(event, room.matrixRoomId);
+      }
+
+      this.logger.log(
+        `Successfully synced Matrix permissions for user ${event.userSlug} in ${chatRooms.length} rooms`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to sync permissions for user ${event.userSlug} in ${event.entityType} ${event.entitySlug}: ${error.message}`,
+        error.stack,
+      );
+      // Don't throw - permission sync failures shouldn't break role changes
+    }
+  }
+
+  /**
+   * Handle when a user joins a chat room to ensure proper permissions
+   */
+  @OnEvent(CHAT_EVENTS.USER_JOINED)
+  @Trace('chat-permission.handleUserJoined')
+  async handleUserJoinedChat(event: UserJoinedChatEvent): Promise<void> {
+    try {
+      this.logger.log(
+        `User ${event.userSlug} joined chat for ${event.entityType} ${event.entitySlug}, syncing permissions`,
+      );
+
+      // Determine the actual user role based on entity type
+      let actualRole = event.userRole;
+
+      if (event.entityType === 'group') {
+        try {
+          const groupMember =
+            await this.groupMemberService.findGroupMemberByUserId(
+              event.userId,
+              event.entityId,
+            );
+          actualRole = groupMember?.groupRole?.name || 'MEMBER';
+        } catch (roleError) {
+          this.logger.warn(
+            `Could not determine group role for user ${event.userSlug}: ${roleError.message}`,
+          );
+        }
+      } else if (event.entityType === 'event') {
+        try {
+          const eventAttendee =
+            await this.eventAttendeeService.findEventAttendeeByUserId(
+              event.userId,
+              event.entityId,
+            );
+          actualRole = eventAttendee?.role?.name || 'ATTENDEE';
+        } catch (roleError) {
+          this.logger.warn(
+            `Could not determine event role for user ${event.userSlug}: ${roleError.message}`,
+          );
+        }
+      }
+
+      await this.syncUserPermissionsInRoom(
+        {
+          userId: event.userId,
+          userSlug: event.userSlug,
+          matrixUserId: event.matrixUserId,
+          entityId: event.entityId,
+          entitySlug: event.entitySlug,
+          entityType: event.entityType,
+          newRole: actualRole,
+          tenantId: event.tenantId,
+          action: 'granted',
+        },
+        event.roomId,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to sync permissions for user ${event.userSlug} joining ${event.entityType} ${event.entitySlug}: ${error.message}`,
+        error.stack,
+      );
+    }
+  }
+
+  /**
+   * Sync user permissions in a specific Matrix room
+   */
+  private async syncUserPermissionsInRoom(
+    event: ChatPermissionSyncEvent,
+    matrixRoomId: string,
+  ): Promise<void> {
+    const powerLevel = this.calculateRequiredPowerLevel(event);
+
+    if (powerLevel === null) {
+      this.logger.debug(
+        `No power level change needed for user ${event.userSlug} with role ${event.newRole}`,
+      );
+      return;
+    }
+
+    if (event.action === 'revoked') {
+      // User lost permissions, set to regular user level
+      await this.chatRoomService.updateUserPowerLevel(
+        matrixRoomId,
+        event.matrixUserId,
+        0, // Regular user level
+      );
+      this.logger.log(
+        `Revoked moderator permissions for user ${event.userSlug} in room ${matrixRoomId}`,
+      );
+    } else {
+      // User gained or maintained permissions
+      await this.chatRoomService.updateUserPowerLevel(
+        matrixRoomId,
+        event.matrixUserId,
+        powerLevel,
+      );
+      this.logger.log(
+        `Granted power level ${powerLevel} to user ${event.userSlug} in room ${matrixRoomId}`,
+      );
+    }
+  }
+
+  /**
+   * Calculate the required Matrix power level based on user role
+   */
+  private calculateRequiredPowerLevel(
+    event: ChatPermissionSyncEvent,
+  ): number | null {
+    const role = event.newRole?.toUpperCase();
+
+    // Moderator-level roles that can redact messages (power level 50)
+    const moderatorRoles = [
+      'HOST',
+      'CO_HOST',
+      'MODERATOR',
+      'ADMIN',
+      'OWNER',
+      'CREATOR',
+    ];
+
+    if (moderatorRoles.includes(role)) {
+      return 50; // Moderator level - can redact messages
+    }
+
+    // Admin-level roles (power level 100) - future use
+    const adminRoles = ['SUPER_ADMIN', 'SYSTEM_ADMIN'];
+    if (adminRoles.includes(role)) {
+      return 100; // Admin level
+    }
+
+    // Regular users or roles that don't need special permissions
+    const regularRoles = [
+      'MEMBER',
+      'ATTENDEE',
+      'GUEST',
+      'PARTICIPANT',
+      'CONFIRMED',
+      'PENDING',
+    ];
+
+    if (regularRoles.includes(role)) {
+      return 0; // Regular user level
+    }
+
+    // Unknown role - no change needed
+    this.logger.warn(
+      `Unknown role '${event.newRole}' for user ${event.userSlug}, no power level change`,
+    );
+    return null;
+  }
+}

--- a/src/chat/rooms/chat-room.service.spec.ts
+++ b/src/chat/rooms/chat-room.service.spec.ts
@@ -26,6 +26,8 @@ import {
 } from '../../core/constants/constant';
 import { EventQueryService } from '../../event/services/event-query.service';
 import { GroupService } from '../../group/group.service';
+import { ChatPermissionEmitterService } from '../services/chat-permission-emitter.service';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 describe('ChatRoomService', () => {
   let service: ChatRoomService;
@@ -192,6 +194,12 @@ describe('ChatRoomService', () => {
   };
 
   const mockRequestCache = new Map();
+
+  const mockChatPermissionEmitter = {
+    emitUserJoinedChat: jest.fn().mockResolvedValue(undefined),
+    emitUserLeftChat: jest.fn().mockResolvedValue(undefined),
+    emitPermissionSyncRequired: jest.fn().mockResolvedValue(undefined),
+  };
 
   beforeEach(async () => {
     // Initialize mock repositories with proper types
@@ -522,6 +530,16 @@ describe('ChatRoomService', () => {
             withLock: jest.fn().mockImplementation(async (key, fn) => {
               return await fn();
             }),
+          },
+        },
+        {
+          provide: ChatPermissionEmitterService,
+          useFactory: () => mockChatPermissionEmitter,
+        },
+        {
+          provide: EventEmitter2,
+          useValue: {
+            emit: jest.fn(),
           },
         },
       ],

--- a/src/chat/services/chat-permission-emitter.service.ts
+++ b/src/chat/services/chat-permission-emitter.service.ts
@@ -1,0 +1,113 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import {
+  ChatPermissionSyncEvent,
+  UserJoinedChatEvent,
+  CHAT_EVENTS,
+} from '../events/chat-permission.events';
+
+/**
+ * Service for emitting chat permission events
+ * This service provides a clean interface for other services to emit chat-related events
+ */
+@Injectable()
+export class ChatPermissionEmitterService {
+  private readonly logger = new Logger(ChatPermissionEmitterService.name);
+
+  constructor(private readonly eventEmitter: EventEmitter2) {}
+
+  /**
+   * Emit event when user role changes and Matrix permissions need syncing
+   */
+  emitPermissionSyncRequired(data: {
+    userId: number;
+    userSlug: string;
+    matrixUserId: string;
+    entityId: number;
+    entitySlug: string;
+    entityType: 'event' | 'group';
+    newRole: string;
+    oldRole?: string;
+    tenantId: string;
+    action: 'granted' | 'revoked' | 'updated';
+  }): void {
+    const event: ChatPermissionSyncEvent = {
+      ...data,
+    };
+
+    this.logger.debug(
+      `Emitting permission sync event for user ${data.userSlug} in ${data.entityType} ${data.entitySlug}`,
+    );
+
+    this.eventEmitter.emit(CHAT_EVENTS.PERMISSION_SYNC_REQUIRED, event);
+  }
+
+  /**
+   * Emit event when user joins a chat room
+   */
+  emitUserJoinedChat(data: {
+    userId: number;
+    userSlug: string;
+    matrixUserId: string;
+    roomId: string;
+    entityId: number;
+    entitySlug: string;
+    entityType: 'event' | 'group';
+    userRole: string;
+    tenantId: string;
+  }): void {
+    const event: UserJoinedChatEvent = {
+      ...data,
+    };
+
+    this.logger.debug(
+      `Emitting user joined chat event for user ${data.userSlug} in room ${data.roomId}`,
+    );
+
+    this.eventEmitter.emit(CHAT_EVENTS.USER_JOINED, event);
+  }
+
+  /**
+   * Convenience method for event host/moderator role changes
+   */
+  emitEventRoleChanged(data: {
+    userId: number;
+    userSlug: string;
+    matrixUserId: string;
+    eventId: number;
+    eventSlug: string;
+    newRole: string;
+    oldRole?: string;
+    tenantId: string;
+    action: 'granted' | 'revoked' | 'updated';
+  }): void {
+    this.emitPermissionSyncRequired({
+      ...data,
+      entityId: data.eventId,
+      entitySlug: data.eventSlug,
+      entityType: 'event',
+    });
+  }
+
+  /**
+   * Convenience method for group member role changes
+   */
+  emitGroupRoleChanged(data: {
+    userId: number;
+    userSlug: string;
+    matrixUserId: string;
+    groupId: number;
+    groupSlug: string;
+    newRole: string;
+    oldRole?: string;
+    tenantId: string;
+    action: 'granted' | 'revoked' | 'updated';
+  }): void {
+    this.emitPermissionSyncRequired({
+      ...data,
+      entityId: data.groupId,
+      entitySlug: data.groupSlug,
+      entityType: 'group',
+    });
+  }
+}

--- a/src/chat/services/discussion.service.spec.ts
+++ b/src/chat/services/discussion.service.spec.ts
@@ -8,6 +8,8 @@ import { ChatRoomService } from '../rooms/chat-room.service';
 import { UserService } from '../../user/user.service';
 import { TenantConnectionService } from '../../tenant/tenant.service';
 import { GroupVisibility } from '../../core/constants/constant';
+import { EventAttendeeService } from '../../event-attendee/event-attendee.service';
+import { GroupMemberService } from '../../group-member/group-member.service';
 
 // Mock services
 const mockGroupService = {
@@ -42,6 +44,14 @@ const mockChatProvider = {
 const mockChatRoomManager = {
   createRoom: jest.fn(),
   addUserToRoom: jest.fn(),
+};
+
+const mockEventAttendeeService = {
+  findEventAttendeeByUserId: jest.fn(),
+};
+
+const mockGroupMemberService = {
+  findGroupMemberByUserId: jest.fn(),
 };
 
 const mockRequest = {
@@ -90,6 +100,14 @@ describe('DiscussionService', () => {
         {
           provide: 'ChatRoomManagerInterface',
           useValue: mockChatRoomManager,
+        },
+        {
+          provide: EventAttendeeService,
+          useValue: mockEventAttendeeService,
+        },
+        {
+          provide: GroupMemberService,
+          useValue: mockGroupMemberService,
         },
         {
           provide: REQUEST,

--- a/src/chat/services/discussion.service.ts
+++ b/src/chat/services/discussion.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Injectable,
   Scope,
   Inject,
@@ -72,7 +73,7 @@ export class DiscussionService implements DiscussionServiceInterface {
 
     if (!tenantId) {
       this.logger.error('Tenant ID is required');
-      throw new Error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
     }
 
     const cache = this.getRequestCache();
@@ -792,8 +793,17 @@ export class DiscussionService implements DiscussionServiceInterface {
     slug: string,
     userId: number,
     body: { message: string },
+    explicitTenantId?: string,
   ): Promise<{ id: string }> {
-    return this.sendEntityDiscussionMessage('event', slug, userId, body);
+    // Get tenant ID from explicit parameter or request context
+    const tenantId = explicitTenantId || this.request?.tenantId;
+
+    if (!tenantId) {
+      this.logger.error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
+    }
+
+    return this.sendEntityDiscussionMessage('event', slug, userId, body, tenantId);
   }
 
   @Trace('discussion.getEventDiscussionMessages')
@@ -802,8 +812,17 @@ export class DiscussionService implements DiscussionServiceInterface {
     userId: number,
     limit = 50,
     from?: string,
+    explicitTenantId?: string,
   ): Promise<DiscussionMessagesResponseDto> {
-    return this.getEntityDiscussionMessages('event', slug, userId, limit, from);
+    // Get tenant ID from explicit parameter or request context
+    const tenantId = explicitTenantId || this.request?.tenantId;
+
+    if (!tenantId) {
+      this.logger.error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
+    }
+
+    return this.getEntityDiscussionMessages('event', slug, userId, limit, from, tenantId);
   }
 
   /**
@@ -1199,7 +1218,7 @@ export class DiscussionService implements DiscussionServiceInterface {
 
     if (!tenantId) {
       this.logger.error('Tenant ID is required');
-      throw new Error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
     }
 
     // Remove the user from the appropriate chat room
@@ -1299,7 +1318,7 @@ export class DiscussionService implements DiscussionServiceInterface {
 
     if (!tenantId) {
       this.logger.error('Tenant ID is required');
-      throw new Error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
     }
 
     const cache = this.getRequestCache();
@@ -1418,7 +1437,7 @@ export class DiscussionService implements DiscussionServiceInterface {
 
     if (!tenantId) {
       this.logger.error('Tenant ID is required');
-      throw new Error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
     }
 
     // Pass the tenant context to the entity discussion method
@@ -1444,7 +1463,7 @@ export class DiscussionService implements DiscussionServiceInterface {
 
     if (!tenantId) {
       this.logger.error('Tenant ID is required');
-      throw new Error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
     }
 
     // Pass the tenant context to the entity discussion method
@@ -1469,7 +1488,7 @@ export class DiscussionService implements DiscussionServiceInterface {
 
     if (!tenantId) {
       this.logger.error('Tenant ID is required');
-      throw new Error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
     }
 
     // Check if the group and user exist
@@ -1684,7 +1703,7 @@ export class DiscussionService implements DiscussionServiceInterface {
   ): Promise<{ groupId: number; userId: number }> {
     if (!tenantId) {
       this.logger.error('Tenant ID is required');
-      throw new Error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
     }
 
     // Get the group ID
@@ -1709,7 +1728,7 @@ export class DiscussionService implements DiscussionServiceInterface {
   ): Promise<number> {
     if (!tenantId) {
       this.logger.error('Tenant ID is required');
-      throw new Error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
     }
 
     try {
@@ -1736,7 +1755,7 @@ export class DiscussionService implements DiscussionServiceInterface {
   ): Promise<number> {
     if (!tenantId) {
       this.logger.error('Tenant ID is required');
-      throw new Error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
     }
 
     try {
@@ -2061,7 +2080,7 @@ export class DiscussionService implements DiscussionServiceInterface {
   ): Promise<void> {
     if (!tenantId) {
       this.logger.error('Tenant ID is required');
-      throw new Error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
     }
 
     // Find the event by slug
@@ -2126,7 +2145,7 @@ export class DiscussionService implements DiscussionServiceInterface {
   ): Promise<{ roomId?: string }> {
     if (!tenantId) {
       this.logger.error('Tenant ID is required');
-      throw new Error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
     }
 
     // Find the event by slug
@@ -2185,7 +2204,7 @@ export class DiscussionService implements DiscussionServiceInterface {
   ): Promise<void> {
     if (!tenantId) {
       this.logger.error('Tenant ID is required');
-      throw new Error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
     }
 
     // Find the group by slug
@@ -2247,7 +2266,7 @@ export class DiscussionService implements DiscussionServiceInterface {
   ): Promise<{ roomId?: string }> {
     if (!tenantId) {
       this.logger.error('Tenant ID is required');
-      throw new Error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
     }
 
     // Find the group by slug
@@ -2352,7 +2371,7 @@ export class DiscussionService implements DiscussionServiceInterface {
   ): Promise<string> {
     if (!tenantId) {
       this.logger.error('Tenant ID is required');
-      throw new Error('Tenant ID is required');
+      throw new BadRequestException('Tenant ID is required');
     }
 
     let entity;

--- a/src/matrix/types/matrix.interfaces.ts
+++ b/src/matrix/types/matrix.interfaces.ts
@@ -57,6 +57,11 @@ export interface IMatrixClient {
     content: any,
     txnId?: string,
   ) => Promise<{ event_id: string }>;
+  redactEvent: (
+    roomId: string,
+    eventId: string,
+    reason?: string,
+  ) => Promise<{ event_id: string }>;
   sendTyping: (
     roomId: string,
     isTyping: boolean,
@@ -123,6 +128,13 @@ export interface IMatrixRoomProvider {
 
 export interface IMatrixMessageProvider {
   sendMessage: (options: any) => Promise<string>;
+  redactMessage: (options: {
+    roomId: string;
+    eventId: string;
+    reason?: string;
+    userSlug: string;
+    tenantId: string;
+  }) => Promise<string>;
   sendTypingNotification: (
     roomId: string,
     userId: string,

--- a/test/chat/message-redaction.e2e-spec.ts
+++ b/test/chat/message-redaction.e2e-spec.ts
@@ -1,0 +1,416 @@
+import {
+  loginAsTester,
+  loginAsAdmin,
+  createEvent,
+  createGroup,
+  createTestUser,
+  sendEventMessage,
+  sendGroupMessage,
+  redactEventMessage,
+  redactGroupMessage,
+  addUserToEvent,
+  addUserToGroup,
+} from '../utils/functions';
+import { TESTING_APP_URL } from '../utils/constants';
+
+/**
+ * Message Redaction E2E Tests
+ *
+ * These tests validate message redaction functionality with proper permissions:
+ * - Users can redact their own messages
+ * - Event hosts can redact attendee/guest messages
+ * - Group admins can redact member messages
+ * - Regular users cannot redact others' messages
+ *
+ * Each test is independent and can run in any order.
+ */
+jest.setTimeout(120000);
+
+describe('Message Redaction E2E Tests', () => {
+  describe('User Self-Redaction in Events', () => {
+    it('should allow a user to redact their own event message', async () => {
+      // Setup: Create event and user
+      const hostToken = await loginAsTester();
+      const userInfo = await createTestUser('self-redact-event-user');
+
+      const eventData = {
+        title: 'Self Redaction Test Event',
+        description: 'Testing user self-redaction',
+        startTime: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        endTime: new Date(Date.now() + 25 * 60 * 60 * 1000).toISOString(),
+        location: 'Test Location',
+        visibility: 'public',
+      };
+
+      const eventSlug = await createEvent(
+        TESTING_APP_URL,
+        hostToken,
+        eventData,
+      );
+      await addUserToEvent(eventSlug, userInfo.user.slug, hostToken);
+
+      // Test: Send message and redact it
+      const messageId = await sendEventMessage(
+        eventSlug,
+        'Message to self-redact',
+        userInfo.token,
+        TESTING_APP_URL,
+      );
+      const response = await redactEventMessage(
+        eventSlug,
+        messageId,
+        userInfo.token,
+        'Self-redacting message',
+        TESTING_APP_URL,
+      );
+
+      // Verify
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.redactionEventId).toBeDefined();
+    });
+  });
+
+  describe('User Self-Redaction in Groups', () => {
+    it('should allow a user to redact their own group message', async () => {
+      // Setup: Create group and user
+      const hostToken = await loginAsTester();
+      const userInfo = await createTestUser('self-redact-group-user');
+
+      const groupData = {
+        name: 'Self Redaction Test Group',
+        description: 'Testing user self-redaction in groups',
+        visibility: 'public',
+      };
+
+      const group = await createGroup(TESTING_APP_URL, hostToken, groupData);
+      await addUserToGroup(group.slug, userInfo.user.slug, hostToken);
+
+      // Test: Send message and redact it
+      const messageId = await sendGroupMessage(
+        group.slug,
+        'Group message to self-redact',
+        userInfo.token,
+      );
+      const response = await redactGroupMessage(
+        group.slug,
+        messageId,
+        userInfo.token,
+        'Self-redacting group message',
+      );
+
+      // Verify
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.redactionEventId).toBeDefined();
+    });
+  });
+
+  describe('Host Moderation in Events', () => {
+    it('should allow event host to redact attendee messages', async () => {
+      // Setup: Create event with host and attendee
+      const hostToken = await loginAsTester();
+      const userInfo = await createTestUser('event-attendee-user');
+
+      const eventData = {
+        title: 'Host Moderation Test Event',
+        description: 'Testing host moderation',
+        startTime: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        endTime: new Date(Date.now() + 25 * 60 * 60 * 1000).toISOString(),
+        location: 'Test Location',
+        visibility: 'public',
+      };
+
+      const eventSlug = await createEvent(
+        TESTING_APP_URL,
+        hostToken,
+        eventData,
+      );
+      await addUserToEvent(eventSlug, userInfo.user.slug, hostToken);
+
+      // Test: User sends message, host redacts it
+      const messageId = await sendEventMessage(
+        eventSlug,
+        'Attendee message to be moderated',
+        userInfo.token,
+      );
+      const response = await redactEventMessage(
+        eventSlug,
+        messageId,
+        hostToken,
+        'Host moderating content',
+      );
+
+      // Verify
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.redactionEventId).toBeDefined();
+    });
+  });
+
+  describe('Group Admin Moderation', () => {
+    it('should allow group creator to redact member messages', async () => {
+      // Setup: Create group with creator and member
+      const hostToken = await loginAsTester();
+      const userInfo = await createTestUser('group-member-user');
+
+      const groupData = {
+        name: 'Group Moderation Test',
+        description: 'Testing group admin moderation',
+        visibility: 'public',
+      };
+
+      const group = await createGroup(TESTING_APP_URL, hostToken, groupData);
+      await addUserToGroup(group.slug, userInfo.user.slug, hostToken);
+
+      // Test: Member sends message, creator redacts it
+      const messageId = await sendGroupMessage(
+        group.slug,
+        'Member message to be moderated',
+        userInfo.token,
+      );
+      const response = await redactGroupMessage(
+        group.slug,
+        messageId,
+        hostToken,
+        'Group admin moderating content',
+      );
+
+      // Verify
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.redactionEventId).toBeDefined();
+    });
+  });
+
+  describe('Admin Permissions', () => {
+    it('should allow admin to redact any event message', async () => {
+      // Setup: Create event with regular host, admin redacts
+      const hostToken = await loginAsTester();
+      const adminToken = await loginAsAdmin();
+
+      const eventData = {
+        title: 'Admin Moderation Test Event',
+        description: 'Testing admin global moderation',
+        startTime: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        endTime: new Date(Date.now() + 25 * 60 * 60 * 1000).toISOString(),
+        location: 'Test Location',
+        visibility: 'public',
+      };
+
+      const eventSlug = await createEvent(
+        TESTING_APP_URL,
+        hostToken,
+        eventData,
+      );
+
+      // Test: Host sends message, admin redacts it
+      const messageId = await sendEventMessage(
+        eventSlug,
+        'Host message for admin to moderate',
+        hostToken,
+      );
+      const response = await redactEventMessage(
+        eventSlug,
+        messageId,
+        adminToken,
+        'Admin moderating content',
+      );
+
+      // Verify
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.redactionEventId).toBeDefined();
+    });
+
+    it('should allow admin to redact any group message', async () => {
+      // Setup: Create group with regular creator, admin redacts
+      const hostToken = await loginAsTester();
+      const adminToken = await loginAsAdmin();
+
+      const groupData = {
+        name: 'Admin Group Moderation Test',
+        description: 'Testing admin global moderation in groups',
+        visibility: 'public',
+      };
+
+      const group = await createGroup(TESTING_APP_URL, hostToken, groupData);
+
+      // Test: Creator sends message, admin redacts it
+      const messageId = await sendGroupMessage(
+        group.slug,
+        'Creator message for admin to moderate',
+        hostToken,
+      );
+      const response = await redactGroupMessage(
+        group.slug,
+        messageId,
+        adminToken,
+        'Admin moderating group content',
+      );
+
+      // Verify
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.redactionEventId).toBeDefined();
+    });
+  });
+
+  describe('Permission Denials', () => {
+    it('should NOT allow regular user to redact host event messages', async () => {
+      // Setup: Create event with host and user
+      const hostToken = await loginAsTester();
+      const userInfo = await createTestUser('permission-test-user');
+
+      const eventData = {
+        title: 'Permission Denial Test Event',
+        description: 'Testing permission denials',
+        startTime: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        endTime: new Date(Date.now() + 25 * 60 * 60 * 1000).toISOString(),
+        location: 'Test Location',
+        visibility: 'public',
+      };
+
+      const eventSlug = await createEvent(
+        TESTING_APP_URL,
+        hostToken,
+        eventData,
+      );
+      await addUserToEvent(eventSlug, userInfo.user.slug, hostToken);
+
+      // Test: Host sends message, user tries to redact it
+      const messageId = await sendEventMessage(
+        eventSlug,
+        'Host message user cannot redact',
+        hostToken,
+      );
+      const response = await redactEventMessage(
+        eventSlug,
+        messageId,
+        userInfo.token,
+        'User trying to redact host message',
+      );
+
+      // Verify permission is denied
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toContain('permission');
+    });
+
+    it('should NOT allow regular member to redact group creator messages', async () => {
+      // Setup: Create group with creator and member
+      const hostToken = await loginAsTester();
+      const userInfo = await createTestUser('group-permission-test-user');
+
+      const groupData = {
+        name: 'Group Permission Denial Test',
+        description: 'Testing group permission denials',
+        visibility: 'public',
+      };
+
+      const group = await createGroup(TESTING_APP_URL, hostToken, groupData);
+      await addUserToGroup(group.slug, userInfo.user.slug, hostToken);
+
+      // Test: Creator sends message, member tries to redact it
+      const messageId = await sendGroupMessage(
+        group.slug,
+        'Creator message member cannot redact',
+        hostToken,
+      );
+      const response = await redactGroupMessage(
+        group.slug,
+        messageId,
+        userInfo.token,
+        'Member trying to redact creator message',
+      );
+
+      // Verify permission is denied
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toContain('permission');
+    });
+  });
+
+  describe('Error Cases', () => {
+    it('should return error for non-existent message in event', async () => {
+      // Setup: Create event
+      const hostToken = await loginAsTester();
+
+      const eventData = {
+        title: 'Error Test Event',
+        description: 'Testing error cases',
+        startTime: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        endTime: new Date(Date.now() + 25 * 60 * 60 * 1000).toISOString(),
+        location: 'Test Location',
+        visibility: 'public',
+      };
+
+      const eventSlug = await createEvent(
+        TESTING_APP_URL,
+        hostToken,
+        eventData,
+      );
+
+      // Test: Try to redact non-existent message
+      const response = await redactEventMessage(
+        eventSlug,
+        '$fake-message-id:matrix.server.com',
+        hostToken,
+        'Testing non-existent message',
+      );
+
+      // Verify error handling
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toContain('not found');
+    });
+
+    it('should return error for non-existent event', async () => {
+      // Setup: Get token
+      const hostToken = await loginAsTester();
+
+      // Test: Try to redact message in non-existent event
+      const response = await redactEventMessage(
+        'non-existent-event',
+        '$fake-message-id:matrix.server.com',
+        hostToken,
+        'Testing non-existent event',
+      );
+
+      // Verify error handling
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(false);
+    });
+
+    it('should require authentication for event message redaction', async () => {
+      // Setup: Create event
+      const hostToken = await loginAsTester();
+
+      const eventData = {
+        title: 'Auth Test Event',
+        description: 'Testing authentication requirement',
+        startTime: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        endTime: new Date(Date.now() + 25 * 60 * 60 * 1000).toISOString(),
+        location: 'Test Location',
+        visibility: 'public',
+      };
+
+      const eventSlug = await createEvent(
+        TESTING_APP_URL,
+        hostToken,
+        eventData,
+      );
+
+      // Test: Try to redact without authentication
+      const response = await redactEventMessage(
+        eventSlug,
+        '$fake-message-id:matrix.server.com',
+        '',
+        'Testing without auth',
+      );
+
+      // Verify authentication is required
+      expect(response.status).toBe(401);
+    });
+  });
+});

--- a/test/chat/message-redaction.e2e-spec.ts.backup
+++ b/test/chat/message-redaction.e2e-spec.ts.backup
@@ -1,0 +1,298 @@
+import {
+  loginAsTester,
+  loginAsAdmin,
+  createEvent,
+  createGroup,
+  createTestUser,
+  sendEventMessage,
+  sendGroupMessage,
+  redactEventMessage,
+  redactGroupMessage,
+  addUserToEvent,
+  addUserToGroup,
+} from '../utils/functions';
+import { TESTING_APP_URL, TESTING_TENANT_ID } from '../utils/constants';
+
+/**
+ * Message Redaction E2E Tests
+ *
+ * These tests validate message redaction functionality with proper permissions:
+ * - Users can redact their own messages
+ * - Event hosts can redact attendee/guest messages
+ * - Group admins can redact member messages
+ * - Regular users cannot redact others' messages
+ *
+ * Tests are consolidated to reuse credentials and reduce Matrix API calls.
+ */
+jest.setTimeout(180000);
+
+// Shared test data - created once and reused across tests
+let sharedHostToken: string;
+let sharedAdminToken: string;
+let sharedTestUser: any;
+let sharedEvent: any;
+let sharedGroup: any;
+
+describe('Message Redaction E2E Tests', () => {
+  // Setup shared credentials and entities once before all tests
+  beforeAll(async () => {
+    // Create shared credentials
+    sharedHostToken = await loginAsTester();
+    sharedAdminToken = await loginAsAdmin();
+    
+    // Create a single test user to reuse across tests
+    sharedTestUser = await createTestUser(
+      TESTING_APP_URL,
+      TESTING_TENANT_ID,
+      `shared-test-user-${Date.now()}-${Math.random().toString(36).substring(7)}@example.com`,
+      'Shared',
+      'TestUser'
+    );
+
+    // Create shared event and group for reuse
+    const eventData = {
+      name: 'Shared Redaction Test Event',
+      description: 'Testing message redaction',
+      type: 'hybrid',
+      startDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      endDate: new Date(Date.now() + 25 * 60 * 60 * 1000),
+      maxAttendees: 100,
+      categories: [1],
+      lat: 0,
+      lon: 0,
+      timeZone: 'UTC',
+    };
+
+    sharedEvent = await createEvent(TESTING_APP_URL, sharedHostToken, eventData);
+    await addUserToEvent(sharedEvent.slug, sharedTestUser.user.slug, sharedHostToken);
+
+    const groupData = {
+      name: 'Shared Redaction Test Group',
+      description: 'Testing message redaction in groups',
+      visibility: 'public',
+    };
+
+    sharedGroup = await createGroup(TESTING_APP_URL, sharedHostToken, groupData);
+    await addUserToGroup(sharedGroup.slug, sharedTestUser.user.slug, sharedHostToken);
+  });
+
+  describe('User Self-Redaction', () => {
+    it('should allow a user to redact their own event message', async () => {
+      // Test: Send message and redact it
+      const messageId = await sendEventMessage(
+        sharedEvent.slug,
+        'Message to self-redact in event',
+        sharedTestUser.token,
+        TESTING_APP_URL,
+      );
+      
+      const response = await redactEventMessage(
+        sharedEvent.slug,
+        messageId,
+        sharedTestUser.token,
+        'Self-redacting event message',
+        TESTING_APP_URL,
+      );
+
+      // Verify
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.redactionEventId).toBeDefined();
+    });
+
+    it('should allow a user to redact their own group message', async () => {
+      // Test: Send message and redact it
+      const messageId = await sendGroupMessage(
+        sharedGroup.slug,
+        'Message to self-redact in group',
+        sharedTestUser.token,
+      );
+      
+      const response = await redactGroupMessage(
+        sharedGroup.slug,
+        messageId,
+        sharedTestUser.token,
+        'Self-redacting group message',
+      );
+
+      // Verify
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.redactionEventId).toBeDefined();
+    });
+  });
+
+  describe('Host/Admin Moderation', () => {
+    it('should allow event host to redact attendee messages', async () => {
+      // Test: User sends message, host redacts it
+      const messageId = await sendEventMessage(
+        sharedEvent.slug,
+        'Attendee message to be moderated',
+        sharedTestUser.token,
+      );
+      
+      const response = await redactEventMessage(
+        sharedEvent.slug,
+        messageId,
+        sharedHostToken,
+        'Host moderating content',
+      );
+
+      // Verify
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.redactionEventId).toBeDefined();
+    });
+
+    it('should allow group creator to redact member messages', async () => {
+      // Test: Member sends message, creator redacts it
+      const messageId = await sendGroupMessage(
+        sharedGroup.slug,
+        'Member message to be moderated',
+        sharedTestUser.token,
+      );
+      
+      const response = await redactGroupMessage(
+        sharedGroup.slug,
+        messageId,
+        sharedHostToken,
+        'Group admin moderating content',
+      );
+
+      // Verify
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.redactionEventId).toBeDefined();
+    });
+
+    it('should allow admin to redact any event message', async () => {
+      // Test: Host sends message, admin redacts it
+      const messageId = await sendEventMessage(
+        sharedEvent.slug,
+        'Host message for admin to moderate',
+        sharedHostToken,
+      );
+      
+      const response = await redactEventMessage(
+        sharedEvent.slug,
+        messageId,
+        sharedAdminToken,
+        'Admin moderating content',
+      );
+
+      // Verify
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.redactionEventId).toBeDefined();
+    });
+
+    it('should allow admin to redact any group message', async () => {
+      // Test: Creator sends message, admin redacts it
+      const messageId = await sendGroupMessage(
+        sharedGroup.slug,
+        'Creator message for admin to moderate',
+        sharedHostToken,
+      );
+      
+      const response = await redactGroupMessage(
+        sharedGroup.slug,
+        messageId,
+        sharedAdminToken,
+        'Admin moderating group content',
+      );
+
+      // Verify
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.redactionEventId).toBeDefined();
+    });
+  });
+
+  describe('Permission Denials', () => {
+    it('should NOT allow regular user to redact host event messages', async () => {
+      // Test: Host sends message, user tries to redact it
+      const messageId = await sendEventMessage(
+        sharedEvent.slug,
+        'Host message user cannot redact',
+        sharedHostToken,
+      );
+      
+      const response = await redactEventMessage(
+        sharedEvent.slug,
+        messageId,
+        sharedTestUser.token,
+        'User trying to redact host message',
+      );
+
+      // Verify permission is denied
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toMatch(/permission|not allowed|unauthorized/i);
+    });
+
+    it('should NOT allow regular member to redact group creator messages', async () => {
+      // Test: Creator sends message, member tries to redact it
+      const messageId = await sendGroupMessage(
+        sharedGroup.slug,
+        'Creator message member cannot redact',
+        sharedHostToken,
+      );
+      
+      const response = await redactGroupMessage(
+        sharedGroup.slug,
+        messageId,
+        sharedTestUser.token,
+        'Member trying to redact creator message',
+      );
+
+      // Verify permission is denied
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toMatch(/permission|not allowed|unauthorized|no Matrix credentials/i);
+    });
+  });
+
+  describe('Error Cases', () => {
+    it('should return error for non-existent message in event', async () => {
+      // Test: Try to redact non-existent message
+      const response = await redactEventMessage(
+        sharedEvent.slug,
+        '$fake-message-id:matrix.server.com',
+        sharedHostToken,
+        'Testing non-existent message',
+      );
+
+      // Verify error handling - be more flexible with error messages
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toMatch(/not found|No chat room found/i);
+    });
+
+    it('should return error for non-existent event', async () => {
+      // Test: Try to redact message in non-existent event
+      const response = await redactEventMessage(
+        'non-existent-event',
+        '$fake-message-id:matrix.server.com',
+        sharedHostToken,
+        'Testing non-existent event',
+      );
+
+      // Verify error handling
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(false);
+    });
+
+    it('should require authentication for event message redaction', async () => {
+      // Test: Try to redact without authentication
+      const response = await redactEventMessage(
+        sharedEvent.slug,
+        '$fake-message-id:matrix.server.com',
+        '',
+        'Testing without auth',
+      );
+
+      // Verify authentication is required
+      expect(response.status).toBe(401);
+    });
+  });
+});

--- a/test/utils/constants.ts
+++ b/test/utils/constants.ts
@@ -1,4 +1,4 @@
-export const TESTING_TENANT_ID = process.env.TEST_TENANT_ID as string;
+export const TESTING_TENANT_ID = (process.env.TEST_TENANT_ID || process.env.TESTING_TENANT_ID) as string;
 export const TESTING_ADMIN_EMAIL = process.env.ADMIN_EMAIL as string;
 export const TESTING_ADMIN_PASSWORD = process.env.ADMIN_PASSWORD as string;
 export const TESTING_ADMIN_ID = 1;

--- a/test/utils/functions.ts
+++ b/test/utils/functions.ts
@@ -363,6 +363,114 @@ async function getCurrentUser(app, tenantId, userToken) {
   return userResponse.body;
 }
 
+async function sendEventMessage(
+  eventSlug: string,
+  message: string,
+  token: string,
+  app: string = TESTING_APP_URL,
+) {
+  // Join chat room first
+  await request(app)
+    .post(`/api/v1/chat/event/${eventSlug}/join`)
+    .set('Authorization', `Bearer ${token}`)
+    .set('x-tenant-id', TESTING_TENANT_ID);
+
+  // Send message
+  const response = await request(app)
+    .post(`/api/v1/chat/event/${eventSlug}/message`)
+    .set('Authorization', `Bearer ${token}`)
+    .set('x-tenant-id', TESTING_TENANT_ID)
+    .send({ message });
+
+  expect(response.status).toBe(200);
+  return response.body.id; // Returns the Matrix event ID
+}
+
+async function sendGroupMessage(
+  groupSlug: string,
+  message: string,
+  token: string,
+  app: string = TESTING_APP_URL,
+) {
+  // Join chat room first
+  await request(app)
+    .post(`/api/v1/chat/group/${groupSlug}/join`)
+    .set('Authorization', `Bearer ${token}`)
+    .set('x-tenant-id', TESTING_TENANT_ID);
+
+  // Send message
+  const response = await request(app)
+    .post(`/api/v1/chat/group/${groupSlug}/message`)
+    .set('Authorization', `Bearer ${token}`)
+    .set('x-tenant-id', TESTING_TENANT_ID)
+    .send({ message });
+
+  expect(response.status).toBe(200);
+  return response.body.id; // Returns the Matrix event ID
+}
+
+async function redactEventMessage(
+  eventSlug: string,
+  messageEventId: string,
+  token: string,
+  reason?: string,
+  app: string = TESTING_APP_URL,
+) {
+  const response = await request(app)
+    .delete(`/api/v1/chat/event/${eventSlug}/message/${messageEventId}`)
+    .set('Authorization', `Bearer ${token}`)
+    .set('x-tenant-id', TESTING_TENANT_ID)
+    .send({ reason });
+
+  return response;
+}
+
+async function redactGroupMessage(
+  groupSlug: string,
+  messageEventId: string,
+  token: string,
+  reason?: string,
+  app: string = TESTING_APP_URL,
+) {
+  const response = await request(app)
+    .delete(`/api/v1/chat/group/${groupSlug}/message/${messageEventId}`)
+    .set('Authorization', `Bearer ${token}`)
+    .set('x-tenant-id', TESTING_TENANT_ID)
+    .send({ reason });
+
+  return response;
+}
+
+async function addUserToEvent(
+  eventSlug: string,
+  userSlug: string,
+  token: string,
+  app: string = TESTING_APP_URL,
+) {
+  const response = await request(app)
+    .post(`/api/v1/events/${eventSlug}/attendees`)
+    .set('Authorization', `Bearer ${token}`)
+    .set('x-tenant-id', TESTING_TENANT_ID)
+    .send({ userSlug, rsvpStatus: 'yes' });
+
+  return response.status === 200 || response.status === 201;
+}
+
+async function addUserToGroup(
+  groupSlug: string,
+  userSlug: string,
+  token: string,
+  app: string = TESTING_APP_URL,
+) {
+  const response = await request(app)
+    .post(`/api/v1/groups/${groupSlug}/members`)
+    .set('Authorization', `Bearer ${token}`)
+    .set('x-tenant-id', TESTING_TENANT_ID)
+    .send({ userSlug });
+
+  return response.status === 200 || response.status === 201;
+}
+
 export {
   getAuthToken,
   createGroup,
@@ -383,4 +491,10 @@ export {
   updateGroupMemberRole,
   getGroupMembers,
   getCurrentUser,
+  sendEventMessage,
+  sendGroupMessage,
+  redactEventMessage,
+  redactGroupMessage,
+  addUserToEvent,
+  addUserToGroup,
 };


### PR DESCRIPTION
- Add redaction endpoints for event and group discussions
- Implement Matrix message redaction with permission checks
- Add automatic permission sync when users join chat rooms
- Support self-redaction and moderator-level redaction
- Include comprehensive E2E tests for all redaction scenarios