### PR TITLE
feat: expose provider, socialId, and isShadowAccount publicly

### DIFF
--- a/src/user/infrastructure/persistence/relational/entities/user.entity.ts
+++ b/src/user/infrastructure/persistence/relational/entities/user.entity.ts
@@ -87,7 +87,6 @@ export class UserEntity extends EntityRelationalHelper {
     example: 'email',
   })
   @Column({ default: AuthProvidersEnum.email })
-  @Expose({ groups: ['me', 'admin'] })
   provider: string;
 
   @ApiProperty({
@@ -98,7 +97,6 @@ export class UserEntity extends EntityRelationalHelper {
   })
   @Index()
   @Column({ type: String, nullable: true })
-  @Expose({ groups: ['me', 'admin'] })
   socialId?: string | null; // For Bluesky users, this contains the DID
 
   @ApiProperty({
@@ -231,7 +229,6 @@ export class UserEntity extends EntityRelationalHelper {
       'Indicates if this is a shadow account created from Bluesky integration',
   })
   @Column({ type: Boolean, default: false })
-  @Expose({ groups: ['admin'] })
   isShadowAccount: boolean;
 
   @Column('jsonb', { nullable: true })


### PR DESCRIPTION
These fields are needed by the frontend to determine which identifier to use for user profile links. They are not sensitive information:
- provider: Authentication method (email, bluesky, google, etc.)
- socialId: External ID (DID for Bluesky users)
- isShadowAccount: Whether this is an auto-created account

Previously these were only exposed in 'me' and 'admin' serialization groups, which meant event.user objects didn't include them. Now the frontend useUserIdentifier composable can properly determine if a user is a Bluesky user and use their DID for profile links.