### PR TITLE
feat: add dashboard summary endpoints for events, groups, and profiles

### DIFF
--- a/design-notes/dashboard-ux-patterns.md
+++ b/design-notes/dashboard-ux-patterns.md
@@ -1,0 +1,114 @@
+# Dashboard UX Patterns for Large Data Sets
+
+> **Confidence:** untested
+> **Added:** 2025-12-06
+> **Context:** Issue #397 - User with 1000+ events causing performance/UX issues
+
+## Problem
+
+Traditional pagination doesn't solve the UX problem for power users. A user with 2000 events would need 67+ pages at 30/page. Users don't want to scroll through history - they want to know "what's next."
+
+## Pattern: "What's Next" Dashboard
+
+Instead of loading all data and paginating, show a focused view:
+
+### UX Structure
+
+```
+┌─────────────────────────────────────────────────────┐
+│ Stats Summary                                       │
+│ [Hosting 1,024 upcoming] [Attending 987] [Past 500] │
+├─────────────────────────────────────────────────────┤
+│ HOSTING THIS WEEK (3)                               │
+│ [Event 1] [Event 2] [Event 3]                       │
+├─────────────────────────────────────────────────────┤
+│ HOSTING LATER (5 of 1,021)            View all →    │
+│ [Event 4] [Event 5] ... (limited preview)           │
+├─────────────────────────────────────────────────────┤
+│ ATTENDING SOON (5 of 987)             View all →    │
+│ [Event A] [Event B] ... (limited preview)           │
+├─────────────────────────────────────────────────────┤
+│ Past events (500)                     Browse past → │
+└─────────────────────────────────────────────────────┘
+```
+
+### Key Principles
+
+1. **Summary stats first** - Counts give context without loading data
+2. **Temporal grouping** - "This Week" vs "Later" adds meaning
+3. **Limited previews** - Show ~5 items, not all
+4. **Lazy-load secondary data** - Past events loaded on demand
+5. **"View all" links** - Lead to paginated full lists
+
+## Pattern: Dashboard Summary API
+
+Single endpoint returning counts + limited previews:
+
+### Response Structure
+
+```typescript
+interface DashboardSummaryDto {
+  counts: {
+    hostingUpcoming: number;
+    attendingUpcoming: number;
+    past: number;
+  };
+  hostingThisWeek: EventEntity[];  // Full list (typically small)
+  hostingLater: EventEntity[];     // Limited to ~5
+  attendingSoon: EventEntity[];    // Limited to ~5
+}
+```
+
+### Implementation Pattern
+
+```typescript
+async getDashboardSummary(userId: number): Promise<DashboardSummaryDto> {
+  // 1. Define query builder factories for reuse
+  const createHostingQuery = () => /* base query for hosting */;
+  const createAttendingQuery = () => /* base query for attending */;
+
+  // 2. Execute all queries in parallel
+  const [
+    hostingUpcomingCount,
+    attendingUpcomingCount,
+    pastCount,
+    hostingThisWeek,
+    hostingLater,
+    attendingSoon,
+  ] = await Promise.all([
+    createHostingQuery().andWhere('startDate >= :now').getCount(),
+    createAttendingQuery().andWhere('startDate >= :now').getCount(),
+    getPastEventsCount(userId),
+    createHostingQuery().andWhere('startDate BETWEEN :now AND :endOfWeek').getMany(),
+    createHostingQuery().andWhere('startDate > :endOfWeek').limit(5).getMany(),
+    createAttendingQuery().andWhere('startDate >= :now').limit(5).getMany(),
+  ]);
+
+  // 3. Batch fetch related data (avoid N+1)
+  const allEvents = [...hostingThisWeek, ...hostingLater, ...attendingSoon];
+  await batchFetchAttendeeCounts(allEvents);
+
+  return { counts, hostingThisWeek, hostingLater, attendingSoon };
+}
+```
+
+### Benefits
+
+- **Fast initial load** - Counts are cheap, limited data fetched
+- **Scales to any size** - 20 events or 20,000 events, same performance
+- **Progressive disclosure** - Full data available via drill-down
+- **Parallel execution** - All queries run concurrently
+
+## Files Implementing This Pattern
+
+- `src/event/dto/dashboard-summary.dto.ts` - Response DTO
+- `src/event/services/event-query.service.ts` - `getDashboardSummary()`
+- `src/event/event.controller.ts` - `GET /api/events/dashboard/summary`
+
+## Validation
+
+To validate this pattern works:
+- [ ] Test with user who has 1000+ events
+- [ ] Measure initial load time vs legacy endpoint
+- [ ] Get user feedback on the UX
+- [ ] Check if "view all" is used frequently (might indicate preview is too limited)

--- a/src/event/dto/dashboard-events-query.dto.ts
+++ b/src/event/dto/dashboard-events-query.dto.ts
@@ -1,0 +1,22 @@
+import { IsOptional, IsString, IsEnum } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { PaginationDto } from '../../utils/dto/pagination.dto';
+
+export enum DashboardEventsTab {
+  Hosting = 'hosting',
+  Attending = 'attending',
+  Past = 'past',
+}
+
+export class DashboardEventsQueryDto extends PaginationDto {
+  @ApiPropertyOptional({
+    description: 'Filter events by tab (hosting, attending, past)',
+    enum: DashboardEventsTab,
+    example: DashboardEventsTab.Hosting,
+  })
+  @IsOptional()
+  @IsEnum(DashboardEventsTab)
+  @Type(() => String)
+  tab?: DashboardEventsTab;
+}

--- a/src/event/dto/dashboard-summary.dto.ts
+++ b/src/event/dto/dashboard-summary.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { EventEntity } from '../infrastructure/persistence/relational/entities/event.entity';
+
+export class DashboardEventCounts {
+  @ApiProperty({ description: 'Total events user is hosting (upcoming)' })
+  hostingUpcoming: number;
+
+  @ApiProperty({ description: 'Total events user is attending (upcoming)' })
+  attendingUpcoming: number;
+
+  @ApiProperty({ description: 'Total past events' })
+  past: number;
+}
+
+export class DashboardSummaryDto {
+  @ApiProperty({ type: DashboardEventCounts })
+  counts: DashboardEventCounts;
+
+  @ApiProperty({
+    type: [EventEntity],
+    description: 'Events user is hosting this week',
+  })
+  hostingThisWeek: EventEntity[];
+
+  @ApiProperty({
+    type: [EventEntity],
+    description: 'Events user is hosting after this week (limited preview)',
+  })
+  hostingLater: EventEntity[];
+
+  @ApiProperty({
+    type: [EventEntity],
+    description: 'Events user is attending soon (limited preview)',
+  })
+  attendingSoon: EventEntity[];
+}

--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -23,6 +23,7 @@ import { UpdateEventDto } from './dto/update-event.dto';
 import { EventEntity } from './infrastructure/persistence/relational/entities/event.entity';
 import { JWTAuthGuard } from '../auth/auth.guard';
 import { QueryEventDto } from './dto/query-events.dto';
+import { DashboardSummaryDto } from './dto/dashboard-summary.dto';
 import { Public } from '../auth/decorators/public.decorator';
 import { AuthUser } from '../core/decorators/auth-user.decorator';
 import { User } from '../user/domain/user';
@@ -91,9 +92,26 @@ export class EventController {
     );
   }
 
+  @Get('dashboard/summary')
+  @ApiOperation({
+    summary: 'Get dashboard summary with counts and upcoming events',
+    description:
+      'Returns event counts and limited previews for the "What\'s Next" dashboard view. Optimized for fast loading.',
+  })
+  @Trace('event.getDashboardSummary')
+  async getDashboardSummary(@AuthUser() user: User): Promise<DashboardSummaryDto> {
+    return this.eventQueryService.getDashboardSummary(user.id);
+  }
+
+  /**
+   * @deprecated Use GET /dashboard/summary instead for better performance.
+   * This endpoint returns ALL events and will be slow for users with many events.
+   * Kept for backward compatibility with past events dialog and chat panel.
+   */
   @Get('dashboard')
   @ApiOperation({
-    summary: 'Get all events for the dashboard.',
+    summary: 'Get all events for the dashboard (DEPRECATED - use /dashboard/summary)',
+    deprecated: true,
   })
   @Trace('event.showDashboardEvents')
   async showDashboardEvents(@AuthUser() user: User): Promise<EventEntity[]> {

--- a/src/group/dto/dashboard-groups-summary.dto.ts
+++ b/src/group/dto/dashboard-groups-summary.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { GroupEntity } from '../infrastructure/persistence/relational/entities/group.entity';
+
+export class DashboardGroupCounts {
+  @ApiProperty({ description: 'Groups where user is owner/admin/moderator' })
+  leading: number;
+
+  @ApiProperty({ description: 'Groups where user is a regular member' })
+  member: number;
+}
+
+export class DashboardGroupsSummaryDto {
+  @ApiProperty({ type: DashboardGroupCounts })
+  counts: DashboardGroupCounts;
+
+  @ApiProperty({
+    type: [GroupEntity],
+    description: 'Groups user is leading (owner/admin/moderator) - limited preview',
+  })
+  leadingGroups: GroupEntity[];
+
+  @ApiProperty({
+    type: [GroupEntity],
+    description: 'Groups user is a member of - limited preview',
+  })
+  memberGroups: GroupEntity[];
+}

--- a/src/group/group.controller.ts
+++ b/src/group/group.controller.ts
@@ -35,6 +35,7 @@ import {
   PreviewAdminMessageDto,
 } from './dto/admin-message.dto';
 import { ContactAdminsDto } from './dto/contact-admins.dto';
+import { DashboardGroupsSummaryDto } from './dto/dashboard-groups-summary.dto';
 
 @ApiTags('Groups')
 @Controller('groups')
@@ -88,8 +89,27 @@ export class GroupController {
     return await this.groupService.getGroupsWhereUserCanCreateEvents(user.id);
   }
 
+  @Get('dashboard/summary')
+  @ApiOperation({
+    summary: 'Get dashboard summary with counts and group previews',
+    description:
+      'Returns group counts and limited previews for the dashboard. Optimized for fast loading.',
+  })
+  async getDashboardSummary(
+    @AuthUser() user: User,
+  ): Promise<DashboardGroupsSummaryDto> {
+    return await this.groupService.getDashboardSummary(user.id);
+  }
+
+  /**
+   * @deprecated Use GET /dashboard/summary instead for better performance.
+   * This endpoint returns ALL groups and will be slow for users with many groups.
+   */
   @Get('dashboard')
-  @ApiOperation({ summary: 'Get all groups for the dashboard' })
+  @ApiOperation({
+    summary: 'Get all groups for the dashboard (DEPRECATED - use /dashboard/summary)',
+    deprecated: true,
+  })
   async showDashboardGroups(@AuthUser() user: User): Promise<GroupEntity[]> {
     return await this.groupService.showDashboardGroups(user.id);
   }

--- a/src/user/dto/profile-summary.dto.ts
+++ b/src/user/dto/profile-summary.dto.ts
@@ -1,0 +1,84 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { EventEntity } from '../../event/infrastructure/persistence/relational/entities/event.entity';
+import { GroupEntity } from '../../group/infrastructure/persistence/relational/entities/group.entity';
+import { GroupMemberEntity } from '../../group-member/infrastructure/persistence/relational/entities/group-member.entity';
+import { SubCategoryEntity } from '../../sub-category/infrastructure/persistence/relational/entities/sub-category.entity';
+
+export class ProfileCounts {
+  @ApiProperty({ description: 'Number of public events organized by user' })
+  organizedEvents: number;
+
+  @ApiProperty({ description: 'Number of public events user is attending' })
+  attendingEvents: number;
+
+  @ApiProperty({ description: 'Number of public groups owned by user' })
+  ownedGroups: number;
+
+  @ApiProperty({ description: 'Number of public group memberships' })
+  groupMemberships: number;
+}
+
+export class ProfileSummaryDto {
+  @ApiProperty({ description: 'User ID' })
+  id: number;
+
+  @ApiProperty({ description: 'User slug' })
+  slug: string;
+
+  @ApiProperty({ description: 'User first name', required: false })
+  firstName?: string;
+
+  @ApiProperty({ description: 'User last name', required: false })
+  lastName?: string;
+
+  @ApiProperty({ description: 'User bio', required: false })
+  bio?: string;
+
+  @ApiProperty({ description: 'User photo', required: false })
+  photo?: { id: string; path: string };
+
+  @ApiProperty({ description: 'Auth provider' })
+  provider?: string;
+
+  @ApiProperty({ description: 'Social ID (e.g., Bluesky DID)', required: false })
+  socialId?: string;
+
+  @ApiProperty({ description: 'Whether this is a shadow account' })
+  isShadowAccount?: boolean;
+
+  @ApiProperty({ description: 'User preferences', required: false })
+  preferences?: Record<string, unknown>;
+
+  @ApiProperty({ type: ProfileCounts })
+  counts: ProfileCounts;
+
+  @ApiProperty({
+    type: [SubCategoryEntity],
+    description: 'User interests',
+  })
+  interests: SubCategoryEntity[];
+
+  @ApiProperty({
+    type: [EventEntity],
+    description: 'Recent organized events - limited preview',
+  })
+  organizedEvents: EventEntity[];
+
+  @ApiProperty({
+    type: [EventEntity],
+    description: 'Recent attending events - limited preview',
+  })
+  attendingEvents: EventEntity[];
+
+  @ApiProperty({
+    type: [GroupEntity],
+    description: 'Owned groups - limited preview',
+  })
+  ownedGroups: GroupEntity[];
+
+  @ApiProperty({
+    type: [GroupMemberEntity],
+    description: 'Group memberships - limited preview',
+  })
+  groupMemberships: GroupMemberEntity[];
+}

--- a/test/dashboard/dashboard-summary.e2e-spec.ts
+++ b/test/dashboard/dashboard-summary.e2e-spec.ts
@@ -1,0 +1,358 @@
+import request from 'supertest';
+import {
+  TESTING_APP_URL,
+  TESTING_TENANT_ID,
+  TESTING_USER_EMAIL,
+  TESTING_USER_PASSWORD,
+} from '../utils/constants';
+import {
+  loginAsTester,
+  createEvent,
+  createGroup,
+  getAuthToken,
+} from '../utils/functions';
+import {
+  EventStatus,
+  EventType,
+  GroupStatus,
+} from '../../src/core/constants/constant';
+
+// Set a global timeout for all tests in this file
+jest.setTimeout(120000);
+
+describe('Dashboard Summary Endpoints (e2e)', () => {
+  let token: string;
+  let createdEvents: any[] = [];
+  let createdGroups: any[] = [];
+
+  beforeAll(async () => {
+    token = await loginAsTester();
+  });
+
+  afterAll(async () => {
+    // Clean up created events
+    for (const event of createdEvents) {
+      try {
+        await request(TESTING_APP_URL)
+          .delete(`/api/events/${event.slug}`)
+          .set('Authorization', `Bearer ${token}`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+      } catch (e) {
+        console.warn(`Failed to delete event ${event.slug}:`, e);
+      }
+    }
+
+    // Clean up created groups
+    for (const group of createdGroups) {
+      try {
+        await request(TESTING_APP_URL)
+          .delete(`/api/groups/${group.slug}`)
+          .set('Authorization', `Bearer ${token}`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+      } catch (e) {
+        console.warn(`Failed to delete group ${group.slug}:`, e);
+      }
+    }
+  });
+
+  describe('GET /events/dashboard/summary', () => {
+    describe('when unauthenticated', () => {
+      it('should fail with 401', async () => {
+        const response = await request(TESTING_APP_URL)
+          .get('/api/events/dashboard/summary')
+          .set('x-tenant-id', TESTING_TENANT_ID);
+
+        expect(response.status).toBe(401);
+      });
+    });
+
+    describe('when authenticated', () => {
+      it('should return summary with counts and arrays', async () => {
+        const response = await request(TESTING_APP_URL)
+          .get('/api/events/dashboard/summary')
+          .set('Authorization', `Bearer ${token}`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+
+        expect(response.status).toBe(200);
+        expect(response.body).toBeDefined();
+
+        // Verify counts object exists with required fields
+        expect(response.body.counts).toBeDefined();
+        expect(typeof response.body.counts.hostingUpcoming).toBe('number');
+        expect(typeof response.body.counts.attendingUpcoming).toBe('number');
+        expect(typeof response.body.counts.past).toBe('number');
+
+        // Verify arrays exist
+        expect(Array.isArray(response.body.hostingThisWeek)).toBe(true);
+        expect(Array.isArray(response.body.hostingLater)).toBe(true);
+        expect(Array.isArray(response.body.attendingSoon)).toBe(true);
+      });
+
+      it('should return events user is hosting', async () => {
+        // Create a future event that the user hosts
+        const futureDate = new Date();
+        futureDate.setDate(futureDate.getDate() + 3); // 3 days from now (this week)
+
+        const event = await createEvent(TESTING_APP_URL, token, {
+          name: 'Dashboard Test Event - Hosting',
+          description: 'Event for testing dashboard summary',
+          type: EventType.InPerson,
+          status: EventStatus.Published,
+          startDate: futureDate.toISOString(),
+        });
+        createdEvents.push(event);
+
+        const response = await request(TESTING_APP_URL)
+          .get('/api/events/dashboard/summary')
+          .set('Authorization', `Bearer ${token}`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+
+        expect(response.status).toBe(200);
+
+        // The event should appear in hostingThisWeek or hostingLater
+        const allHosting = [
+          ...response.body.hostingThisWeek,
+          ...response.body.hostingLater,
+        ];
+        const hasCreatedEvent = allHosting.some((e) => e.id === event.id);
+        expect(hasCreatedEvent).toBe(true);
+
+        // Count should reflect the event
+        expect(response.body.counts.hostingUpcoming).toBeGreaterThanOrEqual(1);
+      });
+
+      it('should limit preview arrays to reasonable size', async () => {
+        const response = await request(TESTING_APP_URL)
+          .get('/api/events/dashboard/summary')
+          .set('Authorization', `Bearer ${token}`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+
+        expect(response.status).toBe(200);
+
+        // Preview arrays should be limited (typically 5-10 items max)
+        expect(response.body.hostingThisWeek.length).toBeLessThanOrEqual(10);
+        expect(response.body.hostingLater.length).toBeLessThanOrEqual(5);
+        expect(response.body.attendingSoon.length).toBeLessThanOrEqual(5);
+      });
+    });
+  });
+
+  describe('GET /groups/dashboard/summary', () => {
+    describe('when unauthenticated', () => {
+      it('should fail with 401', async () => {
+        const response = await request(TESTING_APP_URL)
+          .get('/api/groups/dashboard/summary')
+          .set('x-tenant-id', TESTING_TENANT_ID);
+
+        expect(response.status).toBe(401);
+      });
+    });
+
+    describe('when authenticated', () => {
+      it('should return summary with counts and arrays', async () => {
+        const response = await request(TESTING_APP_URL)
+          .get('/api/groups/dashboard/summary')
+          .set('Authorization', `Bearer ${token}`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+
+        expect(response.status).toBe(200);
+        expect(response.body).toBeDefined();
+
+        // Verify counts object exists with required fields
+        expect(response.body.counts).toBeDefined();
+        expect(typeof response.body.counts.leading).toBe('number');
+        expect(typeof response.body.counts.member).toBe('number');
+
+        // Verify arrays exist
+        expect(Array.isArray(response.body.leadingGroups)).toBe(true);
+        expect(Array.isArray(response.body.memberGroups)).toBe(true);
+      });
+
+      it('should return groups user is leading', async () => {
+        // Create a group that the user owns
+        const group = await createGroup(TESTING_APP_URL, token, {
+          name: 'Dashboard Test Group - Leading',
+          description: 'Group for testing dashboard summary',
+          status: GroupStatus.Published,
+          visibility: 'public',
+        });
+        createdGroups.push(group);
+
+        const response = await request(TESTING_APP_URL)
+          .get('/api/groups/dashboard/summary')
+          .set('Authorization', `Bearer ${token}`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+
+        expect(response.status).toBe(200);
+
+        // The group should appear in leadingGroups
+        const hasCreatedGroup = response.body.leadingGroups.some(
+          (g) => g.id === group.id,
+        );
+        expect(hasCreatedGroup).toBe(true);
+
+        // Count should reflect the group
+        expect(response.body.counts.leading).toBeGreaterThanOrEqual(1);
+      });
+
+      it('should limit preview arrays to reasonable size', async () => {
+        const response = await request(TESTING_APP_URL)
+          .get('/api/groups/dashboard/summary')
+          .set('Authorization', `Bearer ${token}`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+
+        expect(response.status).toBe(200);
+
+        // Preview arrays should be limited (typically 5-10 items max)
+        expect(response.body.leadingGroups.length).toBeLessThanOrEqual(10);
+        expect(response.body.memberGroups.length).toBeLessThanOrEqual(10);
+      });
+    });
+  });
+
+  describe('GET /users/:identifier/profile/summary', () => {
+    let userSlug: string;
+
+    beforeAll(async () => {
+      // Get current user's slug
+      const meResponse = await request(TESTING_APP_URL)
+        .get('/api/v1/auth/me')
+        .set('Authorization', `Bearer ${token}`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+
+      expect(meResponse.status).toBe(200);
+      userSlug = meResponse.body.slug;
+    });
+
+    describe('when accessing public profile', () => {
+      it('should return profile summary by slug', async () => {
+        const response = await request(TESTING_APP_URL)
+          .get(`/api/v1/users/${userSlug}/profile/summary`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+
+        expect(response.status).toBe(200);
+        expect(response.body).toBeDefined();
+
+        // Verify basic user info
+        expect(response.body.slug).toBe(userSlug);
+
+        // Verify counts object exists with required fields
+        expect(response.body.counts).toBeDefined();
+        expect(typeof response.body.counts.organizedEvents).toBe('number');
+        expect(typeof response.body.counts.attendingEvents).toBe('number');
+        expect(typeof response.body.counts.ownedGroups).toBe('number');
+        expect(typeof response.body.counts.groupMemberships).toBe('number');
+
+        // Verify preview arrays exist
+        expect(Array.isArray(response.body.organizedEvents)).toBe(true);
+        expect(Array.isArray(response.body.attendingEvents)).toBe(true);
+        expect(Array.isArray(response.body.ownedGroups)).toBe(true);
+        expect(Array.isArray(response.body.groupMemberships)).toBe(true);
+      });
+
+      it('should return empty response for non-existent user slug', async () => {
+        const response = await request(TESTING_APP_URL)
+          .get('/api/v1/users/non-existent-user-slug-12345/profile/summary')
+          .set('x-tenant-id', TESTING_TENANT_ID);
+
+        // Returns 200 with empty body when user not found
+        expect(response.status).toBe(200);
+        // Body should be empty or not have required profile fields
+        expect(response.body.slug).toBeUndefined();
+      });
+
+      it('should limit preview arrays to reasonable size', async () => {
+        const response = await request(TESTING_APP_URL)
+          .get(`/api/v1/users/${userSlug}/profile/summary`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+
+        expect(response.status).toBe(200);
+
+        // Preview arrays should be limited (typically 5 items max)
+        expect(response.body.organizedEvents.length).toBeLessThanOrEqual(5);
+        expect(response.body.attendingEvents.length).toBeLessThanOrEqual(5);
+        expect(response.body.ownedGroups.length).toBeLessThanOrEqual(5);
+        expect(response.body.groupMemberships.length).toBeLessThanOrEqual(5);
+      });
+    });
+
+    describe('identifier resolution', () => {
+      it('should work with user slug', async () => {
+        const response = await request(TESTING_APP_URL)
+          .get(`/api/v1/users/${userSlug}/profile/summary`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+
+        expect(response.status).toBe(200);
+        expect(response.body.slug).toBe(userSlug);
+      });
+
+      it('should return empty response for non-existent DID', async () => {
+        // Test with a properly formatted but non-existent DID
+        const response = await request(TESTING_APP_URL)
+          .get('/api/v1/users/did:plc:nonexistent123456789/profile/summary')
+          .set('x-tenant-id', TESTING_TENANT_ID);
+
+        // Returns 200 with empty body since DID doesn't exist
+        expect(response.status).toBe(200);
+        expect(response.body.slug).toBeUndefined();
+      });
+
+      it('should return empty response for non-existent handle', async () => {
+        // Test with a handle format that doesn't exist
+        const response = await request(TESTING_APP_URL)
+          .get(
+            '/api/v1/users/nonexistent.handle.bsky.social/profile/summary',
+          )
+          .set('x-tenant-id', TESTING_TENANT_ID);
+
+        // Returns 200 with empty body since handle doesn't resolve
+        expect(response.status).toBe(200);
+        expect(response.body.slug).toBeUndefined();
+      });
+    });
+
+    describe('profile data integrity', () => {
+      it('should include user events in counts', async () => {
+        // First create an event
+        const futureDate = new Date();
+        futureDate.setDate(futureDate.getDate() + 7);
+
+        const event = await createEvent(TESTING_APP_URL, token, {
+          name: 'Profile Summary Test Event',
+          description: 'Event for testing profile summary',
+          type: EventType.InPerson,
+          status: EventStatus.Published,
+          startDate: futureDate.toISOString(),
+        });
+        createdEvents.push(event);
+
+        // Then check the profile summary
+        const response = await request(TESTING_APP_URL)
+          .get(`/api/v1/users/${userSlug}/profile/summary`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+
+        expect(response.status).toBe(200);
+        expect(response.body.counts.organizedEvents).toBeGreaterThanOrEqual(1);
+      });
+
+      it('should include user groups in counts', async () => {
+        // First create a group
+        const group = await createGroup(TESTING_APP_URL, token, {
+          name: 'Profile Summary Test Group',
+          description: 'Group for testing profile summary',
+          status: GroupStatus.Published,
+          visibility: 'public',
+        });
+        createdGroups.push(group);
+
+        // Then check the profile summary
+        const response = await request(TESTING_APP_URL)
+          .get(`/api/v1/users/${userSlug}/profile/summary`)
+          .set('x-tenant-id', TESTING_TENANT_ID);
+
+        expect(response.status).toBe(200);
+        expect(response.body.counts.ownedGroups).toBeGreaterThanOrEqual(1);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add optimized dashboard summary endpoints that return counts + limited previews instead of full arrays
- Support multiple identifier types (slug, DID, ATProto handle) in profile lookup
- Deprecate legacy `/dashboard` endpoint that returned all events

## Changes
- **Events**: `GET /events/dashboard/summary` - hosting/attending counts + this week/later previews
- **Groups**: `GET /groups/dashboard/summary` - leading/member counts + preview items  
- **Profile**: `GET /users/:identifier/profile/summary` - activity counts + limited event/group previews

## Why
Power users with 1000+ events were experiencing slow loads. This implements the "What's Next" UX pattern with counts and limited previews for fast initial loads.

## Test plan
- [x] Verify `/events/dashboard/summary` returns correct counts and limited previews
- [x] Verify `/groups/dashboard/summary` returns correct counts and limited previews
- [x] Verify `/users/:slug/profile/summary` works with slugs
- [x] Verify `/users/did:plc:xxx/profile/summary` works with DIDs
- [x] Verify `/users/handle.bsky.social/profile/summary` works with handles

Closes #397