### PR TITLE
fix: add missing image join in getHomePageUserCreatedGroups

### DIFF
--- a/src/group/group.service.ts
+++ b/src/group/group.service.ts
@@ -729,6 +729,7 @@ export class GroupService {
     const queryBuilder = this.groupRepository
       .createQueryBuilder('group')
       .leftJoinAndSelect('group.createdBy', 'createdBy')
+      .leftJoinAndSelect('group.image', 'image')
       .loadRelationCountAndMap(
         'group.groupMembersCount',
         'group.groupMembers',


### PR DESCRIPTION
Fixes missing images for "groups you organize" section.

## Problem
PR #398 converted from `find()` to `createQueryBuilder()` for performance but dropped the `group.image` relation.

## Why it broke
TypeORM's `createQueryBuilder()` ignores `eager: true` relations - they must be explicitly joined.

## Verification
- HAR logs showed `organizedGroups` missing `image` field while `memberGroups` had it
- Frontend doesn't display creator photos so didn't add those joins
- Tests pass ✅