### PR TITLE
fix: use actual entity visibility for Matrix room creation

### DIFF
--- a/src/matrix/matrix-event.listener.ts
+++ b/src/matrix/matrix-event.listener.ts
@@ -822,7 +822,7 @@ export class MatrixEventListener {
         room_alias_name: localpart, // Use localpart for room alias
         name: `${event.name} Chat`,
         topic: `Chat room for ${event.name}`,
-        isPublic: true, // This gets converted to visibility and preset internally
+        isPublic: event.visibility === 'public', // Use actual event visibility
       };
 
       await this.matrixRoomService.createRoom(roomOptions, tenantId);
@@ -876,7 +876,7 @@ export class MatrixEventListener {
         {
           name: group.name,
           slug: group.slug,
-          visibility: 'private',
+          visibility: group.visibility === 'public' ? 'public' : 'private',
         },
         localpart,
         tenantId,


### PR DESCRIPTION
The MatrixEventListener was creating rooms with hardcoded visibility values:
- Groups were hardcoded as 'private'
- Events were hardcoded as 'public'

This caused a mismatch where database entities marked as 'public' would still create encrypted private Matrix rooms. Now both group and event room creation use the actual entity visibility from the database.