### PR TITLE
fix(auth): set statusId for shadow accounts to enable passwordless login

### DIFF
--- a/src/database/migrations/1761600217954-FixNullStatusIdUsers.ts
+++ b/src/database/migrations/1761600217954-FixNullStatusIdUsers.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixNullStatusIdUsers1761600217954 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const schema = queryRunner.connection.options.name || 'public';
+
+    // This migration fixes users with NULL statusId, which prevents passwordless login
+    // Shadow accounts and early users were created without statusId set
+    // This affects ~75 users in production including admins and Bluesky shadow accounts
+
+    // Update all users with NULL statusId to active (statusId = 1)
+    await queryRunner.query(`
+      UPDATE "${schema}".users
+      SET "statusId" = 1
+      WHERE "statusId" IS NULL;
+    `);
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    // We don't want to revert users back to NULL statusId in the down migration
+    // as it would break their login again
+    // This is a data fix migration, not a schema change
+  }
+}

--- a/src/shadow-account/shadow-account.service.ts
+++ b/src/shadow-account/shadow-account.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { UserEntity } from '../user/infrastructure/persistence/relational/entities/user.entity';
+import { StatusEntity } from '../status/infrastructure/persistence/relational/entities/status.entity';
 import { TenantConnectionService } from '../tenant/tenant.service';
 import { AuthProvidersEnum } from '../auth/auth-providers.enum';
+import { StatusEnum } from '../status/status.enum';
 import { ulid } from 'ulid';
 import slugify from 'slugify';
 import { generateShortCode } from '../utils/short-code';
@@ -92,6 +94,12 @@ export class ShadowAccountService {
           shadowUser.lastName = null;
           // Use empty string instead of null for password
           shadowUser.password = '';
+
+          // Set status to active
+          const status = new StatusEntity();
+          status.id = StatusEnum.active;
+          shadowUser.status = status;
+
           shadowUser.ulid = ulid().toLowerCase();
           shadowUser.slug = `${slugify(
             (displayName || 'shadow-user').trim().toLowerCase(),


### PR DESCRIPTION
## Summary
- Fixes shadow accounts created with NULL statusId that prevents passwordless login
- Adds migration to update ~75 existing affected users to active status
- Ensures all future shadow accounts are created with active status

## Problem
Shadow accounts and early users were created without `statusId` set, making them inactive. This prevents passwordless login from working because `auth.service.ts` correctly skips inactive users when sending login codes.

**Affected users:** ~75 users in production including:
- Admin accounts
- All Bluesky shadow accounts  
- Early email-based shadow accounts

## Root Cause
`shadow-account.service.ts` (line 86-103) creates users directly without setting `statusId`.

## Solution
1. **Code fix:** Set `statusId = StatusEnum.active` when creating shadow accounts
2. **Data migration:** Update all existing users with `NULL statusId` to `statusId = 1` (active)

## Testing
- ✅ Linting passed
- ✅ All tests passed
- ✅ Migration tested on local database
  - Before: 71 shadow accounts with NULL statusId
  - After: 0 users with NULL statusId, all 317 users active

## Impact
- Unblocks 75 users from using passwordless login
- Fixes Bluesky integration login flow
- All future shadow accounts will work correctly

Fixes #330