### PR TITLE
perf: add indexes to eventAttendees for query optimization

### DIFF
--- a/src/database/migrations/1764351067000-AddEventAttendeesIndexes.ts
+++ b/src/database/migrations/1764351067000-AddEventAttendeesIndexes.ts
@@ -1,0 +1,91 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddEventAttendeesIndexes1764351067000
+  implements MigrationInterface
+{
+  name = 'AddEventAttendeesIndexes1764351067000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const schema = queryRunner.connection.options.name || 'public';
+
+    // Add index on eventAttendees.userId for filtering events by user
+    // This supports queries like: WHERE attendee.userId = $1
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_eventAttendees_userId"
+      ON "${schema}"."eventAttendees" ("userId")
+    `);
+
+    // Add index on eventAttendees.eventId for join conditions
+    // This supports: JOIN eventAttendees ON eventAttendees.eventId = event.id
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_eventAttendees_eventId"
+      ON "${schema}"."eventAttendees" ("eventId")
+    `);
+
+    // Add composite index for filtering user's events by status
+    // This supports: WHERE attendee.userId = $1 AND attendee.status != $2
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_eventAttendees_userId_status"
+      ON "${schema}"."eventAttendees" ("userId", "status")
+    `);
+
+    // Add composite index for counting attendees by event and status
+    // This supports: WHERE status = $1 GROUP BY eventId
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_eventAttendees_status_eventId"
+      ON "${schema}"."eventAttendees" ("status", "eventId")
+    `);
+
+    // Add index on events.startDate for date filtering and ORDER BY
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_events_startDate"
+      ON "${schema}"."events" ("startDate")
+    `);
+
+    // Add index on events.status for filtering by event status
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_events_status"
+      ON "${schema}"."events" ("status")
+    `);
+
+    // Add composite index for common query pattern: status + startDate
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_events_status_startDate"
+      ON "${schema}"."events" ("status", "startDate")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const schema = queryRunner.connection.options.name || 'public';
+
+    // Drop events indexes
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "${schema}"."IDX_events_status_startDate"
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "${schema}"."IDX_events_status"
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "${schema}"."IDX_events_startDate"
+    `);
+
+    // Drop eventAttendees indexes
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "${schema}"."IDX_eventAttendees_status_eventId"
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "${schema}"."IDX_eventAttendees_userId_status"
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "${schema}"."IDX_eventAttendees_eventId"
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "${schema}"."IDX_eventAttendees_userId"
+    `);
+  }
+}

--- a/src/event-attendee/infrastructure/persistence/relational/entities/event-attendee.entity.ts
+++ b/src/event-attendee/infrastructure/persistence/relational/entities/event-attendee.entity.ts
@@ -5,6 +5,7 @@ import {
   PrimaryGeneratedColumn,
   CreateDateColumn,
   UpdateDateColumn,
+  Index,
 } from 'typeorm';
 import { UserEntity } from '../../../../../user/infrastructure/persistence/relational/entities/user.entity';
 import { EventEntity } from '../../../../../event/infrastructure/persistence/relational/entities/event.entity';
@@ -14,6 +15,10 @@ import { SourceFields } from '../../../../../core/interfaces/source-data.interfa
 import { EventSourceType } from '../../../../../core/constants/source-type.constant';
 
 @Entity({ name: 'eventAttendees' })
+@Index('IDX_eventAttendees_user', ['user'])
+@Index('IDX_eventAttendees_event', ['event'])
+@Index('IDX_eventAttendees_user_status', ['user', 'status'])
+@Index('IDX_eventAttendees_status_event', ['status', 'event'])
 export class EventAttendeesEntity implements SourceFields {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/event/infrastructure/persistence/relational/entities/event.entity.ts
+++ b/src/event/infrastructure/persistence/relational/entities/event.entity.ts
@@ -34,6 +34,7 @@ import { EventSourceType } from '../../../../../core/constants/source-type.const
 import { EventSeriesEntity } from '../../../../../event-series/infrastructure/persistence/relational/entities/event-series.entity';
 
 @Entity({ name: 'events' })
+@Index('IDX_events_status_startDate', ['status', 'startDate'])
 export class EventEntity
   extends EntityRelationalHelper
   implements SourceFields
@@ -80,6 +81,7 @@ export class EventEntity
   description: string;
 
   @Column({ type: Date })
+  @Index()
   startDate: Date;
 
   @Column({ type: Date, nullable: true })
@@ -121,6 +123,7 @@ export class EventEntity
     type: 'enum',
     enum: EventStatus,
   })
+  @Index()
   status: EventStatus;
 
   @Column({


### PR DESCRIPTION
## Summary
- Add indexes on `userId`, `eventId`, and composite `(userId, status)` to `eventAttendees` table
- These indexes optimize the common query pattern for fetching events a user is attending
- Expected improvement: query time from ~2s to ~10-50ms

## Test plan
- [x] Run migration in dev
- [x] Check Jaeger traces for event query performance
- [x] Verify indexes created in tenant schemas