### PR TITLE
fix: return FileEntity for profile photo to enable URL transformation

### DIFF
--- a/src/user/dto/profile-summary.dto.ts
+++ b/src/user/dto/profile-summary.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { EventEntity } from '../../event/infrastructure/persistence/relational/entities/event.entity';
+import { FileEntity } from '../../file/infrastructure/persistence/relational/entities/file.entity';
 import { GroupEntity } from '../../group/infrastructure/persistence/relational/entities/group.entity';
 import { GroupMemberEntity } from '../../group-member/infrastructure/persistence/relational/entities/group-member.entity';
 import { SubCategoryEntity } from '../../sub-category/infrastructure/persistence/relational/entities/sub-category.entity';
@@ -34,8 +35,8 @@ export class ProfileSummaryDto {
   @ApiProperty({ description: 'User bio', required: false })
   bio?: string;
 
-  @ApiProperty({ description: 'User photo', required: false })
-  photo?: { id: string; path: string };
+  @ApiProperty({ description: 'User photo', required: false, type: FileEntity })
+  photo?: FileEntity | null;
 
   @ApiProperty({ description: 'Auth provider' })
   provider?: string;

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -520,9 +520,7 @@ export class UserService {
       firstName: user.firstName ?? undefined,
       lastName: user.lastName ?? undefined,
       bio: user.bio ?? undefined,
-      photo: user.photo
-        ? { id: String(user.photo.id), path: user.photo.path }
-        : undefined,
+      photo: user.photo,
       provider: user.provider ?? undefined,
       socialId: user.socialId ?? undefined,
       isShadowAccount: user.isShadowAccount,


### PR DESCRIPTION
## Summary
- Profile photos on user profile pages were showing broken images (displaying alt text instead)
- The profile summary endpoint was returning raw S3 paths instead of full CloudFront URLs
- Root cause: photo was manually extracted as `{ id, path }`, bypassing the `@Transform` decorator on `FileEntity.path`

## Fix
Return the full `FileEntity` for photo instead of manually constructing the object. This allows class-transformer to apply the URL transformation automatically.

## Test plan
- [x] CI tests pass
- [x] Verify profile summary endpoint returns full CloudFront URL for photo path
- [x] Verify profile page displays user avatar correctly

Closes OpenMeet-Team/openmeet-platform#308