### PR TITLE
Fix private group access by removing VisibilityGuard restrictions

### DIFF
--- a/src/group/group.controller.ts
+++ b/src/group/group.controller.ts
@@ -106,7 +106,7 @@ export class GroupController {
   }
 
   @Public()
-  @UseGuards(JWTAuthGuard, VisibilityGuard)
+  @UseGuards(JWTAuthGuard)
   @Get(':slug')
   @ApiOperation({
     summary: 'Get group by group slug and authenticated user',
@@ -176,7 +176,7 @@ export class GroupController {
   // Events are handling Matrix chats correctly - groups will be adapted later
 
   @Public()
-  @UseGuards(JWTAuthGuard, VisibilityGuard)
+  @UseGuards(JWTAuthGuard)
   @Post(':slug/join')
   @ApiOperation({ summary: 'Joining a group through link' })
   async joinGroup(@AuthUser() user: User, @Param('slug') slug: string) {
@@ -184,7 +184,7 @@ export class GroupController {
   }
 
   @Public()
-  @UseGuards(JWTAuthGuard, VisibilityGuard)
+  @UseGuards(JWTAuthGuard)
   @Delete(':slug/leave')
   @ApiOperation({ summary: 'Leave a group' })
   async leaveGroup(@AuthUser() user: User, @Param('slug') slug: string) {

--- a/src/shared/guard/visibility.guard.spec.ts
+++ b/src/shared/guard/visibility.guard.spec.ts
@@ -246,6 +246,7 @@ describe('VisibilityGuard', () => {
         123,
       );
     });
+
   });
 
   describe('canActivate - Authentication Required', () => {

--- a/test/group/group-private-access.e2e-spec.ts
+++ b/test/group/group-private-access.e2e-spec.ts
@@ -99,6 +99,24 @@ describe('Group Private Access (e2e)', () => {
     );
   });
 
+  it('should allow authenticated users to join private groups', async () => {
+    // Create another user to test joining functionality
+    const testUser2Token = await loginAsTester(); // This will create a different user or return same user for testing
+
+    // Try to join the private group as an authenticated user
+    const joinResponse = await request(TESTING_APP_URL)
+      .post(`/api/groups/${privateGroup.slug}/join`)
+      .set('Authorization', `Bearer ${testUser2Token}`)
+      .set('x-tenant-id', TESTING_TENANT_ID)
+      .set('x-group-slug', privateGroup.slug);
+
+    // Should allow joining (the API should return success, even if requires approval)
+    expect(joinResponse.status).toBe(201);
+
+    // The response should contain the group member information
+    expect(joinResponse.body).toHaveProperty('id');
+  });
+
   it('should handle authenticated groups with helpful message for unauthenticated users', async () => {
     // First clean up the previous private group
     await request(TESTING_APP_URL)


### PR DESCRIPTION
- Remove VisibilityGuard from main group GET endpoint to allow discovery of private groups
- Remove VisibilityGuard from join/leave endpoints to enable private group joining
- Add e2e test for private group join functionality
- Keep VisibilityGuard on sensitive endpoints (/about, /events, /members)

This allows users to see private group basic info and join them, while maintaining security for group content access. Fixes issue where private groups showed "You must be a member of this private group to access it" instead of join options.