### PR TITLE
perf(metrics): reduce cardinality by 92% with area-based labels

### DIFF
--- a/src/common/utils/metrics.util.ts
+++ b/src/common/utils/metrics.util.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared utilities for metrics collection
+ */
+
+/**
+ * Categorize requests by API area to maintain low cardinality in metrics
+ * Returns one of: events, groups, auth, matrix, bluesky, health, other
+ *
+ * This is used by both the request interceptor and exception filter to
+ * ensure consistent categorization across all metrics.
+ */
+export function getApiArea(url: string): string {
+  const path = url.split('?')[0].toLowerCase();
+
+  if (path.includes('/health') || path.includes('/metrics')) return 'health';
+  if (path.includes('/api/events') || path.includes('/api/event-series'))
+    return 'events';
+  if (path.includes('/api/groups')) return 'groups';
+  if (path.includes('/api/auth') || path.includes('/api/v1/auth'))
+    return 'auth';
+  if (path.includes('/api/matrix')) return 'matrix';
+  if (path.includes('/api/bluesky')) return 'bluesky';
+  if (path.includes('/api/integration')) return 'integration';
+  if (path.includes('/api/home') || path.includes('/api/feed')) return 'home';
+  if (path.includes('/api/users')) return 'users';
+  if (path.includes('/oidc')) return 'oidc';
+
+  return 'other';
+}

--- a/src/filters/global-exception.filter.ts
+++ b/src/filters/global-exception.filter.ts
@@ -10,6 +10,7 @@ import { Request, Response } from 'express';
 import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { InjectMetric } from '@willsoto/nestjs-prometheus';
 import { Counter } from 'prom-client';
+import { getApiArea } from '../common/utils/metrics.util';
 
 @Catch()
 export class GlobalExceptionFilter implements ExceptionFilter {
@@ -42,12 +43,13 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     const errorMessage =
       exception instanceof Error ? exception.message : 'Unknown error occurred';
 
-    // Increment exception counter with labels
+    // Increment exception counter with simplified labels (low cardinality)
+    const area = getApiArea(path);
+    const statusGroup = Math.floor(status / 100) * 100;
     this.exceptionCounter.inc({
       method,
-      path,
-      status,
-      error: errorName,
+      area,
+      status: statusGroup.toString(),
     });
 
     // Create a span for the exception

--- a/src/metrics/metrics.module.ts
+++ b/src/metrics/metrics.module.ts
@@ -10,27 +10,28 @@ import {
 import { TenantModule } from '../tenant/tenant.module';
 
 // Define HTTP metrics providers for export and reuse
+// Changed from path-based to area-based labels to reduce cardinality
 const httpMetricsProviders = [
   makeCounterProvider({
     name: 'http_requests_total',
     help: 'Total number of HTTP requests',
-    labelNames: ['method', 'path'],
+    labelNames: ['method', 'area'], // area: events, groups, auth, matrix, etc.
   }),
   makeHistogramProvider({
     name: 'http_request_duration_seconds',
     help: 'Duration of HTTP requests in seconds',
-    labelNames: ['method', 'path'],
+    labelNames: ['method', 'area'],
     buckets: [0.01, 0.05, 0.1, 0.5, 1, 2.5, 5, 10],
   }),
   makeCounterProvider({
     name: 'http_request_errors_total',
     help: 'Total number of HTTP request errors',
-    labelNames: ['method', 'path', 'status', 'error'],
+    labelNames: ['method', 'area', 'status'], // status: 200, 400, 500 (grouped)
   }),
   makeCounterProvider({
     name: 'unhandled_exceptions_total',
     help: 'Total number of unhandled exceptions',
-    labelNames: ['method', 'path', 'status', 'error'],
+    labelNames: ['method', 'area', 'status'], // Simplified to reduce cardinality
   }),
 ];
 


### PR DESCRIPTION
## Summary
Major metrics simplification that reduces Prometheus time series from ~9,000 to ~790 (92% reduction) and saves ~$40/month in costs.

**Problem identified:** Path normalization was completely broken - regex patterns didn't match `/api/...` paths, causing 108+ unique paths to be recorded instead of the intended normalized paths.

**Solution:** Replaced path-based metrics entirely with area-based categorization (11 areas vs 108+ paths) and added structured JSON logging for detailed per-endpoint analysis.

## Changes

### New Files
- `src/common/utils/metrics.util.ts` - Shared `getApiArea()` function that categorizes API requests into 11 areas (events, groups, auth, matrix, etc.)

### Updated Files
- `src/interceptors/request-counter.interceptor.ts` - Removed 160+ lines of broken path normalization regex, replaced with area-based labels and structured JSON logging
- `src/filters/global-exception.filter.ts` - Simplified error labels (removed error names, grouped status codes)
- `src/metrics/metrics.module.ts` - Changed labelNames from `path` to `area` for all HTTP metrics

## Metrics Updated
- `http_requests_total`: `['method', 'path']` → `['method', 'area']`
- `http_request_duration_seconds`: `['method', 'path']` → `['method', 'area']`
- `http_request_errors_total`: `['method', 'path', 'status', 'error']` → `['method', 'area', 'status']`
- `unhandled_exceptions_total`: `['method', 'path', 'status', 'error']` → `['method', 'area', 'status']`

## Impact
- ✅ Reduces time series from ~9,072 to ~792 (92% reduction)
- ✅ Expected cost savings: $1.50/day → $0.10/day (~$40/month)
- ✅ Improves observability with structured logs containing tenant_id, user_id, duration, etc.
- ✅ Eliminates maintenance burden of fragile path normalization regex

## Structured Logging
Added JSON-formatted logs for every request with full details:
```json
{
  "event": "http_request",
  "timestamp": "2025-01-15T10:30:00.000Z",
  "method": "GET",
  "path": "/api/events/my-event-slug",
  "status": 200,
  "duration_ms": 234,
  "area": "events",
  "tenant_id": "acme",
  "user_id": 123
}
```

This enables detailed per-endpoint analysis via CloudWatch Logs Insights, which is cheaper than high-cardinality metrics.

## Test Plan
- [x] Code builds successfully
- [x] Deploy to dev environment
- [ ] Verify metrics are being collected with new area labels
- [ ] Verify structured logs appear in CloudWatch
- [ ] Confirm Prometheus active time series count decreases
- [ ] Update Grafana dashboards to use `area` instead of `path` labels
- [ ] Deploy to production

## Breaking Changes
⚠️ **Dashboards using `path` labels will need to be updated to use `area` labels**

For per-endpoint analysis, use CloudWatch Logs Insights instead of metrics queries.