### PR TITLE
fix: add missing image relations to user profile queries

### DIFF
--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -224,6 +224,7 @@ export class UserService {
     // Only show public events on user profiles
     const eventsQuery = this.usersRepository.manager
       .createQueryBuilder(EventEntity, 'event')
+      .leftJoinAndSelect('event.image', 'eventImage')
       .where('event.userId = :userId', { userId: user.id })
       .andWhere('event.visibility = :visibility', { visibility: 'public' })
       .andWhere('event.status IN (:...statuses)', {
@@ -237,6 +238,7 @@ export class UserService {
     // Only show public groups on user profiles (anonymous users can view profiles)
     const groupsQuery = this.usersRepository.manager
       .createQueryBuilder(GroupEntity, 'group')
+      .leftJoinAndSelect('group.image', 'groupImage')
       .where('group.createdById = :userId', { userId: user.id })
       .andWhere('group.visibility = :visibility', { visibility: 'public' })
       .andWhere('group.status = :status', { status: 'published' });
@@ -249,6 +251,7 @@ export class UserService {
     const groupMembersQuery = this.usersRepository.manager
       .createQueryBuilder(GroupMemberEntity, 'groupMember')
       .leftJoinAndSelect('groupMember.group', 'group')
+      .leftJoinAndSelect('group.image', 'groupMemberGroupImage')
       .leftJoinAndSelect('groupMember.groupRole', 'groupRole')
       .where('groupMember.userId = :userId', { userId: user.id })
       .andWhere('group.visibility = :visibility', { visibility: 'public' })


### PR DESCRIPTION
## Summary
- Add `leftJoinAndSelect` for `event.image` in the organized events query
- Add `leftJoinAndSelect` for `group.image` in the owned groups query
- Add `leftJoinAndSelect` for `group.image` in the group memberships query

Fixes images not appearing for groups and events on user profile pages (e.g., `/members/tom-scanlan-dvasc6`).

## Root Cause
When using `createQueryBuilder`, eager loading doesn't work automatically - relations must be explicitly joined. The recent query updates removed these joins.

## Test plan
- [x] Visit a user profile page with groups/events that have images
- [x] Verify images appear for owned groups
- [x] Verify images appear for organized events
- [x] Verify images appear for group memberships