### PR TITLE
feat(atproto): add sync tracking columns to events and eventAttendees

### DIFF
--- a/src/database/migrations/1769291626489-AddAtprotoSyncFields.ts
+++ b/src/database/migrations/1769291626489-AddAtprotoSyncFields.ts
@@ -1,0 +1,60 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAtprotoSyncFields1769291626489 implements MigrationInterface {
+  name = 'AddAtprotoSyncFields1769291626489';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const schema = queryRunner.connection.options.name || 'public';
+
+    // Add AT Protocol sync tracking columns to events table
+    // These track when events are PUBLISHED to user's PDS (distinct from sourceId which tracks IMPORTED records)
+    await queryRunner.query(`
+      ALTER TABLE "${schema}"."events"
+      ADD COLUMN IF NOT EXISTS "atprotoUri" TEXT,
+      ADD COLUMN IF NOT EXISTS "atprotoRkey" VARCHAR(50),
+      ADD COLUMN IF NOT EXISTS "atprotoSyncedAt" TIMESTAMP
+    `);
+
+    // Index for finding pending syncs: public events not yet published to PDS
+    // Uses partial index for efficiency - only indexes records matching the WHERE clause
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_events_atproto_pending_sync"
+      ON "${schema}"."events" ("visibility", "atprotoUri")
+      WHERE "visibility" = 'public' AND "atprotoUri" IS NULL
+    `);
+
+    // Add AT Protocol sync tracking columns to eventAttendees table
+    // These track when RSVPs are PUBLISHED to user's PDS
+    await queryRunner.query(`
+      ALTER TABLE "${schema}"."eventAttendees"
+      ADD COLUMN IF NOT EXISTS "atprotoUri" TEXT,
+      ADD COLUMN IF NOT EXISTS "atprotoRkey" VARCHAR(50),
+      ADD COLUMN IF NOT EXISTS "atprotoSyncedAt" TIMESTAMP
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const schema = queryRunner.connection.options.name || 'public';
+
+    // Drop the partial index first
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "${schema}"."IDX_events_atproto_pending_sync"
+    `);
+
+    // Drop columns from events table (in reverse order of creation)
+    await queryRunner.query(`
+      ALTER TABLE "${schema}"."events"
+      DROP COLUMN IF EXISTS "atprotoSyncedAt",
+      DROP COLUMN IF EXISTS "atprotoRkey",
+      DROP COLUMN IF EXISTS "atprotoUri"
+    `);
+
+    // Drop columns from eventAttendees table
+    await queryRunner.query(`
+      ALTER TABLE "${schema}"."eventAttendees"
+      DROP COLUMN IF EXISTS "atprotoSyncedAt",
+      DROP COLUMN IF EXISTS "atprotoRkey",
+      DROP COLUMN IF EXISTS "atprotoUri"
+    `);
+  }
+}

--- a/src/event-attendee/infrastructure/persistence/relational/entities/event-attendee.entity.ts
+++ b/src/event-attendee/infrastructure/persistence/relational/entities/event-attendee.entity.ts
@@ -67,4 +67,27 @@ export class EventAttendeesEntity implements SourceFields {
 
   @Column({ type: 'timestamp', nullable: true })
   lastSyncedAt: Date | null;
+
+  /**
+   * AT Protocol URI where this RSVP is published (on attendee's PDS).
+   * Format: at://did:plc:xxx/community.lexicon.calendar.rsvp/rkey
+   * NULL means not yet published.
+   * Note: Distinct from sourceId which tracks IMPORTED records from external sources.
+   */
+  @Column({ type: 'text', nullable: true })
+  atprotoUri: string | null;
+
+  /**
+   * AT Protocol record key for this RSVP.
+   * Used for updates/deletes on the PDS. TIDs are ~13 chars.
+   */
+  @Column({ type: 'varchar', length: 50, nullable: true })
+  atprotoRkey: string | null;
+
+  /**
+   * When this RSVP was last synced to the user's PDS.
+   * Compare with updatedAt to detect changes needing re-sync.
+   */
+  @Column({ type: 'timestamp', nullable: true })
+  atprotoSyncedAt: Date | null;
 }

--- a/src/event/infrastructure/persistence/relational/entities/event.entity.ts
+++ b/src/event/infrastructure/persistence/relational/entities/event.entity.ts
@@ -183,6 +183,29 @@ export class EventEntity
   @Column({ type: 'timestamp', nullable: true })
   lastSyncedAt: Date | null;
 
+  /**
+   * AT Protocol URI where this event is published (on organizer's PDS).
+   * Format: at://did:plc:xxx/community.lexicon.calendar.event/rkey
+   * NULL means not yet published (pending sync for public events).
+   * Note: Distinct from sourceId which tracks IMPORTED records from external sources.
+   */
+  @Column({ type: 'text', nullable: true })
+  atprotoUri: string | null;
+
+  /**
+   * AT Protocol record key for this event.
+   * Used for updates/deletes on the PDS. TIDs are ~13 chars.
+   */
+  @Column({ type: 'varchar', length: 50, nullable: true })
+  atprotoRkey: string | null;
+
+  /**
+   * When this event was last synced to the user's PDS.
+   * Compare with updatedAt to detect changes needing re-sync.
+   */
+  @Column({ type: 'timestamp', nullable: true })
+  atprotoSyncedAt: Date | null;
+
   // Explicitly define seriesSlug column - needed for TypeScript
   @Column({ type: 'varchar', length: 255, nullable: true })
   seriesSlug: string | null;


### PR DESCRIPTION
## Summary

- Add `atprotoUri`, `atprotoRkey`, `atprotoSyncedAt` columns to `events` and `eventAttendees` tables
- These track when records are **published** to user's PDS (distinct from `sourceId` which tracks **imported** records)
- Add partial index `IDX_events_atproto_pending_sync` for efficient pending sync queries

## Sync State Detection

| visibility | atprotoUri | State |
|------------|------------|-------|
| `public` | `NULL` | **Pending sync** - should be on PDS but isn't |
| `public` | `at://...` | **Synced** - on PDS |
| `unlisted` | `NULL` | **Local only** - never goes to PDS |
| `private` | `NULL` | **Local only** - never goes to PDS |

## Test plan

- [x] Migration runs successfully on all tenant schemas
- [x] Columns verified in `events` table
- [x] Columns verified in `eventAttendees` table  
- [x] Partial index created
- [x] Build passes