### PR TITLE
fix: Add group membership check to activity feed endpoints (Issue #379)

### DIFF
--- a/src/activity-feed/activity-feed.controller.spec.ts
+++ b/src/activity-feed/activity-feed.controller.spec.ts
@@ -6,6 +6,9 @@ import { REQUEST } from '@nestjs/core';
 import { GroupVisibility } from '../core/constants/constant';
 import { ActivityFeedEntity } from './infrastructure/persistence/relational/entities/activity-feed.entity';
 import { GroupEntity } from '../group/infrastructure/persistence/relational/entities/group.entity';
+import { EventQueryService } from '../event/services/event-query.service';
+import { EventAttendeeService } from '../event-attendee/event-attendee.service';
+import { GroupMemberService } from '../group-member/group-member.service';
 
 describe('GroupActivityFeedController', () => {
   let controller: GroupActivityFeedController;
@@ -88,6 +91,25 @@ describe('GroupActivityFeedController', () => {
           provide: GroupService,
           useFactory: () => ({
             getGroupBySlug: jest.fn(),
+            findGroupBySlug: jest.fn(),
+          }),
+        },
+        {
+          provide: EventQueryService,
+          useFactory: () => ({
+            findEventBySlug: jest.fn(),
+          }),
+        },
+        {
+          provide: EventAttendeeService,
+          useFactory: () => ({
+            findEventAttendeeByUserId: jest.fn(),
+          }),
+        },
+        {
+          provide: GroupMemberService,
+          useFactory: () => ({
+            findGroupMemberByUserId: jest.fn(),
           }),
         },
         {

--- a/src/activity-feed/activity-feed.controller.ts
+++ b/src/activity-feed/activity-feed.controller.ts
@@ -16,6 +16,7 @@ import { ActivityFeedQueryDto } from './dto/activity-feed-query.dto';
 import { ActivityFeedEntity } from './infrastructure/persistence/relational/entities/activity-feed.entity';
 import { Public } from '../auth/decorators/public.decorator';
 import { JWTAuthGuard } from '../auth/auth.guard';
+import { VisibilityGuard } from '../shared/guard/visibility.guard';
 
 @ApiTags('Activity Feed')
 @Controller('feed')
@@ -94,11 +95,12 @@ export class GroupActivityFeedController {
   ) {}
 
   @Public()
+  @UseGuards(JWTAuthGuard, VisibilityGuard)
   @Get(':slug/feed')
   @ApiOperation({
     summary: 'Get activity feed for a group',
     description:
-      'Returns recent activities for a group. Public endpoint with optional auth for more visibility.',
+      'Returns recent activities for a group. Access control based on group visibility: Public (anyone), Authenticated (logged in users), Private (members only).',
   })
   async getGroupFeed(
     @Param('slug') slug: string,
@@ -165,11 +167,12 @@ export class EventActivityFeedController {
   ) {}
 
   @Public()
+  @UseGuards(JWTAuthGuard, VisibilityGuard)
   @Get(':slug/feed')
   @ApiOperation({
     summary: 'Get activity feed for an event',
     description:
-      'Returns recent activities for an event. Public endpoint with optional auth for more visibility.',
+      'Returns recent activities for an event. Access control based on event visibility: Public (anyone), Authenticated (logged in users), Private (attendees only).',
   })
   async getEventFeed(
     @Param('slug') slug: string,

--- a/src/activity-feed/activity-feed.module.ts
+++ b/src/activity-feed/activity-feed.module.ts
@@ -13,6 +13,8 @@ import { GroupModule } from '../group/group.module';
 import { TenantModule } from '../tenant/tenant.module';
 import { EventModule } from '../event/event.module';
 import { BlueskyModule } from '../bluesky/bluesky.module';
+import { EventAttendeeModule } from '../event-attendee/event-attendee.module';
+import { GroupMemberModule } from '../group-member/group-member.module';
 
 @Module({
   imports: [
@@ -22,6 +24,8 @@ import { BlueskyModule } from '../bluesky/bluesky.module';
     forwardRef(() => UserModule),
     forwardRef(() => GroupModule),
     forwardRef(() => EventModule),
+    EventAttendeeModule,
+    GroupMemberModule,
   ],
   controllers: [
     SitewideActivityFeedController,

--- a/test/activity-feed/activity-feed-security.e2e-spec.ts
+++ b/test/activity-feed/activity-feed-security.e2e-spec.ts
@@ -1,0 +1,222 @@
+import request from 'supertest';
+import { TESTING_APP_URL, TESTING_TENANT_ID } from '../utils/constants';
+import {
+  createGroup,
+  loginAsAdmin,
+  createTestUser,
+  joinGroup,
+} from '../utils/functions';
+import {
+  GroupStatus,
+  GroupVisibility,
+} from '../../src/core/constants/constant';
+
+// Set a global timeout for all tests in this file
+jest.setTimeout(60000);
+
+describe('Activity Feed Security (E2E)', () => {
+  const app = TESTING_APP_URL;
+  let adminToken: string;
+  let groupMemberToken: string;
+  let nonMemberToken: string;
+  let privateGroup: any;
+  let authenticatedGroup: any;
+  let publicGroup: any;
+
+  // Store user info
+  let groupMemberUser: any;
+  let nonMemberUser: any;
+
+  beforeAll(async () => {
+    try {
+      // Get admin token
+      adminToken = await loginAsAdmin();
+
+      const timestamp = Date.now();
+
+      // Create test users
+      groupMemberUser = await createTestUser(
+        app,
+        TESTING_TENANT_ID,
+        `feed.member.${timestamp}@example.com`,
+        'Feed',
+        'Member',
+      );
+      groupMemberToken = groupMemberUser.token;
+
+      nonMemberUser = await createTestUser(
+        app,
+        TESTING_TENANT_ID,
+        `feed.nonmember.${timestamp}@example.com`,
+        'Feed',
+        'NonMember',
+      );
+      nonMemberToken = nonMemberUser.token;
+
+      // Create private group
+      privateGroup = await createGroup(app, adminToken, {
+        name: `Private Test Group ${timestamp}`,
+        description: 'A private group for testing activity feed security',
+        status: GroupStatus.Published,
+        visibility: GroupVisibility.Private,
+      });
+
+      // Create authenticated (unlisted) group
+      authenticatedGroup = await createGroup(app, adminToken, {
+        name: `Authenticated Test Group ${timestamp}`,
+        description: 'An authenticated group for testing activity feed security',
+        status: GroupStatus.Published,
+        visibility: GroupVisibility.Authenticated,
+      });
+
+      // Create public group
+      publicGroup = await createGroup(app, adminToken, {
+        name: `Public Test Group ${timestamp}`,
+        description: 'A public group for testing activity feed security',
+        status: GroupStatus.Published,
+        visibility: GroupVisibility.Public,
+      });
+
+      // Add groupMember to private group only
+      await joinGroup(app, TESTING_TENANT_ID, privateGroup.slug, groupMemberToken);
+
+      console.log('Test setup complete:', {
+        privateGroup: privateGroup.slug,
+        authenticatedGroup: authenticatedGroup.slug,
+        publicGroup: publicGroup.slug,
+        groupMemberId: groupMemberUser.id,
+        nonMemberId: nonMemberUser.id,
+      });
+    } catch (error) {
+      console.error('Error in beforeAll:', error);
+      throw error;
+    }
+  });
+
+  describe('GET /groups/:slug/feed - Private Groups', () => {
+    it('should allow group members to access private group feed', async () => {
+      // Given: User is a member of private group
+      // When: Member requests group feed
+      const response = await request(app)
+        .get(`/api/groups/${privateGroup.slug}/feed`)
+        .set('Authorization', `Bearer ${groupMemberToken}`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+
+      console.log('Member access response:', {
+        status: response.status,
+        bodyLength: response.body?.length,
+      });
+
+      // Then: Should return activities (200 OK)
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+    });
+
+    it('should deny non-members access to private group feed', async () => {
+      // Given: User is NOT a member of private group
+      // When: Non-member requests group feed
+      const response = await request(app)
+        .get(`/api/groups/${privateGroup.slug}/feed`)
+        .set('Authorization', `Bearer ${nonMemberToken}`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+
+      console.log('Non-member access response:', {
+        status: response.status,
+        body: response.body,
+      });
+
+      // Then: Should receive Forbidden error (403)
+      expect(response.status).toBe(403);
+      expect(response.body.message).toBeDefined();
+    });
+
+    it('should deny unauthenticated users access to private group feed', async () => {
+      // Given: User is not logged in
+      // When: Unauthenticated request to private group feed
+      const response = await request(app)
+        .get(`/api/groups/${privateGroup.slug}/feed`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+
+      console.log('Unauthenticated access response:', {
+        status: response.status,
+        body: response.body,
+      });
+
+      // Then: Should receive Forbidden or Unauthorized (403 or 401)
+      expect([401, 403]).toContain(response.status);
+    });
+  });
+
+  describe('GET /groups/:slug/feed - Authenticated Groups', () => {
+    it('should allow authenticated users to access authenticated group feed', async () => {
+      // Given: Authenticated (unlisted) group exists
+      // When: Any authenticated user requests feed
+      const response = await request(app)
+        .get(`/api/groups/${authenticatedGroup.slug}/feed`)
+        .set('Authorization', `Bearer ${nonMemberToken}`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+
+      console.log('Authenticated user access to authenticated group:', {
+        status: response.status,
+        bodyLength: response.body?.length,
+      });
+
+      // Then: Should succeed (authenticated = anyone with account can access)
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+    });
+
+    it('should deny unauthenticated users access to authenticated group feed', async () => {
+      // Given: Authenticated group exists
+      // When: Unauthenticated user requests feed
+      const response = await request(app)
+        .get(`/api/groups/${authenticatedGroup.slug}/feed`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+
+      console.log('Unauthenticated access to authenticated group:', {
+        status: response.status,
+        body: response.body,
+      });
+
+      // Then: Should be denied (401 or 403)
+      expect([401, 403]).toContain(response.status);
+    });
+  });
+
+  describe('GET /groups/:slug/feed - Public Groups', () => {
+    it('should allow anyone to access public group feed', async () => {
+      // Given: Public group exists
+      // When: Unauthenticated user requests feed
+      const response = await request(app)
+        .get(`/api/groups/${publicGroup.slug}/feed`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+
+      console.log('Unauthenticated access to public group:', {
+        status: response.status,
+        bodyLength: response.body?.length,
+      });
+
+      // Then: Should succeed
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+    });
+
+    it('should allow authenticated users to access public group feed', async () => {
+      // Given: Public group exists
+      // When: Authenticated user requests feed
+      const response = await request(app)
+        .get(`/api/groups/${publicGroup.slug}/feed`)
+        .set('Authorization', `Bearer ${nonMemberToken}`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+
+      console.log('Authenticated user access to public group:', {
+        status: response.status,
+        bodyLength: response.body?.length,
+      });
+
+      // Then: Should succeed
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds VisibilityGuard to activity feed endpoints to enforce access control based on group/event visibility.

## Problem
Activity feed endpoints allowed unauthorized access:
- Non-members could view private group activities
- Unauthenticated users could access authenticated group/event feeds
- No membership verification before returning activity data

## Solution
- Added `VisibilityGuard` to `GET /groups/:slug/feed`
- Added `VisibilityGuard` to `GET /events/:slug/feed`
- Added required module imports (EventAttendeeModule, GroupMemberModule)
- Updated unit tests with VisibilityGuard mocks

## Access Control Rules
- **Public:** Anyone can access
- **Authenticated:** Requires logged-in user
- **Private Groups:** Requires group membership (GroupMemberService check)
- **Private Events:** Requires event attendance (EventAttendeeService check)

## Testing
- ✅ All unit tests pass (16/16)
- ✅ E2E tests verify all visibility levels
- ✅ Service running successfully in Docker

## Security Impact
**Before:** P0 security issue - unauthorized feed access  
**After:** Proper authorization via VisibilityGuard

#379