### PR TITLE
fix(auth): resolve Bluesky handle dynamically in /auth/me endpoint

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -586,7 +586,16 @@ export class AuthService {
 
   async me(userJwtPayload: JwtPayloadType): Promise<NullableType<User>> {
     try {
-      return await this.userService.findById(userJwtPayload.id);
+      const user = await this.userService.findById(userJwtPayload.id);
+
+      // Resolve Bluesky handle dynamically if user exists
+      // This ensures /auth/me returns current handle, not stale database value
+      // See commit c3e042f for design rationale on dynamic handle resolution
+      if (user) {
+        await this.userService.resolveBlueskyHandle(user);
+      }
+
+      return user;
     } catch (error) {
       this.logger.error('Error in me() method:', {
         userId: userJwtPayload.id,


### PR DESCRIPTION
## Summary
- Fixes OpenMeet-Team/openmeet-platform#338: ATProto handle not updating on account settings page

When a Bluesky user changes their handle (e.g., from `openmeet.bsky.social` to `openmeet.net`), the `/auth/me` endpoint was returning the stale database value instead of the current resolved handle.

## Root Cause
The `me()` method in `auth.service.ts` called `userService.findById()` but didn't call `resolveBlueskyHandle()` like other profile endpoints do (`findBySlug()`, `getSummaryBySlug()`).

## Changes
- Added `resolveBlueskyHandle()` call in `me()` method after fetching the user
- Added 4 unit tests for handle resolution in `/auth/me`

## Test Plan
- [x] All 1164 unit tests pass
- [x] New tests verify:
  - `resolveBlueskyHandle` is called for Bluesky users
  - Returned user has resolved handle in preferences
  - Non-Bluesky users handled gracefully
  - Null users don't trigger resolution
- [x] Manual: Log in as Bluesky user with changed handle, verify account settings shows current handle