### PR TITLE
fix(ical): correctly convert UTC dates to event timezone in ICS files

### DIFF
--- a/src/event/services/ical/ical.service.ts
+++ b/src/event/services/ical/ical.service.ts
@@ -7,6 +7,7 @@ import { RecurrencePatternService } from '../../../event-series/services/recurre
 import { EventStatus } from '../../../core/constants/constant';
 import { REQUEST } from '@nestjs/core';
 import { TenantConnectionService } from '../../../tenant/tenant.service';
+import { toZonedTime } from 'date-fns-tz';
 
 @Injectable({ scope: Scope.REQUEST })
 export class ICalendarService {
@@ -42,13 +43,20 @@ export class ICalendarService {
     // Use event's timezone or fallback to UTC
     const timezone = event.timeZone || 'UTC';
 
+    // Convert UTC dates to the event's timezone
+    // This ensures the ICS file contains correct local times with TZID
+    const startDate = toZonedTime(new Date(event.startDate), timezone);
+    const endDate = event.endDate
+      ? toZonedTime(new Date(event.endDate), timezone)
+      : undefined;
+
     // Create the basic event
     const calEvent = icalGenerator().createEvent({
       summary: event.name,
       description: event.description,
       location: event.location,
-      start: new Date(event.startDate),
-      end: event.endDate ? new Date(event.endDate) : undefined,
+      start: startDate,
+      end: endDate,
       timezone: timezone,
       allDay: event.isAllDay || false,
     });


### PR DESCRIPTION
Fixes the root cause of timezone issues in calendar invite .ics attachments. Calendar apps were showing incorrect dates and times for events with non-UTC timezones because UTC timestamps from the database were not being properly converted to the event's configured timezone.

Fixes https://github.com/OpenMeet-Team/openmeet-platform/issues/257

## Problem
Events with non-UTC timezones showed incorrect dates/times in calendar apps.

**Example (from issue #257):**
- Event: Nov 4, 2025 5:00 PM America/Los_Angeles  
- Calendar showed: Nov 5, 4:00 AM (wrong date and time)
- Email showed: Nov 4, 5:00 PM PST (correct)

## Root Cause
`ical.service.ts` passed UTC Date objects directly to ical-generator without timezone conversion.

## Solution
Use `date-fns-tz` to convert UTC dates to event timezone before ICS generation.

## Changes
- Import `toZonedTime` from date-fns-tz
- Convert dates in `createCalendarEvent()`
- Add 2 timezone-specific unit tests (PST/EST)
- All 26 tests passing ✅

## Testing
✅ UTC to America/Los_Angeles conversion verified  
✅ UTC to America/New_York conversion verified  
✅ UTC events still work correctly (Z format)  
✅ All existing tests pass

## Related
- #341 - Fixed email body display
- Together these fully resolve #257