### PR TITLE
feat: add sendNotifications parameter to event update endpoint

### DIFF
--- a/src/event-mail/services/event-announcement.service.spec.ts
+++ b/src/event-mail/services/event-announcement.service.spec.ts
@@ -439,6 +439,7 @@ describe('EventAnnouncementService', () => {
         slug: 'test-event',
         userId: 1,
         tenantId: 'test-tenant-123',
+        sendNotifications: true,
       });
 
       // Assert - emails should be sent to group members
@@ -528,6 +529,7 @@ describe('EventAnnouncementService', () => {
         slug: 'test-event',
         userId: 1,
         tenantId: 'test-tenant-123',
+        sendNotifications: true,
       });
 
       // Assert - Should send emails to event attendees (David, Emma) even without a group
@@ -544,6 +546,7 @@ describe('EventAnnouncementService', () => {
         slug: 'test-event',
         userId: 1,
         tenantId: 'test-tenant-123',
+        sendNotifications: true,
       });
 
       // Assert - Should send emails to event attendees (David, Emma) even if group has no members
@@ -561,6 +564,7 @@ describe('EventAnnouncementService', () => {
         slug: 'test-event',
         userId: 1,
         tenantId: 'test-tenant-123',
+        sendNotifications: true,
       });
 
       // Assert
@@ -587,6 +591,7 @@ describe('EventAnnouncementService', () => {
         slug: 'test-event',
         userId: 1,
         tenantId: 'test-tenant-123',
+        sendNotifications: true,
       });
 
       // Assert
@@ -612,6 +617,7 @@ describe('EventAnnouncementService', () => {
           slug: 'test-event',
           userId: 1,
           tenantId: 'test-tenant-123',
+          sendNotifications: true,
         }),
       ).resolves.not.toThrow();
 
@@ -628,6 +634,7 @@ describe('EventAnnouncementService', () => {
         slug: 'non-existent-event',
         userId: 1,
         tenantId: 'test-tenant-123',
+        sendNotifications: true,
       });
 
       // Assert
@@ -648,6 +655,7 @@ describe('EventAnnouncementService', () => {
         slug: 'test-event',
         userId: 1,
         tenantId: 'test-tenant-123',
+        sendNotifications: true,
       });
 
       // Assert - should send cancellation emails, not update emails
@@ -676,6 +684,48 @@ describe('EventAnnouncementService', () => {
         tenantConfig: expect.any(Object),
         icsContent: expect.any(String),
       });
+    });
+
+    it('should NOT send notification emails when sendNotifications is false', async () => {
+      // Act
+      await service.handleEventUpdated({
+        eventId: 1,
+        slug: 'test-event',
+        userId: 1,
+        tenantId: 'test-tenant-123',
+        sendNotifications: false,
+      });
+
+      // Assert - no emails should be sent
+      expect(mailerService.sendCalendarInviteMail).not.toHaveBeenCalled();
+    });
+
+    it('should send notification emails when sendNotifications is true', async () => {
+      // Act
+      await service.handleEventUpdated({
+        eventId: 1,
+        slug: 'test-event',
+        userId: 1,
+        tenantId: 'test-tenant-123',
+        sendNotifications: true,
+      });
+
+      // Assert - emails should be sent
+      expect(mailerService.sendCalendarInviteMail).toHaveBeenCalledTimes(5);
+    });
+
+    it('should NOT send notification emails when sendNotifications is undefined (default behavior)', async () => {
+      // Act
+      await service.handleEventUpdated({
+        eventId: 1,
+        slug: 'test-event',
+        userId: 1,
+        tenantId: 'test-tenant-123',
+        // sendNotifications omitted - should default to false
+      });
+
+      // Assert - no emails should be sent by default
+      expect(mailerService.sendCalendarInviteMail).not.toHaveBeenCalled();
     });
   });
 

--- a/src/event-mail/services/event-announcement.service.ts
+++ b/src/event-mail/services/event-announcement.service.ts
@@ -239,12 +239,22 @@ export class EventAnnouncementService {
     slug: string;
     userId: number;
     tenantId?: string;
+    sendNotifications?: boolean;
   }) {
     this.logger.log('Processing event update announcement', {
       eventId: params.eventId,
       slug: params.slug,
       tenantId: params.tenantId,
+      sendNotifications: params.sendNotifications,
     });
+
+    // Skip sending notifications if explicitly disabled (defaults to false)
+    if (params.sendNotifications !== true) {
+      this.logger.log(
+        `Skipping event update notifications for ${params.slug} (sendNotifications=${params.sendNotifications})`,
+      );
+      return;
+    }
 
     try {
       // Get the event with related data using slug (includes group and user relations)

--- a/src/event/dto/update-event.dto.ts
+++ b/src/event/dto/update-event.dto.ts
@@ -27,4 +27,14 @@ export class UpdateEventDto extends PartialType(CreateEventDto) {
   @IsOptional()
   @IsString()
   seriesSlug?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Whether to send notification emails to attendees about this update. Defaults to false to avoid notification fatigue for minor edits.',
+    example: false,
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  sendNotifications?: boolean;
 }

--- a/src/event/event.controller.spec.ts
+++ b/src/event/event.controller.spec.ts
@@ -285,6 +285,7 @@ describe('EventController', () => {
         mockEvent.slug,
         updateEventDto,
         mockUser.id,
+        undefined,
       );
     });
 

--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -205,6 +205,7 @@ export class EventController {
       slug,
       updateEventDto,
       userId,
+      updateEventDto.sendNotifications,
     );
 
     // Log what we're returning to help debug the test issue

--- a/src/event/services/event-management.service.ts
+++ b/src/event/services/event-management.service.ts
@@ -461,6 +461,7 @@ export class EventManagementService {
    * @param slug The slug of the event to update
    * @param updateEventDto The data to update the event with
    * @param userId The ID of the user performing the update
+   * @param sendNotifications Whether to send notification emails to attendees (defaults to false)
    * @param The userId parameter is deprecated and will be removed in a future version
    */
   @Trace('event-management.update')
@@ -468,6 +469,7 @@ export class EventManagementService {
     slug: string,
     updateEventDto: UpdateEventDto,
     userId?: number, // deprecated
+    sendNotifications?: boolean,
   ): Promise<EventEntity> {
     await this.initializeRepository();
 
@@ -885,6 +887,7 @@ export class EventManagementService {
       slug: updatedEvent.slug,
       userId: this.request.user?.id,
       tenantId: this.request.tenantId,
+      sendNotifications: sendNotifications ?? false, // Default to false
     });
 
     return updatedEvent;

--- a/test/event/calendar-invite.e2e-spec.ts
+++ b/test/event/calendar-invite.e2e-spec.ts
@@ -657,6 +657,7 @@ describe('Calendar Invite E2E', () => {
           startDate: newStartDate.toISOString(),
           endDate: new Date(newStartDate.getTime() + 7200000).toISOString(), // +2 hours
           location: 'Updated Venue, 456 New St',
+          sendNotifications: true, // Explicitly request notifications
         })
         .expect(200);
 


### PR DESCRIPTION
## Summary
- Add optional `sendNotifications` boolean parameter to `PATCH /events/:slug` endpoint
- Defaults to `false` to reduce notification fatigue for minor edits (typos, image changes)
- Only sends notification emails when explicitly set to `true`

## User Problem
Event organizers felt anxious about making minor edits because every change automatically notified all RSVPed attendees. Quote from user Kurt: "It makes me nervous to change anything if I know people are getting emailed."

## Changes
- `UpdateEventDto`: Added `sendNotifications?: boolean` field with Swagger documentation
- `EventController`: Passes parameter through to service
- `EventManagementService`: Includes `sendNotifications` in event emission (defaults to `false`)
- `EventAnnouncementService`: Checks flag before sending emails, skips if not explicitly `true`

## Test plan
- [x] Unit tests added for sendNotifications behavior (3 new tests)
- [x] All 25 event-announcement service tests pass
- [x] All 26 event controller tests pass
- [x] Manual test: Edit event without toggle → no emails sent
- [x] Manual test: Edit event with sendNotifications: true → emails sent

Closes #423
Related: OpenMeet-Team/openmeet-platform#318