### PR TITLE
Fix: Enable link previews for authenticated (unlisted) events

### DIFF
--- a/src/meta/meta.controller.ts
+++ b/src/meta/meta.controller.ts
@@ -268,10 +268,11 @@ if (!/bot|crawl|spider/i.test(navigator.userAgent)) {
         return;
       }
 
-      // Security: Only serve meta tags for PUBLIC events
-      if (event.visibility !== EventVisibility.Public) {
+      // Security: Only serve meta tags for PUBLIC and AUTHENTICATED events
+      // Private events return 404 to prevent information leakage
+      if (event.visibility === EventVisibility.Private) {
         this.logger.warn(
-          `Attempted to fetch meta for non-public event: ${slug} (visibility: ${event.visibility})`,
+          `Attempted to fetch meta for private event: ${slug}`,
         );
         res.status(HttpStatus.NOT_FOUND).send('Event not found');
         return;
@@ -279,14 +280,19 @@ if (!/bot|crawl|spider/i.test(navigator.userAgent)) {
 
       const html = this.renderMetaHTML('event', event);
 
+      // Set appropriate robot directives based on visibility
+      const robotsTag = event.visibility === EventVisibility.Public
+        ? 'index, follow'
+        : 'noindex, nofollow'; // Authenticated events: allow previews but not search indexing
+
       res.set({
         'Content-Type': 'text/html; charset=utf-8',
         'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
         Vary: 'User-Agent',
-        'X-Robots-Tag': 'index, follow',
+        'X-Robots-Tag': robotsTag,
       });
 
-      this.logger.debug(`Served meta HTML for public event: ${slug}`);
+      this.logger.debug(`Served meta HTML for event: ${slug} (visibility: ${event.visibility})`);
       res.send(html);
     } catch (error) {
       this.logger.error(`Error fetching event meta for ${slug}:`, error);
@@ -315,10 +321,11 @@ if (!/bot|crawl|spider/i.test(navigator.userAgent)) {
         return;
       }
 
-      // Security: Only serve meta tags for PUBLIC groups
-      if (group.visibility !== GroupVisibility.Public) {
+      // Security: Only serve meta tags for PUBLIC and AUTHENTICATED groups
+      // Private groups return 404 to prevent information leakage
+      if (group.visibility === GroupVisibility.Private) {
         this.logger.warn(
-          `Attempted to fetch meta for non-public group: ${slug} (visibility: ${group.visibility})`,
+          `Attempted to fetch meta for private group: ${slug}`,
         );
         res.status(HttpStatus.NOT_FOUND).send('Group not found');
         return;
@@ -326,14 +333,19 @@ if (!/bot|crawl|spider/i.test(navigator.userAgent)) {
 
       const html = this.renderMetaHTML('group', group);
 
+      // Set appropriate robot directives based on visibility
+      const robotsTag = group.visibility === GroupVisibility.Public
+        ? 'index, follow'
+        : 'noindex, nofollow'; // Authenticated groups: allow previews but not search indexing
+
       res.set({
         'Content-Type': 'text/html; charset=utf-8',
         'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
         Vary: 'User-Agent',
-        'X-Robots-Tag': 'index, follow',
+        'X-Robots-Tag': robotsTag,
       });
 
-      this.logger.debug(`Served meta HTML for public group: ${slug}`);
+      this.logger.debug(`Served meta HTML for group: ${slug} (visibility: ${group.visibility})`);
       res.send(html);
     } catch (error) {
       this.logger.error(`Error fetching group meta for ${slug}:`, error);


### PR DESCRIPTION
## Summary
Enables link preview bots (WhatsApp, Discord, Slack) to access meta tags for authenticated events and groups, while preventing search engine indexing.

**Problem**: Users reported they couldn't share authenticated events on WhatsApp because the bot was blocked, resulting in no preview - just a bare link.

**Solution**: Modified `MetaController` to allow bots to access authenticated content for link previews, while setting `X-Robots-Tag: noindex, nofollow` to prevent search engine indexing.

## Changes
- ✅ Allow bots to access **authenticated** events/groups for link previews
- ✅ Set `X-Robots-Tag: noindex, nofollow` for authenticated content (no search indexing)
- ✅ Keep **private** events completely hidden (404 for all bots)
- ✅ Added comprehensive behavior-oriented tests (30 tests passing)

## Visibility Behavior After This Fix

| Visibility | Search Index | Link Preview | Bot Access |
|-----------|-------------|--------------|------------|
| Public | ✅ Yes | ✅ Yes | ✅ Full |
| Authenticated | ❌ No | ✅ Yes | ✅ Preview only |
| Private | ❌ No | ❌ No | ❌ 404 |

## Test plan
- [x] All existing tests pass (30/30)
- [x] New tests verify bot access behavior for each visibility level
- [ ] Manual testing: Create authenticated event → share on WhatsApp → verify rich preview appears
- [ ] Manual testing: Verify authenticated events don't appear in Google search results

## Files Changed
- `src/meta/meta.controller.ts`: Modified bot access logic
- `src/meta/meta.controller.spec.ts`: Added comprehensive tests

## Related
- Design doc: `design-notes/event-visibility-and-permissions.md` (v2 section)
- This is part of Phase 3 of the visibility migration plan