### PR TITLE
fix: improve sitemap to include only public events and groups

### DIFF
--- a/src/sitemap/sitemap.service.spec.ts
+++ b/src/sitemap/sitemap.service.spec.ts
@@ -5,6 +5,7 @@ import { promisify } from 'util';
 import { SitemapService } from './sitemap.service';
 import { EventQueryService } from '../event/services/event-query.service';
 import { GroupService } from '../group/group.service';
+import { EventVisibility, GroupVisibility } from '../core/constants/constant';
 
 const parseXml = promisify(parseString);
 
@@ -50,19 +51,28 @@ describe('SitemapService', () => {
   });
 
   describe('getPublicEvents', () => {
-    it('should return events with 5+ attendees after filtering', async () => {
+    it('should return public events with 3+ attendees after filtering', async () => {
       const mockEvents = [
         {
           slug: 'event-1',
           updatedAt: new Date('2023-01-01'),
           startDate: new Date('2023-12-01'),
-          attendeesCount: 7,
+          attendeesCount: 5,
+          visibility: EventVisibility.Public,
         },
         {
           slug: 'event-2',
           updatedAt: new Date('2023-01-02'),
           startDate: new Date('2023-12-02'),
-          attendeesCount: 3, // This should be filtered out
+          attendeesCount: 4,
+          visibility: EventVisibility.Private, // Should be filtered out (private)
+        },
+        {
+          slug: 'event-3',
+          updatedAt: new Date('2023-01-03'),
+          startDate: new Date('2023-12-03'),
+          attendeesCount: 2, // Should be filtered out (< 3 attendees)
+          visibility: EventVisibility.Public,
         },
       ];
 
@@ -77,7 +87,6 @@ describe('SitemapService', () => {
         { page: 1, limit: 1000 },
         expect.objectContaining({
           fromDate: expect.any(String),
-          toDate: expect.any(String),
           includeRecurring: true,
           expandRecurring: false,
         }),
@@ -89,17 +98,25 @@ describe('SitemapService', () => {
   });
 
   describe('getPublicGroups', () => {
-    it('should return groups with 3+ members after filtering', async () => {
+    it('should return public groups with 3+ members after filtering', async () => {
       const mockGroups = [
         {
           slug: 'group-1',
           updatedAt: new Date('2023-01-01'),
           groupMembersCount: 5,
+          visibility: GroupVisibility.Public,
         },
         {
           slug: 'group-2',
           updatedAt: new Date('2023-01-02'),
-          groupMembersCount: 2, // This should be filtered out
+          groupMembersCount: 4,
+          visibility: GroupVisibility.Private, // Should be filtered out (private)
+        },
+        {
+          slug: 'group-3',
+          updatedAt: new Date('2023-01-03'),
+          groupMembersCount: 2, // Should be filtered out (< 3 members)
+          visibility: GroupVisibility.Public,
         },
       ];
 
@@ -127,7 +144,8 @@ describe('SitemapService', () => {
           slug: 'event-1',
           updatedAt: new Date('2023-01-01'),
           startDate: new Date('2023-12-01'),
-          attendeesCount: 7,
+          attendeesCount: 5,
+          visibility: EventVisibility.Public,
         },
       ];
       const mockGroups = [
@@ -135,6 +153,7 @@ describe('SitemapService', () => {
           slug: 'group-1',
           updatedAt: new Date('2023-01-01'),
           groupMembersCount: 5,
+          visibility: GroupVisibility.Public,
         },
       ];
 

--- a/src/sitemap/sitemap.service.ts
+++ b/src/sitemap/sitemap.service.ts
@@ -4,6 +4,7 @@ import { EventEntity } from '../event/infrastructure/persistence/relational/enti
 import { GroupEntity } from '../group/infrastructure/persistence/relational/entities/group.entity';
 import { EventQueryService } from '../event/services/event-query.service';
 import { GroupService } from '../group/group.service';
+import { EventVisibility, GroupVisibility } from '../core/constants/constant';
 
 export interface SitemapUrl {
   loc: string;
@@ -33,19 +34,16 @@ export class SitemapService {
     // Set tenant ID on request for service layer
     this.request.tenantId = tenantId;
 
-    // SEO-focused filters: only upcoming events in next 6 months
+    // SEO-focused filters: only upcoming events (no end date limit)
     const now = new Date();
-    const sixMonthsFromNow = new Date();
-    sixMonthsFromNow.setMonth(sixMonthsFromNow.getMonth() + 6);
 
     // Format dates as YYYY-MM-DD as expected by the DTO
     const fromDate = now.toISOString().split('T')[0];
-    const toDate = sixMonthsFromNow.toISOString().split('T')[0];
+    // No toDate to include all future events
 
     // Use the event query service to get filtered public events
     const queryEventDto = {
       fromDate,
-      toDate,
       includeRecurring: true,
       expandRecurring: false,
     } as any; // Type assertion to avoid DTO validation issues
@@ -56,10 +54,10 @@ export class SitemapService {
       undefined, // No user (public access)
     );
 
-    // Filter events to only include those with 5+ attendees
+    // Filter events to only include public events with 3+ attendees per design notes
     const events = result.data || [];
     return events.filter((event: any) => {
-      return (event.attendeesCount || 0) >= 5;
+      return event.visibility === EventVisibility.Public && (event.attendeesCount || 0) >= 3;
     });
   }
 
@@ -76,10 +74,10 @@ export class SitemapService {
       undefined, // No user (public access)
     );
 
-    // Filter groups to only include active ones (with 3+ members)
+    // Filter groups to only include public groups with 3+ members per design notes
     const groups = result.data || [];
     return groups.filter((group: any) => {
-      return (group.groupMembersCount || 0) >= 3;
+      return group.visibility === GroupVisibility.Public && (group.groupMembersCount || 0) >= 3;
     });
   }
 

--- a/src/sitemap/sitemap.service.ts
+++ b/src/sitemap/sitemap.service.ts
@@ -57,7 +57,10 @@ export class SitemapService {
     // Filter events to only include public events with 3+ attendees per design notes
     const events = result.data || [];
     return events.filter((event: any) => {
-      return event.visibility === EventVisibility.Public && (event.attendeesCount || 0) >= 3;
+      return (
+        event.visibility === EventVisibility.Public &&
+        (event.attendeesCount || 0) >= 3
+      );
     });
   }
 
@@ -77,7 +80,10 @@ export class SitemapService {
     // Filter groups to only include public groups with 3+ members per design notes
     const groups = result.data || [];
     return groups.filter((group: any) => {
-      return group.visibility === GroupVisibility.Public && (group.groupMembersCount || 0) >= 3;
+      return (
+        group.visibility === GroupVisibility.Public &&
+        (group.groupMembersCount || 0) >= 3
+      );
     });
   }
 


### PR DESCRIPTION
- Add public visibility filtering for events (EventVisibility.Public)
- Add public visibility filtering for groups (GroupVisibility.Public)
- Reduce event attendee requirement from 5+ to 3+ per design notes
- Remove 6-month date limit to include all future events
- Ensures sitemap only indexes publicly accessible content