### PR TITLE
feat(group): allow group admins to change group slug

### DIFF
--- a/src/core/constants/constant.ts
+++ b/src/core/constants/constant.ts
@@ -147,6 +147,13 @@ export enum PostgisSrid {
 
 export const DEFAULT_RADIUS = 200; // default radius in Miles for location searching
 
+// Slug validation constants
+// Slug must be 3-100 characters, start and end with alphanumeric, can contain hyphens
+// Note: Accepts both lower and uppercase - will be normalized to lowercase by the service
+export const SLUG_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9-]{1,98}[a-zA-Z0-9]$/;
+export const SLUG_VALIDATION_MESSAGE =
+  'Slug must be 3-100 characters, alphanumeric with hyphens, and cannot start or end with a hyphen';
+
 export interface TenantConfig {
   id: string; // tenant id, ex: asdf2jkl
   name: string; // tenant name, ex: Openmeet

--- a/src/group/dto/update-group.dto.ts
+++ b/src/group/dto/update-group.dto.ts
@@ -1,4 +1,22 @@
 import { PartialType } from '@nestjs/swagger';
 import { CreateGroupDto } from './create-group.dto';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, Matches } from 'class-validator';
+import {
+  SLUG_REGEX,
+  SLUG_VALIDATION_MESSAGE,
+} from '../../core/constants/constant';
 
-export class UpdateGroupDto extends PartialType(CreateGroupDto) {}
+export class UpdateGroupDto extends PartialType(CreateGroupDto) {
+  @ApiPropertyOptional({
+    description:
+      'The URL slug for the group. Must be 3-100 characters, lowercase alphanumeric with hyphens, cannot start or end with hyphen.',
+    example: 'my-awesome-group',
+  })
+  @IsOptional()
+  @IsString()
+  @Matches(SLUG_REGEX, {
+    message: SLUG_VALIDATION_MESSAGE,
+  })
+  slug?: string;
+}

--- a/src/matrix/types/matrix.interfaces.ts
+++ b/src/matrix/types/matrix.interfaces.ts
@@ -37,6 +37,10 @@ export interface IMatrixClient {
   getRoomIdForAlias: (
     roomAlias: string,
   ) => Promise<{ room_id: string; servers?: string[] }>;
+  createAlias: (
+    alias: string,
+    roomId: string,
+  ) => Promise<Record<string, never>>;
 
   // State and profile operations
   getStateEvent: (

--- a/src/matrix/utils/room-alias.utils.ts
+++ b/src/matrix/utils/room-alias.utils.ts
@@ -170,4 +170,23 @@ export class RoomAliasUtils {
       .replace(/--+/g, '-') // Replace multiple hyphens with single hyphen
       .replace(/^-+|-+$/g, ''); // Remove leading/trailing hyphens
   }
+
+  /**
+   * Build a Matrix room alias for either an event or group
+   * This is a convenience method that delegates to the appropriate generator
+   * @param entityType 'event' or 'group'
+   * @param slug The entity's slug
+   * @param tenantId The tenant ID
+   * @returns Full room alias (e.g., "#group-my-slug-tenant:matrix.openmeet.net")
+   */
+  buildRoomAlias(
+    entityType: 'event' | 'group',
+    slug: string,
+    tenantId: string,
+  ): string {
+    if (entityType === 'event') {
+      return this.generateEventRoomAlias(slug, tenantId);
+    }
+    return this.generateGroupRoomAlias(slug, tenantId);
+  }
 }

--- a/test/group/group-slug-change.e2e-spec.ts
+++ b/test/group/group-slug-change.e2e-spec.ts
@@ -1,0 +1,401 @@
+import * as request from 'supertest';
+import { TESTING_APP_URL, TESTING_TENANT_ID } from '../utils/constants';
+import {
+  loginAsTester,
+  createGroup,
+  updateGroup,
+  getGroupDetails,
+  waitForEventProcessing,
+} from '../utils/functions';
+
+describe('Group Slug Change (e2e)', () => {
+  const testTenantId = TESTING_TENANT_ID;
+  let serverApp: any;
+  let ownerToken: string;
+  let testGroup: any;
+  const createdGroups: string[] = [];
+
+  beforeAll(async () => {
+    serverApp = request.agent(TESTING_APP_URL).set('x-tenant-id', testTenantId);
+    ownerToken = await loginAsTester();
+  }, 30000);
+
+  afterAll(async () => {
+    for (const slug of createdGroups) {
+      try {
+        await serverApp
+          .delete(`/api/groups/${slug}`)
+          .set('Authorization', `Bearer ${ownerToken}`)
+          .timeout(10000);
+      } catch (error) {
+        console.log(`Group cleanup failed for ${slug}:`, error.message);
+      }
+    }
+  }, 30000);
+
+  describe('valid slug changes', () => {
+    it('should successfully change group slug when new slug is valid and unique', async () => {
+      const timestamp = Date.now();
+      testGroup = await createGroup(TESTING_APP_URL, ownerToken, {
+        name: 'Slug Change Test Group',
+        description: 'Testing slug change functionality',
+        visibility: 'public',
+        status: 'published',
+      });
+      createdGroups.push(testGroup.slug);
+
+      const originalSlug = testGroup.slug;
+      const newSlug = `new-test-slug-${timestamp}`;
+
+      const updateResponse = await updateGroup(
+        TESTING_APP_URL,
+        ownerToken,
+        originalSlug,
+        { slug: newSlug },
+      );
+
+      expect(updateResponse.status).toBe(200);
+      expect(updateResponse.body.slug).toBe(newSlug);
+
+      // Update tracking for cleanup
+      const idx = createdGroups.indexOf(originalSlug);
+      if (idx > -1) createdGroups[idx] = newSlug;
+
+      // Verify new slug works
+      const newGroup = await getGroupDetails(ownerToken, newSlug);
+      expect(newGroup.name).toBe('Slug Change Test Group');
+
+      // Verify old slug returns 404
+      const oldSlugResponse = await serverApp
+        .get(`/api/groups/${originalSlug}`)
+        .set('Authorization', `Bearer ${ownerToken}`);
+      expect(oldSlugResponse.status).toBe(404);
+    }, 15000);
+
+    it('should normalize slug to lowercase', async () => {
+      const timestamp = Date.now();
+      testGroup = await createGroup(TESTING_APP_URL, ownerToken, {
+        name: 'Case Test Group',
+        description: 'Testing slug case normalization',
+        visibility: 'public',
+        status: 'published',
+      });
+      createdGroups.push(testGroup.slug);
+
+      const mixedCaseSlug = `Mixed-Case-${timestamp}`;
+      const expectedSlug = mixedCaseSlug.toLowerCase();
+
+      const updateResponse = await updateGroup(
+        TESTING_APP_URL,
+        ownerToken,
+        testGroup.slug,
+        { slug: mixedCaseSlug },
+      );
+
+      expect(updateResponse.status).toBe(200);
+      expect(updateResponse.body.slug).toBe(expectedSlug);
+
+      // Update tracking for cleanup
+      const idx = createdGroups.indexOf(testGroup.slug);
+      if (idx > -1) createdGroups[idx] = expectedSlug;
+    }, 15000);
+
+    it('should allow updating to same slug (no-op)', async () => {
+      testGroup = await createGroup(TESTING_APP_URL, ownerToken, {
+        name: 'Same Slug Test',
+        description: 'Testing same slug update',
+        visibility: 'public',
+        status: 'published',
+      });
+      createdGroups.push(testGroup.slug);
+
+      const updateResponse = await updateGroup(
+        TESTING_APP_URL,
+        ownerToken,
+        testGroup.slug,
+        { slug: testGroup.slug },
+      );
+
+      expect(updateResponse.status).toBe(200);
+      expect(updateResponse.body.slug).toBe(testGroup.slug);
+    }, 15000);
+
+    it('should allow slug change along with other field updates', async () => {
+      const timestamp = Date.now();
+      testGroup = await createGroup(TESTING_APP_URL, ownerToken, {
+        name: 'Multi-field Test',
+        description: 'Original description',
+        visibility: 'public',
+        status: 'published',
+      });
+      createdGroups.push(testGroup.slug);
+
+      const newSlug = `multi-update-${timestamp}`;
+
+      const updateResponse = await updateGroup(
+        TESTING_APP_URL,
+        ownerToken,
+        testGroup.slug,
+        {
+          slug: newSlug,
+          name: 'Updated Name',
+          description: 'Updated description',
+        },
+      );
+
+      expect(updateResponse.status).toBe(200);
+      expect(updateResponse.body.slug).toBe(newSlug);
+      expect(updateResponse.body.name).toBe('Updated Name');
+      expect(updateResponse.body.description).toBe('Updated description');
+
+      // Update tracking for cleanup
+      const idx = createdGroups.indexOf(testGroup.slug);
+      if (idx > -1) createdGroups[idx] = newSlug;
+    }, 15000);
+  });
+
+  describe('invalid slug changes', () => {
+    it('should reject slug that is too short (less than 3 characters)', async () => {
+      testGroup = await createGroup(TESTING_APP_URL, ownerToken, {
+        name: 'Short Slug Test',
+        description: 'Testing short slug rejection',
+        visibility: 'public',
+        status: 'published',
+      });
+      createdGroups.push(testGroup.slug);
+
+      const updateResponse = await updateGroup(
+        TESTING_APP_URL,
+        ownerToken,
+        testGroup.slug,
+        { slug: 'ab' },
+      );
+
+      expect(updateResponse.status).toBe(422);
+    }, 15000);
+
+    it('should reject slug with invalid characters', async () => {
+      testGroup = await createGroup(TESTING_APP_URL, ownerToken, {
+        name: 'Invalid Chars Test',
+        description: 'Testing invalid character rejection',
+        visibility: 'public',
+        status: 'published',
+      });
+      createdGroups.push(testGroup.slug);
+
+      const updateResponse = await updateGroup(
+        TESTING_APP_URL,
+        ownerToken,
+        testGroup.slug,
+        { slug: 'invalid_slug!@#' },
+      );
+
+      expect(updateResponse.status).toBe(422);
+    }, 15000);
+
+    it('should reject slug starting with hyphen', async () => {
+      testGroup = await createGroup(TESTING_APP_URL, ownerToken, {
+        name: 'Leading Hyphen Test',
+        description: 'Testing leading hyphen rejection',
+        visibility: 'public',
+        status: 'published',
+      });
+      createdGroups.push(testGroup.slug);
+
+      const updateResponse = await updateGroup(
+        TESTING_APP_URL,
+        ownerToken,
+        testGroup.slug,
+        { slug: '-invalid-start' },
+      );
+
+      expect(updateResponse.status).toBe(422);
+    }, 15000);
+
+    it('should reject slug ending with hyphen', async () => {
+      testGroup = await createGroup(TESTING_APP_URL, ownerToken, {
+        name: 'Trailing Hyphen Test',
+        description: 'Testing trailing hyphen rejection',
+        visibility: 'public',
+        status: 'published',
+      });
+      createdGroups.push(testGroup.slug);
+
+      const updateResponse = await updateGroup(
+        TESTING_APP_URL,
+        ownerToken,
+        testGroup.slug,
+        { slug: 'invalid-end-' },
+      );
+
+      expect(updateResponse.status).toBe(422);
+    }, 15000);
+  });
+
+  describe('slug uniqueness', () => {
+    it('should reject slug that is already in use by another group', async () => {
+      const firstGroup = await createGroup(TESTING_APP_URL, ownerToken, {
+        name: 'First Group',
+        description: 'First group for uniqueness test',
+        visibility: 'public',
+        status: 'published',
+      });
+      createdGroups.push(firstGroup.slug);
+
+      const secondGroup = await createGroup(TESTING_APP_URL, ownerToken, {
+        name: 'Second Group',
+        description: 'Second group for uniqueness test',
+        visibility: 'public',
+        status: 'published',
+      });
+      createdGroups.push(secondGroup.slug);
+
+      // Try to change first group's slug to second group's slug
+      const updateResponse = await updateGroup(
+        TESTING_APP_URL,
+        ownerToken,
+        firstGroup.slug,
+        { slug: secondGroup.slug },
+      );
+
+      expect(updateResponse.status).toBe(409);
+    }, 15000);
+  });
+
+  describe('Matrix room alias updates', () => {
+    const HOMESERVER_TOKEN = process.env.MATRIX_APPSERVICE_HS_TOKEN;
+
+    // Skip Matrix tests if token not available
+    const describeIfMatrixAvailable = HOMESERVER_TOKEN
+      ? describe
+      : describe.skip;
+
+    describeIfMatrixAvailable('when group has a Matrix chat room', () => {
+      it('should allow chat room access via new alias after slug change', async () => {
+        const timestamp = Date.now();
+
+        // 1. Create a group (this triggers Matrix room creation via group.created event)
+        const testGroup = await createGroup(TESTING_APP_URL, ownerToken, {
+          name: 'Matrix Alias Test Group',
+          description: 'Testing Matrix alias update on slug change',
+          visibility: 'public',
+          status: 'published',
+        });
+        createdGroups.push(testGroup.slug);
+        const originalSlug = testGroup.slug;
+
+        // 2. Trigger room creation by querying the AppService for the room alias
+        const originalRoomAlias = `#group-${originalSlug}-${testTenantId}:matrix.openmeet.net`;
+        const roomCreateResponse = await serverApp
+          .get(
+            `/api/matrix/appservice/rooms/${encodeURIComponent(originalRoomAlias)}`,
+          )
+          .set('Authorization', `Bearer ${HOMESERVER_TOKEN}`);
+
+        // Verify room was created successfully (empty object = success per Matrix spec)
+        expect(roomCreateResponse.status).toBe(200);
+        expect(roomCreateResponse.body).toEqual({});
+
+        // 3. Wait for event processing to complete
+        await waitForEventProcessing(1000);
+
+        // 4. Change the group slug
+        const newSlug = `matrix-alias-updated-${timestamp}`;
+        const updateResponse = await updateGroup(
+          TESTING_APP_URL,
+          ownerToken,
+          originalSlug,
+          { slug: newSlug },
+        );
+
+        expect(updateResponse.status).toBe(200);
+        expect(updateResponse.body.slug).toBe(newSlug);
+
+        // Update cleanup tracking
+        const idx = createdGroups.indexOf(originalSlug);
+        if (idx > -1) createdGroups[idx] = newSlug;
+
+        // 5. Wait for Matrix alias update to propagate
+        await waitForEventProcessing(2000);
+
+        // 6. Verify the new alias resolves to the same room
+        const newRoomAlias = `#group-${newSlug}-${testTenantId}:matrix.openmeet.net`;
+        const newAliasResponse = await serverApp
+          .get(
+            `/api/matrix/appservice/rooms/${encodeURIComponent(newRoomAlias)}`,
+          )
+          .set('Authorization', `Bearer ${HOMESERVER_TOKEN}`);
+
+        // Room should be accessible via new alias (empty object = success)
+        expect(newAliasResponse.status).toBe(200);
+        expect(newAliasResponse.body).toEqual({});
+      }, 30000);
+
+      it('should update canonical alias and record old alias in alt_aliases', async () => {
+        const timestamp = Date.now();
+
+        // 1. Create a group
+        const testGroup = await createGroup(TESTING_APP_URL, ownerToken, {
+          name: 'Matrix Alias Update Test',
+          description: 'Testing canonical alias update with alt_aliases',
+          visibility: 'public',
+          status: 'published',
+        });
+        createdGroups.push(testGroup.slug);
+        const originalSlug = testGroup.slug;
+
+        // 2. Trigger room creation
+        const originalRoomAlias = `#group-${originalSlug}-${testTenantId}:matrix.openmeet.net`;
+        const createResponse = await serverApp
+          .get(
+            `/api/matrix/appservice/rooms/${encodeURIComponent(originalRoomAlias)}`,
+          )
+          .set('Authorization', `Bearer ${HOMESERVER_TOKEN}`);
+        expect(createResponse.status).toBe(200);
+
+        await waitForEventProcessing(1000);
+
+        // 3. Change the slug
+        const newSlug = `alias-update-test-${timestamp}`;
+        const updateResponse = await updateGroup(
+          TESTING_APP_URL,
+          ownerToken,
+          originalSlug,
+          { slug: newSlug },
+        );
+        expect(updateResponse.status).toBe(200);
+
+        // Update cleanup tracking
+        const idx = createdGroups.indexOf(originalSlug);
+        if (idx > -1) createdGroups[idx] = newSlug;
+
+        await waitForEventProcessing(2000);
+
+        // 4. Verify new alias works via AppService
+        const newRoomAlias = `#group-${newSlug}-${testTenantId}:matrix.openmeet.net`;
+        const newAliasResponse = await serverApp
+          .get(
+            `/api/matrix/appservice/rooms/${encodeURIComponent(newRoomAlias)}`,
+          )
+          .set('Authorization', `Bearer ${HOMESERVER_TOKEN}`);
+        expect(newAliasResponse.status).toBe(200);
+        expect(newAliasResponse.body).toEqual({});
+
+        // 5. The old alias won't work via AppService (entity with old slug no longer exists)
+        // but the Matrix room's canonical_alias state should have it in alt_aliases
+        // This test verifies the AppService behavior is correct (returns "Room not found"
+        // for aliases where the entity slug doesn't exist)
+        const oldAliasResponse = await serverApp
+          .get(
+            `/api/matrix/appservice/rooms/${encodeURIComponent(originalRoomAlias)}`,
+          )
+          .set('Authorization', `Bearer ${HOMESERVER_TOKEN}`);
+
+        // AppService returns "Room not found" because entity with old slug doesn't exist
+        // The actual Matrix alias still exists and would resolve via Matrix federation
+        expect(oldAliasResponse.status).toBe(200);
+        expect(oldAliasResponse.body).toEqual({ error: 'Room not found' });
+      }, 30000);
+    });
+  });
+});

--- a/test/utils/functions.ts
+++ b/test/utils/functions.ts
@@ -493,6 +493,21 @@ async function getGroupDetails(token: string, groupSlug: string) {
   return response.body;
 }
 
+async function updateGroup(
+  app: string,
+  authToken: string,
+  groupSlug: string,
+  groupData: any,
+): Promise<any> {
+  const response = await request(app)
+    .patch(`/api/groups/${groupSlug}`)
+    .set('x-tenant-id', TESTING_TENANT_ID)
+    .set('Authorization', `Bearer ${authToken}`)
+    .send(groupData);
+
+  return response;
+}
+
 async function getCurrentUserDetails(token: string) {
   const response = await request(TESTING_APP_URL)
     .get('/api/v1/auth/me')
@@ -570,6 +585,7 @@ async function createFile(
 export {
   getAuthToken,
   createGroup,
+  updateGroup,
   createEvent,
   deleteGroup,
   deleteEvent,


### PR DESCRIPTION
## Summary
- Allow group admins to change the group's URL slug
- Add client-side and server-side validation (3-100 chars, lowercase alphanumeric with hyphens)
- Update Matrix room alias when slug changes (keeps old alias as fallback)
- Clean break approach - old URLs will 404 (redirect support can be added later)

## Changes
- Add slug field to `UpdateGroupDto` with validation
- Add slug change logic to `GroupService.update()` with uniqueness check
- Add `updateRoomAliasForSlugChange()` to `MatrixRoomService`
- Emit `group.slug.changed` event handled by `MatrixEventListener`
- Add shared `SLUG_REGEX` and `SLUG_VALIDATION_MESSAGE` constants

## Test Plan
- [x] 11 e2e tests for slug change scenarios (format validation, uniqueness, Matrix alias)
- [x] Manual test: Change group slug in dev, verify old URL 404s, new URL works
- [ ] Manual test: Verify Matrix chat still accessible after slug change

## Related
- Closes OpenMeet-Team/openmeet-platform#182
- Frontend PR: OpenMeet-Team/openmeet-platform (pending)