### PR TITLE
fix(metrics): pass all histogram labels when stopping timers

### DIFF
--- a/src/event/services/event-integration.service.ts
+++ b/src/event/services/event-integration.service.ts
@@ -101,7 +101,12 @@ export class EventIntegrationService {
         );
 
         // Stop the timer with is_duplicate = true
-        timer({ is_duplicate: 'true' });
+        timer({
+          tenant: tenantId,
+          source_type: eventData.source.type,
+          operation: 'process',
+          is_duplicate: 'true',
+        });
 
         return this.updateExistingEvent(
           existingEvent,
@@ -115,7 +120,12 @@ export class EventIntegrationService {
       this.logger.debug('No existing event found, creating a new one');
 
       // Stop the timer with is_duplicate = false
-      timer({ is_duplicate: 'false' });
+      timer({
+        tenant: tenantId,
+        source_type: eventData.source.type,
+        operation: 'process',
+        is_duplicate: 'false',
+      });
 
       return this.createNewEvent(eventData, eventRepository, tenantId);
     } catch (error) {
@@ -127,7 +137,12 @@ export class EventIntegrationService {
       });
 
       // Stop the timer for error case
-      timer({ is_duplicate: 'error' });
+      timer({
+        tenant: tenantId,
+        source_type: eventData.source.type,
+        operation: 'process',
+        is_duplicate: 'error',
+      });
 
       throw error;
     }
@@ -900,7 +915,12 @@ export class EventIntegrationService {
         });
 
         // End the timing
-        timer();
+        timer({
+          tenant: tenantId,
+          source_type: sourceType,
+          operation: 'delete',
+          is_duplicate: 'n/a',
+        });
 
         return {
           success: false,
@@ -940,7 +960,12 @@ export class EventIntegrationService {
       });
 
       // End the timing
-      timer();
+      timer({
+        tenant: tenantId,
+        source_type: sourceType,
+        operation: 'delete',
+        is_duplicate: 'n/a',
+      });
 
       return {
         success: true,
@@ -955,7 +980,12 @@ export class EventIntegrationService {
       });
 
       // End the timing
-      timer();
+      timer({
+        tenant: tenantId,
+        source_type: sourceType,
+        operation: 'delete',
+        is_duplicate: 'n/a',
+      });
 
       throw error;
     }


### PR DESCRIPTION
## Summary

Fixes histogram metric labels bug in event integration processing where Grafana visualizations showed incorrect linear increases in processing time instead of realistic p95 latencies.

**Root cause:** The `event_integration_processing_duration_seconds` histogram timer was initialized with all 4 labels (`tenant`, `source_type`, `operation`, `is_duplicate`) but only partial or no labels were passed when stopping the timer. Some versions of prom-client replace labels instead of merging them, causing incomplete label sets and incorrect Prometheus aggregations.

**Solution:** Updated 6 timer stops across `processExternalEvent` and `deleteExternalEvent` methods to include all required labels consistently.

### Changes made
- Fixed 3 timer stops in `processExternalEvent` (lines ~104, ~123, ~135)
- Fixed 3 timer stops in `deleteExternalEvent` (lines ~918, ~963, ~983)
- All timer stops now pass complete label sets: `{tenant, source_type, operation, is_duplicate}`

## Test plan

- ✅ All 19 tests pass in `event-integration.service.spec.ts`
- ✅ Linting passes with no errors
- ✅ No TypeScript compilation errors

**Expected outcome:** Grafana dashboards will now show accurate p95 latencies for event integration processing instead of linearly increasing values.

## Related issues

Closes #319