### PR TITLE
fix(sitemap): remove durable flag from GroupService to fix tenant context

### DIFF
--- a/src/group/group.service.ts
+++ b/src/group/group.service.ts
@@ -55,7 +55,7 @@ import { EventRecommendationService } from '../event/services/event-recommendati
 // import { forwardRef } from '@nestjs/common'; // Currently not used
 // ChatRoomService removed - Matrix Application Service handles room operations directly
 
-@Injectable({ scope: Scope.REQUEST, durable: true })
+@Injectable({ scope: Scope.REQUEST })
 export class GroupService {
   private readonly auditLogger = AuditLoggerService.getInstance();
   private readonly logger = new Logger(GroupService.name);


### PR DESCRIPTION
## Summary

Sitemap at `platform.openmeet.net/sitemap.xml` was returning 6 URLs instead of 12+ because groups were missing. The `durable: true` flag on GroupService caused stale tenant context when accessed via Host header lookup.

## Test plan

- [x] Local: Host header lookup returns groups
- [x] Local: x-tenant-id header still works  
- [x] Unit tests pass

## Post-merge verification

- [ ] `curl https://platform-dev.openmeet.net/sitemap.xml` returns groups