### PR TITLE
fix(integration): accept string lat/lon per AT Protocol lexicon

### DIFF
--- a/src/event/dto/external-event.dto.spec.ts
+++ b/src/event/dto/external-event.dto.spec.ts
@@ -1,0 +1,83 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { ExternalEventLocationDto } from './external-event.dto';
+
+describe('ExternalEventLocationDto', () => {
+  describe('lat/lon transformation', () => {
+    it('should accept numeric lat/lon values', async () => {
+      const input = {
+        lat: 59.358296,
+        lon: 18.091465,
+        description: 'Test Location',
+      };
+
+      const dto = plainToInstance(ExternalEventLocationDto, input);
+      const errors = await validate(dto);
+
+      expect(errors.length).toBe(0);
+      expect(dto.lat).toBe(59.358296);
+      expect(dto.lon).toBe(18.091465);
+      expect(typeof dto.lat).toBe('number');
+      expect(typeof dto.lon).toBe('number');
+    });
+
+    it('should transform string lat/lon to numbers (AT Protocol format)', async () => {
+      const input = {
+        lat: '59.35829640000001',
+        lon: '18.0914655',
+        description: 'Berghs School of Communication AB, Stockholm, Sweden',
+      };
+
+      const dto = plainToInstance(ExternalEventLocationDto, input);
+      const errors = await validate(dto);
+
+      expect(errors.length).toBe(0);
+      expect(dto.lat).toBeCloseTo(59.358296, 5);
+      expect(dto.lon).toBeCloseTo(18.091465, 5);
+      expect(typeof dto.lat).toBe('number');
+      expect(typeof dto.lon).toBe('number');
+    });
+
+    it('should handle negative coordinate strings', async () => {
+      const input = {
+        lat: '-33.8688',
+        lon: '-151.2093',
+        description: 'Sydney, Australia',
+      };
+
+      const dto = plainToInstance(ExternalEventLocationDto, input);
+      const errors = await validate(dto);
+
+      expect(errors.length).toBe(0);
+      expect(dto.lat).toBeCloseTo(-33.8688, 4);
+      expect(dto.lon).toBeCloseTo(-151.2093, 4);
+    });
+
+    it('should allow location without coordinates', async () => {
+      const input = {
+        description: 'Online Event',
+        url: 'https://meet.google.com/xyz',
+      };
+
+      const dto = plainToInstance(ExternalEventLocationDto, input);
+      const errors = await validate(dto);
+
+      expect(errors.length).toBe(0);
+      expect(dto.lat).toBeUndefined();
+      expect(dto.lon).toBeUndefined();
+    });
+
+    it('should reject invalid string values that cannot be parsed', async () => {
+      const input = {
+        lat: 'not-a-number',
+        lon: 'also-not-a-number',
+      };
+
+      const dto = plainToInstance(ExternalEventLocationDto, input);
+      const errors = await validate(dto);
+
+      // parseFloat('not-a-number') returns NaN, which fails IsNumber validation
+      expect(errors.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/event/dto/external-event.dto.ts
+++ b/src/event/dto/external-event.dto.ts
@@ -12,7 +12,7 @@ import {
   IsUrl,
   IsArray,
 } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Type, Transform } from 'class-transformer';
 import {
   EventType,
   EventStatus,
@@ -29,12 +29,20 @@ export class ExternalEventLocationDto {
   @IsOptional()
   description?: string;
 
-  @ApiPropertyOptional({ description: 'Location latitude', example: 40.7128 })
+  @ApiPropertyOptional({
+    description: 'Location latitude (accepts string or number per AT Protocol)',
+    example: 40.7128,
+  })
+  @Transform(({ value }) => (typeof value === 'string' ? parseFloat(value) : value))
   @IsNumber()
   @IsOptional()
   lat?: number;
 
-  @ApiPropertyOptional({ description: 'Location longitude', example: -74.006 })
+  @ApiPropertyOptional({
+    description: 'Location longitude (accepts string or number per AT Protocol)',
+    example: -74.006,
+  })
+  @Transform(({ value }) => (typeof value === 'string' ? parseFloat(value) : value))
   @IsNumber()
   @IsOptional()
   lon?: number;


### PR DESCRIPTION
## Summary
- Accept string lat/lon coordinates in ExternalEventLocationDto per AT Protocol lexicon
- Add Transform decorator to convert strings to numbers for internal use
- Add unit tests for the coordinate transformation

## Problem
The AT Protocol lexicon defines geo coordinates as strings, but our API was validating for numbers only. This caused 18 event imports to fail overnight with validation errors like:

```
"lat must be a number conforming to the specified constraints"
"lon must be a number conforming to the specified constraints"
```

## Solution
Use class-transformer's `@Transform` decorator to convert string values to numbers before validation, maintaining compatibility with both string (AT Protocol) and number formats.

## Test plan
- [x] Unit tests for string-to-number transformation
- [x] Existing event-integration tests pass
- [ ] Deploy to dev and verify events with string coordinates are imported successfully