### PR TITLE
feat: improve local developer setup with auto-migrations and test fixes

### DIFF
--- a/DEVELOPER-SETUP.md
+++ b/DEVELOPER-SETUP.md
@@ -1,0 +1,126 @@
+# Local Development Setup Guide
+
+This guide explains how to run the full OpenMeet stack locally using Docker Compose.
+
+## Quick Start
+
+```bash
+# 1. Copy the env file
+cp env-example-relational .env
+
+# 2. Install dependencies locally (required for tests and IDE support)
+npm install
+
+# 3. Start all services (migrations and seeds run automatically)
+docker compose -f docker-compose-dev.yml up -d
+
+# 4. Verify API is running (wait ~2 min for migrations to complete)
+curl http://localhost:3000/health/liveness
+# Expected: {"status":"ok","info":{"api":{"status":"up"}}}
+
+# 5. Run tests to verify setup
+npm run test                                       # Unit tests (~30s)
+npm run test:e2e -- --testPathPattern="auth.e2e"  # Auth e2e tests (~15s)
+```
+
+## Services Overview
+
+| Service | Port | Description |
+|---------|------|-------------|
+| api | [3000](http://localhost:3000/api/) and [api docs](http://localhost:3000/docs/)  | OpenMeet API (NestJS) |
+| postgres | 5432 | PostgreSQL with PostGIS |
+| redis | 6379 | Cache and session store |
+| rabbitmq | 5672, [15672](http://localhost:15672) | Message queue (mgmt UI) |
+| matrix | 8448 | Matrix Synapse homeserver |
+| matrix-auth-service | [8081](http://localhost:8081) | MAS (Matrix Authentication Service) |
+| maildev | 1025, [1080](http://localhost:1080) | Email testing (UI) |
+| pgadmin | [8080](http://localhost:8080) | Database admin UI |
+| tracing | [16686](http://localhost:16686) | Jaeger tracing UI |
+
+## Customizing Your Environment
+
+### Connecting to Dev/Prod Services
+
+To point at dev/prod Matrix, Bluesky, etc., edit `.env` and update:
+
+```bash
+# Point at dev Matrix instead of local
+MATRIX_HOMESERVER_URL=https://matrix.dev.openmeet.net
+MATRIX_SERVER_NAME=matrix.openmeet.net
+
+# Use dev MAS
+MAS_ISSUER=https://mas.dev.openmeet.net/
+MAS_PUBLIC_BASE=https://mas.dev.openmeet.net
+```
+
+### Enabling Bluesky Integration
+
+The Bluesky services (firehose-consumer, event-processor) need:
+
+```bash
+BSKY_API_KEY=your-api-key
+BSKY_TENANT_ID=your-tenant-id
+```
+
+### Using Real Email (SES)
+
+Replace the maildev config:
+
+```bash
+MAIL_HOST=email-smtp.us-east-1.amazonaws.com
+MAIL_PORT=465
+MAIL_USER=your-smtp-user
+MAIL_PASSWORD=your-smtp-password
+MAIL_SECURE=true
+```
+
+## Troubleshooting
+
+### Config Renderer Fails
+
+Check logs:
+```bash
+docker logs openmeet_config_renderer
+```
+
+Common issues:
+- Missing environment variable - add it to `.env`
+- Template syntax error - check `matrix-config/*.gomplate.yaml`
+
+### Matrix Services Won't Start
+
+Matrix depends on config-renderer completing successfully:
+```bash
+# Check if configs were generated
+docker exec openmeet_config_renderer ls /rendered-config/
+```
+
+### Database Connection Issues
+
+Ensure postgres is healthy:
+```bash
+docker compose -f docker-compose-dev.yml ps postgres
+```
+
+## Debugging Tools
+
+```bash
+# psql into local database
+docker exec -it openmeet_postgres psql -U root -d api
+
+# View logs
+docker compose -f docker-compose-dev.yml logs -f api
+
+# Check container status
+docker compose -f docker-compose-dev.yml ps
+```
+
+## Environment Variables Reference
+
+See `env-example-relational` for all available variables. Key sections:
+
+- **Database**: `DATABASE_*` - PostgreSQL connection
+- **Redis**: `ELASTICACHE_*` - Cache configuration
+- **Matrix**: `MATRIX_*`, `MAS_*`, `SYNAPSE_*` - Matrix/MAS configuration
+- **OAuth**: `OAUTH_*` - OAuth provider for MAS upstream auth
+- **Appservice**: `MATRIX_APPSERVICE_*` - Bot configuration

--- a/README.md
+++ b/README.md
@@ -104,39 +104,11 @@ The admin user is created during database seeding using:
 
 ### Local Setup
 
-**Option 1: Full Docker environment (recommended)**
-
-This starts PostgreSQL, Redis, Matrix, RabbitMQ, and the API with hot reload:
-```bash
-# Copy example config
-cp env-example-relational .env-local
-
-# Start all services
-docker compose -f docker-compose-dev.yml up --build
-
-# API available at http://localhost:3000
-# Swagger docs at http://localhost:3000/api/docs
-```
-
-**Option 2: API only (dependencies via Docker)**
-
-```bash
-# Start dependencies only
-docker compose -f docker-compose-dev.yml up -d postgres redis maildev
-
-# Copy example config (NestJS reads .env automatically)
-cp env-example-relational .env
-
-# Install dependencies
-npm install
-
-# Run migrations first, then seed data
-npm run migration:run:tenants
-npm run seed:run:prod
-
-# Start development server
-npm run start:dev
-```
+See **[DEVELOPER-SETUP.md](./DEVELOPER-SETUP.md)** for complete local development instructions including:
+- Quick start with Docker Compose
+- Services overview with ports
+- Debugging tools (psql, logs)
+- Troubleshooting guide
 
 ### Database Migrations
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -60,6 +60,28 @@ services:
     networks:
       - api-network
 
+  # Database migrations and seeds - runs before api starts
+  # Safe to run every time: migrations track state, seeds check before insert
+  migrate:
+    image: node:22.18.0-alpine
+    container_name: openmeet_migrate
+    working_dir: /app
+    command: sh -c "npm install && npm run migration:run && npm run migration:run:tenants && npm run seed:run:relational"
+    volumes:
+      - .:/app
+      - /app/node_modules
+    environment:
+      - NODE_ENV=development
+      - DATABASE_HOST=postgres
+    env_file:
+      - .env
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - api-network
+    restart: "no"
+
   # Config renderer - generates Matrix configs from templates for local development
   config-renderer:
     image: alpine:3.19
@@ -185,12 +207,12 @@ services:
       - MAIL_HOST=maildev
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://tracing:4318
     env_file:
-      - .env-local
+      - .env
     networks:
       - api-network
     depends_on:
-      postgres:
-        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
       redis:
         condition: service_started
     restart: unless-stopped
@@ -267,7 +289,8 @@ services:
     restart: unless-stopped
 
   # Bluesky Event Processor - consumes from RabbitMQ and calls OpenMeet API
-  # Required env vars in .env-local:
+  # Optional: requires bsky-firehose-consumer sibling repo
+  # Required env vars in .env:
   #   BSKY_API_KEY - service API key for OpenMeet API auth
   #   BSKY_TENANT_ID - tenant ID (e.g., lsdfaopkljdfs for local dev)
   bsky-event-processor:
@@ -293,7 +316,7 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://tracing:4318
       - OTEL_SERVICE_NAME=bsky-event-processor
     env_file:
-      - .env-local
+      - .env
     depends_on:
       rabbitmq:
         condition: service_healthy

--- a/env-example-relational
+++ b/env-example-relational
@@ -1,4 +1,5 @@
 NODE_ENV=development
+ENVIRONMENT=local
 APP_PORT=3000
 APP_NAME="NestJS API"
 API_PREFIX=api
@@ -7,7 +8,10 @@ APP_HEADER_LANGUAGE=x-custom-lang
 FRONTEND_DOMAIN=http://localhost:3000
 BACKEND_DOMAIN=http://localhost:3000
 
-TENANTS_B64=WwogIHsKICAgICJpZCI6ICIiLAogICAgIm5hbWUiOiAiUHVibGljIgogIH0sCiAgewogICAgImlkIjogIjEiLAogICAgIm5hbWUiOiAiT3Blbk1lZXQiCiAgfSwKICB7CiAgICAiaWQiOiAidGVzdGluZyIsCiAgICAibmFtZSI6ICJUZXN0aW5nIgogIH0KXQ==
+# TENANTS_B64 is base64 encoded JSON array of tenant configs
+# Each tenant needs: id, name, frontendDomain
+# Generate with: echo '[{...}]' | base64 -w0
+TENANTS_B64=W3siaWQiOiIiLCJuYW1lIjoiUHVibGljIiwiZnJvbnRlbmREb21haW4iOiJodHRwOi8vbG9jYWxob3N0OjkwMDUifSx7ImlkIjoiMSIsIm5hbWUiOiJPcGVuTWVldCIsImZyb250ZW5kRG9tYWluIjoiaHR0cDovL2xvY2FsaG9zdDo5MDA1In0seyJpZCI6InRlc3RpbmciLCJuYW1lIjoiVGVzdGluZyIsImZyb250ZW5kRG9tYWluIjoiaHR0cDovL2xvY2FsaG9zdDo5MDA1In1d
 
 # Test tenant, must exist in the TENANTS_B64 variable
 TEST_TENANT_ID=testing
@@ -21,7 +25,9 @@ TEST_USER_EMAIL=test@openmeet.net
 TEST_USER_PASSWORD=secret
 
 DATABASE_TYPE=postgres
-DATABASE_HOST=localhost
+# Use 'postgres' for Docker, 'localhost' for host-based development
+# TODO: This may cause issues when running migrations from host
+DATABASE_HOST=postgres
 DATABASE_PORT=5432
 DATABASE_USERNAME=root
 DATABASE_PASSWORD=secret
@@ -45,6 +51,7 @@ SECRET_ACCESS_KEY=None
 AWS_S3_REGION=None
 AWS_DEFAULT_S3_BUCKET=None
 
+# MAIL_HOST is for API inside Docker (container-to-container)
 MAIL_HOST=maildev
 MAIL_PORT=1025
 MAIL_USER=
@@ -55,6 +62,9 @@ MAIL_REQUIRE_TLS=false
 MAIL_DEFAULT_EMAIL=noreply@openmeet.net
 MAIL_DEFAULT_NAME=Api
 MAIL_CLIENT_PORT=1080
+MAIL_MODE=plain
+# TESTING_MAIL_HOST is for e2e tests running on host
+TESTING_MAIL_HOST=localhost
 
 AUTH_JWT_SECRET=secret
 AUTH_JWT_TOKEN_EXPIRES_IN=15m
@@ -64,6 +74,9 @@ AUTH_FORGOT_SECRET=secret_for_forgot
 AUTH_FORGOT_TOKEN_EXPIRES_IN=30m
 AUTH_CONFIRM_EMAIL_SECRET=secret_for_confirm_email
 AUTH_CONFIRM_EMAIL_TOKEN_EXPIRES_IN=1d
+
+# Service-to-service API keys (comma-separated) for external integrations (e.g., Bluesky processor)
+SERVICE_API_KEYS=local-dev-service-key-12345
 
 FACEBOOK_APP_ID=
 FACEBOOK_APP_SECRET=
@@ -121,10 +134,40 @@ SYNAPSE_MAX_UPLOAD_SIZE=50M
 SYNAPSE_URL_PREVIEW_ENABLED=false
 
 # MAS (Matrix Authentication Service) configuration
-MAS_ISSUER=http://api:3000
-MAS_CLIENT_SECRET=ci_test_mas_client_secret_for_synapse
-MAS_ADMIN_TOKEN=ci_test_matrix_admin_token
+# For local development with docker-compose-dev.yml
+MAS_ISSUER=http://matrix-auth-service:8080/
+MAS_CLIENT_SECRET=local-dev-mas-client-secret
+MAS_ADMIN_TOKEN=local-dev-mas-admin-token
+MAS_PUBLIC_BASE=http://localhost:8081
+MAS_DATABASE_HOST=postgres
+MAS_DATABASE_NAME=mas
+MAS_ENCRYPTION_SECRET=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+MAS_MATRIX_HOMESERVER_URL=http://matrix:8448
+MAS_SERVICE_NAME=OpenMeet Local Development
+MAS_INTROSPECTION_ENDPOINT=http://matrix-auth-service:8080/oauth2/introspect
+MAS_ACCOUNT_MANAGEMENT_URL=http://localhost:8081/account
 
 # MAS Token TTL configuration (in seconds)
 MAS_ACCESS_TOKEN_TTL=300
 MAS_COMPAT_TOKEN_TTL=300
+
+# Template variables for config-renderer (all are required by gomplate templates)
+WEB_CLIENT_LOCATION=http://localhost:9005
+PROMETHEUS_ENABLED=false
+POLICY_ADMIN_USERS=admin@openmeet.net
+
+# MAS mail config (falls back to MAIL_HOST/MAIL_PORT but gomplate needs vars to exist)
+MAS_MAIL_HOST=maildev
+MAS_MAIL_PORT=1025
+
+# OAuth provider configuration (MAS uses this to authenticate users via OpenMeet API)
+OAUTH_PROVIDER_NAME=OpenMeet Local Development
+OAUTH_ISSUER=http://api:3000/oidc
+OAUTH_CLIENT_ID=mas_client
+OAUTH_CLIENT_SECRET=local-dev-mas-client-secret
+
+# Matrix Appservice configuration (for OpenMeet bot to interact with Matrix)
+MATRIX_APPSERVICE_ID=openmeet-bot-local
+MATRIX_APPSERVICE_URL=http://api:3000/api/matrix/appservice
+MATRIX_APPSERVICE_TOKEN=local-dev-appservice-token-971a507cac6945e1259b7d7377b7c497
+MATRIX_APPSERVICE_HS_TOKEN=local-dev-hs-token-df51b086825667040f89888d920641c44d

--- a/env-example-relational-ci
+++ b/env-example-relational-ci
@@ -56,6 +56,8 @@ MAIL_REQUIRE_TLS=false
 MAIL_DEFAULT_EMAIL=noreply@openmeet.net
 MAIL_DEFAULT_NAME=Api
 MAIL_CLIENT_PORT=1080
+# In CI, tests run inside Docker so use container name
+TESTING_MAIL_HOST=maildev
 
 AUTH_JWT_SECRET=secret
 AUTH_JWT_TOKEN_EXPIRES_IN=15m

--- a/src/database/migrations/1748529522591-AddContactPermissions.ts
+++ b/src/database/migrations/1748529522591-AddContactPermissions.ts
@@ -8,14 +8,19 @@ export class AddContactPermissions1748529522591 implements MigrationInterface {
 
     // Add new enum values to the groupPermissions_name_enum
     await queryRunner.query(`
-      ALTER TYPE "${schema}"."groupPermissions_name_enum" 
+      ALTER TYPE "${schema}"."groupPermissions_name_enum"
       ADD VALUE IF NOT EXISTS 'CONTACT_MEMBERS'
     `);
 
     await queryRunner.query(`
-      ALTER TYPE "${schema}"."groupPermissions_name_enum" 
+      ALTER TYPE "${schema}"."groupPermissions_name_enum"
       ADD VALUE IF NOT EXISTS 'CONTACT_ADMINS'
     `);
+
+    // Commit enum changes so they can be used by subsequent migrations
+    // PostgreSQL requires enum values to be committed before use
+    await queryRunner.commitTransaction();
+    await queryRunner.startTransaction();
   }
 
   public down(_queryRunner: QueryRunner): Promise<void> {

--- a/test/utils/constants.ts
+++ b/test/utils/constants.ts
@@ -9,7 +9,7 @@ export const TESTING_APP_URL =
   process.env.BACKEND_DOMAIN || `http://localhost:${process.env.APP_PORT}`;
 export const TESTING_FRONTEND_DOMAIN =
   process.env.FRONTEND_DOMAIN || 'http://localhost:8080';
-export const TESTING_MAIL_HOST = process.env.MAIL_HOST;
+export const TESTING_MAIL_HOST = process.env.TESTING_MAIL_HOST;
 export const TESTING_MAIL_PORT = process.env.MAIL_CLIENT_PORT;
 export const TESTING_MAS_URL =
   process.env.MAS_SERVICE_URL || 'http://localhost:8080';


### PR DESCRIPTION
## Summary
- Add auto-migration service to docker-compose that runs before API starts
- Add DEVELOPER-SETUP.md quick start guide with debugging tools (psql, logs)
- Fix test configuration issues that prevented e2e tests from passing locally

## Changes
- **docker-compose-dev.yml**: Added `migrate` service, API now depends on migrations completing
- **env-example-relational**: Added `frontendDomain` to TENANTS_B64, `TESTING_MAIL_HOST`, `SERVICE_API_KEYS`
- **test/utils/constants.ts**: Use dedicated `TESTING_MAIL_HOST` env var (tests run on host, not in Docker)
- **Migration fix**: Commit enum changes before subsequent migrations can use them
- **DEVELOPER-SETUP.md**: New quick start guide with services overview and debugging commands

## Test plan
- [x] Unit tests pass (1083 tests)
- [x] Auth e2e tests pass (63 tests)
- [x] Shadow-account e2e tests pass (10 tests)
- [x] Event/group e2e tests pass
- [x] Fresh clone: `cp env-example-relational .env && npm install && docker compose -f docker-compose-dev.yml up -d`
- [x] Verify tests pass on fresh setup