### PR TITLE
fix: make approval optional for private groups

### DIFF
--- a/src/group/group.service.ts
+++ b/src/group/group.service.ts
@@ -780,10 +780,7 @@ export class GroupService {
     let assignedRole: GroupRole;
     let newGroupMember;
 
-    if (
-      groupEntity?.requireApproval ||
-      groupEntity?.visibility === GroupVisibility.Private
-    ) {
+    if (groupEntity?.requireApproval) {
       newGroupMember = await this.groupMemberService.createGroupMember(
         { userId: userEntity.id, groupId: groupEntity.id },
         GroupRole.Guest,


### PR DESCRIPTION
## Summary
Fixes the bug where ALL private groups required approval, even when the group admin selected "no approval needed".

This PR removes hardcoded logic that forced approval for all private groups and properly respects the `requireApproval` setting.

## Root Cause
The `joinGroup` method in `group.service.ts` had a hardcoded check that forced all private groups to require approval, completely ignoring the `requireApproval` setting.

## Changes
- Removed the hardcoded private group approval check at line 785
- Now properly checks only the `requireApproval` setting

## Behavior After Fix
- `requireApproval = true` → User assigned **Guest** role (requires admin approval)
- `requireApproval = false` → User assigned **Member** role (immediate access)

This works for **all group visibility types** (Public, Unlisted, Private).

## Design Alignment
According to `design-notes/visibility-model-v2-private-groups.md` (lines 360-385):
- **Auto-Approval (Default)**: User joins immediately as member
- **Manual Approval (Optional)**: Group admin enables "Require Approval" setting

## Test Plan
- [x] Create private group with "no approval needed"
- [x] Join group while logged in
- [x] Verify user is immediately a Member (not Guest)
- [x] Verify user has full access without admin approval
- [x] Test with `requireApproval = true` to ensure approval still works
- [x] Test with public/unlisted groups to ensure no regression

## Location
`openmeet-api/src/group/group.service.ts:783-797`