### PR TITLE
feat: Add calendar invites to event creation emails

### DIFF
--- a/src/event-mail/services/event-announcement.service.spec.ts
+++ b/src/event-mail/services/event-announcement.service.spec.ts
@@ -215,7 +215,7 @@ describe('EventAnnouncementService', () => {
 
   describe('handleEventCreated', () => {
     beforeEach(() => {
-      mailerService.sendMjmlMail.mockResolvedValue(undefined);
+      mailerService.sendCalendarInviteMail.mockResolvedValue(undefined);
     });
 
     it('should send announcement emails to group members and event attendees when a new event is created', async () => {
@@ -230,9 +230,9 @@ describe('EventAnnouncementService', () => {
       // Assert - emails should be sent to group members + event attendees
 
       // Should send emails to group members (Alice, Bob, Carol) + event attendees (David, Emma) = 5 total, excluding organizer
-      expect(mailerService.sendMjmlMail).toHaveBeenCalledTimes(5);
+      expect(mailerService.sendCalendarInviteMail).toHaveBeenCalledTimes(5);
 
-      expect(mailerService.sendMjmlMail).toHaveBeenCalledWith({
+      expect(mailerService.sendCalendarInviteMail).toHaveBeenCalledWith({
         to: 'alice@example.com',
         subject: 'New Event: Test Event in Test Group',
         templateName: 'event/new-event-announcement',
@@ -252,9 +252,10 @@ describe('EventAnnouncementService', () => {
           organizerUrl: expect.stringContaining('/members/organizer-user'),
         },
         tenantConfig: expect.any(Object),
+        icsContent: expect.any(String),
       });
 
-      expect(mailerService.sendMjmlMail).toHaveBeenCalledWith({
+      expect(mailerService.sendCalendarInviteMail).toHaveBeenCalledWith({
         to: 'bob@example.com',
         subject: 'New Event: Test Event in Test Group',
         templateName: 'event/new-event-announcement',
@@ -274,9 +275,10 @@ describe('EventAnnouncementService', () => {
           organizerUrl: expect.stringContaining('/members/organizer-user'),
         },
         tenantConfig: expect.any(Object),
+        icsContent: expect.any(String),
       });
 
-      expect(mailerService.sendMjmlMail).toHaveBeenCalledWith({
+      expect(mailerService.sendCalendarInviteMail).toHaveBeenCalledWith({
         to: 'carol@example.com',
         subject: 'New Event: Test Event in Test Group',
         templateName: 'event/new-event-announcement',
@@ -296,6 +298,7 @@ describe('EventAnnouncementService', () => {
           organizerUrl: expect.stringContaining('/members/organizer-user'),
         },
         tenantConfig: expect.any(Object),
+        icsContent: expect.any(String),
       });
     });
 
@@ -315,7 +318,7 @@ describe('EventAnnouncementService', () => {
       });
 
       // Assert - Should send emails to event attendees (David, Emma) even without a group
-      expect(mailerService.sendMjmlMail).toHaveBeenCalledTimes(2);
+      expect(mailerService.sendCalendarInviteMail).toHaveBeenCalledTimes(2);
     });
 
     it('should send emails to event attendees even if group has no members', async () => {
@@ -331,7 +334,7 @@ describe('EventAnnouncementService', () => {
       });
 
       // Assert - Should send emails to event attendees (David, Emma) even if group has no members
-      expect(mailerService.sendMjmlMail).toHaveBeenCalledTimes(2);
+      expect(mailerService.sendCalendarInviteMail).toHaveBeenCalledTimes(2);
     });
 
     it('should not send emails if there are no group members and no event attendees', async () => {
@@ -348,7 +351,7 @@ describe('EventAnnouncementService', () => {
       });
 
       // Assert
-      expect(mailerService.sendMjmlMail).not.toHaveBeenCalled();
+      expect(mailerService.sendCalendarInviteMail).not.toHaveBeenCalled();
     });
 
     it('should send email to the event organizer if they are also a group member', async () => {
@@ -375,17 +378,17 @@ describe('EventAnnouncementService', () => {
 
       // Assert
       // Should send 6 emails (Alice, Bob, Carol, David, Emma, John the organizer)
-      expect(mailerService.sendMjmlMail).toHaveBeenCalledTimes(6);
+      expect(mailerService.sendCalendarInviteMail).toHaveBeenCalledTimes(6);
 
       // Verify organizer received an email
-      const emailCalls = mailerService.sendMjmlMail.mock.calls;
+      const emailCalls = mailerService.sendCalendarInviteMail.mock.calls;
       const emailAddresses = emailCalls.map((call) => call[0].to);
       expect(emailAddresses).toContain('organizer@example.com');
     });
 
     it('should handle email sending failures gracefully', async () => {
       // Arrange
-      mailerService.sendMjmlMail.mockRejectedValueOnce(
+      mailerService.sendCalendarInviteMail.mockRejectedValueOnce(
         new Error('SMTP server down'),
       );
 
@@ -399,7 +402,7 @@ describe('EventAnnouncementService', () => {
         }),
       ).resolves.not.toThrow();
 
-      expect(mailerService.sendMjmlMail).toHaveBeenCalledTimes(5);
+      expect(mailerService.sendCalendarInviteMail).toHaveBeenCalledTimes(5);
     });
 
     it('should not send emails if event is not found', async () => {
@@ -415,7 +418,7 @@ describe('EventAnnouncementService', () => {
       });
 
       // Assert
-      expect(mailerService.sendMjmlMail).not.toHaveBeenCalled();
+      expect(mailerService.sendCalendarInviteMail).not.toHaveBeenCalled();
     });
   });
 

--- a/src/event-mail/services/event-announcement.service.ts
+++ b/src/event-mail/services/event-announcement.service.ts
@@ -148,10 +148,36 @@ export class EventAnnouncementService {
       // Get tenant configuration for emails
       const tenantConfig = this.getTenantConfig();
 
+      // Get event organizer info
+      const organizer = event.user || null;
+      if (!organizer) {
+        this.logger.warn(
+          `Event ${event.slug} has no organizer, skipping announcement`,
+        );
+        return;
+      }
+
       // Send emails to each recipient
       const emailPromises = recipientsToNotify.map(async (user) => {
         try {
-          await this.mailerService.sendMjmlMail({
+          // Generate calendar invite for this recipient
+          const eventUrl = `${tenantConfig?.frontendDomain}/events/${event.slug}`;
+          const icsContent = this.icalService.generateCalendarInvite(
+            event,
+            {
+              email: user.email!,
+              firstName: user.firstName || undefined,
+              lastName: user.lastName || undefined,
+            },
+            {
+              email: organizer.email || '',
+              firstName: organizer.firstName || undefined,
+              lastName: organizer.lastName || undefined,
+            },
+            eventUrl,
+          );
+
+          await this.mailerService.sendCalendarInviteMail({
             to: user.email!,
             subject: event.group?.name
               ? `New Event: ${event.name} in ${event.group.name}`
@@ -169,7 +195,7 @@ export class EventAnnouncementService {
               organizerName:
                 `${event.user?.firstName || ''} ${event.user?.lastName || ''}`.trim(),
               organizerSlug: event.user?.slug,
-              eventUrl: `${tenantConfig?.frontendDomain}/events/${event.slug}`,
+              eventUrl,
               groupUrl: event.group?.slug
                 ? `${tenantConfig?.frontendDomain}/groups/${event.group.slug}`
                 : null,
@@ -178,9 +204,12 @@ export class EventAnnouncementService {
                 : null,
             },
             tenantConfig,
+            icsContent,
           });
 
-          this.logger.debug(`Sent announcement email to ${user.email}`);
+          this.logger.debug(
+            `Sent announcement with calendar invite to ${user.email}`,
+          );
         } catch (error) {
           this.logger.error(
             `Failed to send announcement email to ${user.email}: ${error.message}`,


### PR DESCRIPTION
## Summary
Event creation emails now include calendar invite (.ics) attachments so recipients can immediately add the event to their calendars.

This completes the event lifecycle calendar invite implementation:
- ✅ **Create**: METHOD:REQUEST ICS (add to calendar)
- ✅ **Update**: METHOD:REQUEST ICS with SEQUENCE (update calendar) - from PR #344
- ✅ **Cancel**: METHOD:CANCEL ICS (remove from calendar) - from PR #344

## Changes
- Modified `handleEventCreated()` to use `sendCalendarInviteMail()` instead of `sendMjmlMail()`
- Generate personalized METHOD:REQUEST ICS for each recipient
- Include VTIMEZONE component for RFC 5545 timezone compliance
- Add organizer validation to ensure event has an organizer

## Who Receives Creation Emails
Recipients include:
- All group members (if event is in a group)
- All event attendees
- Deduplicated if someone is both a member and attendee

## Technical Details
- **METHOD**: REQUEST (calendar invitation)
- **UID**: Uses immutable `event.ulid` for calendar entry tracking
- **SEQUENCE**: Uses `updatedAt` timestamp (will be 0 for new events)
- **VTIMEZONE**: Includes full timezone definitions for proper time display
- **Personalization**: Each recipient gets their own ICS with PARTSTAT=ACCEPTED

## Testing
- Updated all `handleEventCreated` tests to expect `sendCalendarInviteMail`
- Added `icsContent` expectation to test assertions
- All 22 event-announcement.service tests passing

## Dependencies
Builds on PR #344 which added:
- VTIMEZONE components for timezone compliance
- Event update calendar invites
- Event cancellation calendar invites