### PR TITLE
fix(bluesky): correct ATProto location schema for event creation

### DIFF
--- a/src/bluesky/BlueskyTypes.ts
+++ b/src/bluesky/BlueskyTypes.ts
@@ -1,11 +1,20 @@
-export interface BlueskyLocation {
-  type: string;
-  lat?: number;
-  lon?: number;
-  description?: string;
-  uri?: string;
+// ATProto union types require $type discriminator
+// Geo location: community.lexicon.location.geo
+// URI location: community.lexicon.calendar.event#uri
+export interface BlueskyGeoLocation {
+  $type: 'community.lexicon.location.geo';
+  latitude: string; // ATProto expects string, not number
+  longitude: string; // ATProto expects string, not number
   name?: string;
 }
+
+export interface BlueskyUriLocation {
+  $type: 'community.lexicon.calendar.event#uri';
+  uri: string;
+  name?: string;
+}
+
+export type BlueskyLocation = BlueskyGeoLocation | BlueskyUriLocation;
 
 export interface BlueskyEventUri {
   uri: string;
@@ -35,10 +44,9 @@ export interface BlueskyEvent {
     mode?: string;
     status?: string;
     locations?: Array<{
-      type: string;
-      lat?: number;
-      lon?: number;
-      description?: string;
+      $type: string;
+      latitude?: string;
+      longitude?: string;
       uri?: string;
       name?: string;
     }>;

--- a/src/bluesky/bluesky.service.ts
+++ b/src/bluesky/bluesky.service.ts
@@ -376,19 +376,21 @@ export class BlueskyService {
       const locations: BlueskyLocation[] = [];
 
       // Add physical location if exists
+      // ATProto schema: $type discriminator, latitude/longitude as strings, name field
       if (event.location && event.lat && event.lon) {
         locations.push({
-          type: 'community.lexicon.location.geo',
-          lat: event.lat,
-          lon: event.lon,
-          description: event.location,
+          $type: 'community.lexicon.location.geo',
+          latitude: String(event.lat),
+          longitude: String(event.lon),
+          name: event.location,
         });
       }
 
       // Add online location if exists
+      // ATProto schema: $type discriminator for union types
       if (event.locationOnline) {
         locations.push({
-          type: 'community.lexicon.calendar.event#uri',
+          $type: 'community.lexicon.calendar.event#uri',
           uri: event.locationOnline,
           name: 'Online Meeting Link',
         });


### PR DESCRIPTION
## Summary
- Fix Bluesky event creation failing with "Bad record" errors for events with physical locations
- ATProto lexicon schema mismatch was causing PDS validation failures

## Changes
- Use `$type` discriminator instead of `type` for union types
- Use `latitude`/`longitude` (strings) instead of `lat`/`lon` (numbers)
- Use `name` field instead of `description` for geo locations
- Update `BlueskyTypes.ts` with properly typed interfaces

## Root Cause
The code was sending:
```typescript
{ type: 'community.lexicon.location.geo', lat: 38.27, lon: -85.64, description: '...' }
```

But the lexicon requires:
```typescript
{ $type: 'community.lexicon.location.geo', latitude: '38.27', longitude: '-85.64', name: '...' }
```

## Test plan
- [x] Added unit tests for geo location schema
- [x] Added unit tests for URI location schema  
- [x] Added unit tests for hybrid events with both location types
- [x] Manual test: Create event with physical location and publish to Bluesky
- [ ] Manual test: Verify event appears correctly on Bluesky

Reported by: seth.computer on Bluesky