### PR TITLE
fix(auth): store Bluesky avatar in preferences instead of photo field

### DIFF
--- a/src/auth-bluesky/auth-bluesky.service.ts
+++ b/src/auth-bluesky/auth-bluesky.service.ts
@@ -240,6 +240,7 @@ export class AuthBlueskyService {
         emailConfirmed: profileData.emailConfirmed,
         firstName: profileData.displayName || profileData.handle,
         lastName: '',
+        avatar: profileData.avatar, // Pass avatar URL for user photo
         // Handle is not stored - it's resolved from DID when needed
       },
       tenantId,

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -800,6 +800,38 @@ export class UserService {
         profile.email = existingUser.email;
       }
 
+      // Update Bluesky avatar in preferences if it changed
+      const existingUserEntity = existingUser as UserEntity;
+      if (
+        authProvider === 'bluesky' &&
+        profile.avatar &&
+        existingUserEntity.preferences?.bluesky?.avatar !== profile.avatar
+      ) {
+        this.logger.log(
+          'Updating existing user with Bluesky avatar in preferences',
+          {
+            userId: existingUser.id,
+            avatar: profile.avatar,
+          },
+        );
+
+        const updatedUser = await this.update(
+          existingUser.id,
+          {
+            preferences: {
+              ...(existingUserEntity.preferences || {}),
+              bluesky: {
+                ...(existingUserEntity.preferences?.bluesky || {}),
+                avatar: profile.avatar,
+              },
+            },
+          },
+          tenantId,
+        );
+
+        return updatedUser as UserEntity;
+      }
+
       return existingUser as UserEntity;
     }
 
@@ -877,6 +909,7 @@ export class UserService {
       createUserData.preferences = {
         bluesky: {
           did: profile.id,
+          avatar: profile.avatar, // Store Bluesky avatar URL
           // Note: We don't store the handle here - it's resolved from DID when needed
           connected: true,
           autoPost: false,


### PR DESCRIPTION
## Summary
- Fixes Bluesky avatar not displaying for users logging in via Bluesky OAuth
- The `photo` field is a `FileEntity` relation (integer FK), not a URL string
- Bluesky avatars are now stored in `preferences.bluesky.avatar` where the frontend's `useAvatarUrl` composable already looks for them

## Changes
- Pass avatar URL through auth flow to `validateSocialLogin`
- Store avatar in `preferences.bluesky.avatar` for new Bluesky users
- Update avatar in preferences when existing user logs in with changed avatar
- Add unit tests for avatar storage in preferences

## Test plan
- [x] Unit tests pass for new avatar preference storage
- [x] Manual test: Login via Bluesky, avatar displays correctly in UI