### PR TITLE
feat: add Google OAuth2 authorization code flow backend support

### DIFF
--- a/src/auth-google/auth-google.service.ts
+++ b/src/auth-google/auth-google.service.ts
@@ -8,6 +8,7 @@ import {
 import { OAuth2Client } from 'google-auth-library';
 import { SocialInterface } from '../social/interfaces/social.interface';
 import { AuthGoogleLoginDto } from './dto/auth-google-login.dto';
+import { AuthGoogleOAuth2Dto } from './dto/auth-google-oauth2.dto';
 import { REQUEST } from '@nestjs/core';
 import { TenantConnectionService } from '../tenant/tenant.service';
 import { TenantConfig } from '../core/constants/constant';
@@ -55,5 +56,62 @@ export class AuthGoogleService {
       firstName: data.given_name,
       lastName: data.family_name,
     };
+  }
+
+  async getProfileByOAuth2Code(
+    oauth2Dto: AuthGoogleOAuth2Dto,
+  ): Promise<SocialInterface> {
+    try {
+      // Exchange authorization code for tokens
+      const { tokens } = await this.google.getToken({
+        code: oauth2Dto.code,
+        redirect_uri: oauth2Dto.redirectUri,
+      });
+
+      if (!tokens.id_token) {
+        throw new UnprocessableEntityException({
+          status: HttpStatus.UNPROCESSABLE_ENTITY,
+          errors: {
+            user: 'noIdToken',
+          },
+        });
+      }
+
+      // Verify the ID token (reusing existing logic)
+      const ticket = await this.google.verifyIdToken({
+        idToken: tokens.id_token,
+        audience: [this.tenantConfig.googleClientId],
+      });
+
+      const data = ticket.getPayload();
+
+      if (!data) {
+        throw new UnprocessableEntityException({
+          status: HttpStatus.UNPROCESSABLE_ENTITY,
+          errors: {
+            user: 'wrongToken',
+          },
+        });
+      }
+
+      // Return same format as existing method
+      return {
+        id: data.sub,
+        email: data.email,
+        firstName: data.given_name,
+        lastName: data.family_name,
+      };
+    } catch (error) {
+      if (error instanceof UnprocessableEntityException) {
+        throw error;
+      }
+
+      throw new UnprocessableEntityException({
+        status: HttpStatus.UNPROCESSABLE_ENTITY,
+        errors: {
+          user: 'invalidAuthorizationCode',
+        },
+      });
+    }
   }
 }

--- a/src/auth-google/dto/auth-google-oauth2.dto.ts
+++ b/src/auth-google/dto/auth-google-oauth2.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsUrl } from 'class-validator';
+
+export class AuthGoogleOAuth2Dto {
+  @ApiProperty({
+    example: 'abc123def456',
+    description: 'Authorization code received from Google OAuth2 redirect'
+  })
+  @IsNotEmpty()
+  code: string;
+
+  @ApiProperty({
+    example: 'https://yourapp.com/auth/google/callback',
+    description: 'Redirect URI used in the OAuth2 flow'
+  })
+  @IsNotEmpty()
+  @IsUrl()
+  redirectUri: string;
+
+  @ApiProperty({
+    example: 'xyz789',
+    description: 'State parameter for CSRF protection',
+    required: false
+  })
+  @IsOptional()
+  state?: string;
+}


### PR DESCRIPTION
Backend changes:
- Add AuthGoogleOAuth2Dto for authorization code parameters
- Add getProfileByOAuth2Code method to AuthGoogleService
- Add POST /auth/google/oauth2/callback endpoint
- Reuse existing social login validation and session logic
- Maintain compatibility with existing Google ID token flow

Completes OAuth2 implementation to eliminate popup-based authentication. Exchanges authorization codes for ID tokens server-side for security.