### PR TITLE
fix(meta): use event timezone for OG meta tag date formatting

### DIFF
--- a/src/meta/meta.controller.ts
+++ b/src/meta/meta.controller.ts
@@ -91,15 +91,18 @@ export class MetaController {
 
   /**
    * Format event date/time for og:description
-   * Returns format like "Sat, Jan 4 at 7:00 PM"
+   * Returns format like "Sat, Jan 4 at 7:00 PM EST"
+   * Uses the event's timezone if provided, otherwise defaults to UTC
    */
-  private formatEventDateTime(startDate: Date): string {
+  private formatEventDateTime(startDate: Date, timeZone?: string): string {
     const dateFormatter = new Intl.DateTimeFormat('en-US', {
       weekday: 'short',
       month: 'short',
       day: 'numeric',
       hour: 'numeric',
       minute: '2-digit',
+      timeZone: timeZone || 'UTC',
+      timeZoneName: 'short',
     });
     return dateFormatter.format(startDate);
   }
@@ -110,9 +113,11 @@ export class MetaController {
   private buildEventDescription(data: any): string {
     const parts: string[] = [];
 
-    // Add formatted date/time if available
+    // Add formatted date/time if available, using event's timezone
     if (data.startDate) {
-      parts.push(this.formatEventDateTime(new Date(data.startDate)));
+      parts.push(
+        this.formatEventDateTime(new Date(data.startDate), data.timeZone),
+      );
     }
 
     // Add location if available
@@ -253,7 +258,7 @@ export class MetaController {
         const startDate = new Date(data.startDate).toISOString();
         additionalMeta += `<meta property="event:start_time" content="${startDate}" />\n`;
 
-        // Format readable date/time for body
+        // Format readable date/time for body using event's timezone
         const dateFormatter = new Intl.DateTimeFormat('en-US', {
           weekday: 'long',
           year: 'numeric',
@@ -261,6 +266,7 @@ export class MetaController {
           day: 'numeric',
           hour: 'numeric',
           minute: '2-digit',
+          timeZone: data.timeZone || 'UTC',
           timeZoneName: 'short',
         });
         const formattedStart = dateFormatter.format(new Date(data.startDate));


### PR DESCRIPTION
## Summary
- Event times in Open Graph meta tags (link previews) were displayed in UTC instead of the event's timezone
- An event created for 6:00 PM EST was showing as 11:00 PM in Bluesky/social media link previews

## Changes
- Updated `formatEventDateTime()` to accept a `timeZone` parameter
- Pass `event.timeZone` to formatters in both `buildEventDescription()` and `renderMetaHTML()`
- Default to UTC when no timezone is provided
- Added `timeZoneName: 'short'` to show timezone abbreviation (EST, PST, etc.)

## Test plan
- [x] Added 3 unit tests for timezone formatting:
  - Event with America/New_York timezone shows EST time
  - Event with America/Los_Angeles timezone shows PST time  
  - Events without timezone default to UTC gracefully
- [x] All 45 tests passing