### PR TITLE
fix(group): strip trailing hyphens from auto-generated slugs

### DIFF
--- a/src/event-series/infrastructure/persistence/relational/entities/event-series.entity.spec.ts
+++ b/src/event-series/infrastructure/persistence/relational/entities/event-series.entity.spec.ts
@@ -1,0 +1,98 @@
+import { EventSeriesEntity } from './event-series.entity';
+import { SLUG_REGEX } from '../../../../../core/constants/constant';
+import * as shortCodeModule from '../../../../../utils/short-code';
+
+describe('EventSeriesEntity', () => {
+  describe('generateSlug', () => {
+    it('should generate a valid slug from a simple name', () => {
+      const series = new EventSeriesEntity();
+      series.name = 'Test Series';
+
+      series.generateSlug();
+
+      // Slug should be "test-series-XXXXXX" where XXXXXX is a short code
+      expect(series.slug).toMatch(/^test-series-[a-z0-9_-]+$/);
+      expect(SLUG_REGEX.test(series.slug)).toBe(true);
+    });
+
+    it('should generate a valid slug from a name ending with special characters', () => {
+      const series = new EventSeriesEntity();
+      series.name = 'Test Series!';
+
+      series.generateSlug();
+
+      // Slug should NOT have trailing hyphens
+      expect(series.slug).not.toMatch(/-$/);
+      expect(SLUG_REGEX.test(series.slug)).toBe(true);
+    });
+
+    it('should NOT overwrite existing slug', () => {
+      const series = new EventSeriesEntity();
+      series.slug = 'existing-slug-abc123';
+      series.name = 'New Name';
+
+      series.generateSlug();
+
+      expect(series.slug).toBe('existing-slug-abc123');
+    });
+
+    it('should strip trailing hyphens when short code ends with hyphen', () => {
+      // Mock generateShortCode to return a value ending with hyphen
+      // Note: EventSeries entity concatenates BEFORE slugify, so slugify handles this
+      const spy = jest
+        .spyOn(shortCodeModule, 'generateShortCode')
+        .mockReturnValue('abc12-');
+
+      const series = new EventSeriesEntity();
+      series.name = 'Test Series';
+
+      series.generateSlug();
+
+      // Slug should NOT end with a hyphen - slugify with strict:true strips trailing hyphens
+      expect(series.slug).not.toMatch(/-$/);
+      expect(SLUG_REGEX.test(series.slug)).toBe(true);
+
+      spy.mockRestore();
+    });
+
+    it('should strip multiple trailing hyphens when short code ends with multiple hyphens', () => {
+      // Mock generateShortCode to return a value ending with multiple hyphens
+      const spy = jest
+        .spyOn(shortCodeModule, 'generateShortCode')
+        .mockReturnValue('ab---');
+
+      const series = new EventSeriesEntity();
+      series.name = 'Test Series';
+
+      series.generateSlug();
+
+      // Slug should NOT end with hyphens
+      expect(series.slug).not.toMatch(/-$/);
+      expect(SLUG_REGEX.test(series.slug)).toBe(true);
+
+      spy.mockRestore();
+    });
+  });
+
+  describe('generateUlid', () => {
+    it('should generate ulid when not set', () => {
+      const series = new EventSeriesEntity();
+
+      series.generateUlid();
+
+      expect(series.ulid).toBeDefined();
+      expect(series.ulid).toHaveLength(26);
+      expect(series.ulid).toMatch(/^[0-9a-z]{26}$/);
+    });
+
+    it('should NOT overwrite existing ulid', () => {
+      const series = new EventSeriesEntity();
+      const existingUlid = '01hqvxz6j8k9m0n1p2q3r4s5t6';
+      series.ulid = existingUlid;
+
+      series.generateUlid();
+
+      expect(series.ulid).toBe(existingUlid);
+    });
+  });
+});

--- a/src/event/infrastructure/persistence/relational/entities/event.entity.spec.ts
+++ b/src/event/infrastructure/persistence/relational/entities/event.entity.spec.ts
@@ -1,0 +1,98 @@
+import { EventEntity } from './event.entity';
+import { SLUG_REGEX } from '../../../../../core/constants/constant';
+import * as shortCodeModule from '../../../../../utils/short-code';
+
+describe('EventEntity', () => {
+  describe('generateSlug', () => {
+    it('should generate a valid slug from a simple name', () => {
+      const event = new EventEntity();
+      event.name = 'Test Event';
+
+      event.generateSlug();
+
+      // Slug should be "test-event-XXXXXX" where XXXXXX is a short code
+      expect(event.slug).toMatch(/^test-event-[a-z0-9_-]+$/);
+      expect(SLUG_REGEX.test(event.slug)).toBe(true);
+    });
+
+    it('should generate a valid slug from a name ending with special characters', () => {
+      const event = new EventEntity();
+      event.name = 'Test Event!';
+
+      event.generateSlug();
+
+      // Slug should NOT have trailing hyphens
+      expect(event.slug).not.toMatch(/-$/);
+      expect(SLUG_REGEX.test(event.slug)).toBe(true);
+    });
+
+    it('should NOT overwrite existing slug', () => {
+      const event = new EventEntity();
+      event.slug = 'existing-slug-abc123';
+      event.name = 'New Name';
+
+      event.generateSlug();
+
+      expect(event.slug).toBe('existing-slug-abc123');
+    });
+
+    it('should strip trailing hyphens when short code ends with hyphen', () => {
+      // Mock generateShortCode to return a value ending with hyphen
+      // Note: Event entity concatenates BEFORE slugify, so slugify handles this
+      const spy = jest
+        .spyOn(shortCodeModule, 'generateShortCode')
+        .mockReturnValue('abc12-');
+
+      const event = new EventEntity();
+      event.name = 'Test Event';
+
+      event.generateSlug();
+
+      // Slug should NOT end with a hyphen - slugify with strict:true strips trailing hyphens
+      expect(event.slug).not.toMatch(/-$/);
+      expect(SLUG_REGEX.test(event.slug)).toBe(true);
+
+      spy.mockRestore();
+    });
+
+    it('should strip multiple trailing hyphens when short code ends with multiple hyphens', () => {
+      // Mock generateShortCode to return a value ending with multiple hyphens
+      const spy = jest
+        .spyOn(shortCodeModule, 'generateShortCode')
+        .mockReturnValue('ab---');
+
+      const event = new EventEntity();
+      event.name = 'Test Event';
+
+      event.generateSlug();
+
+      // Slug should NOT end with hyphens
+      expect(event.slug).not.toMatch(/-$/);
+      expect(SLUG_REGEX.test(event.slug)).toBe(true);
+
+      spy.mockRestore();
+    });
+  });
+
+  describe('generateUlid', () => {
+    it('should generate ulid when not set', () => {
+      const event = new EventEntity();
+
+      event.generateUlid();
+
+      expect(event.ulid).toBeDefined();
+      expect(event.ulid).toHaveLength(26);
+      expect(event.ulid).toMatch(/^[0-9a-z]{26}$/);
+    });
+
+    it('should NOT overwrite existing ulid', () => {
+      const event = new EventEntity();
+      const existingUlid = '01hqvxz6j8k9m0n1p2q3r4s5t6';
+      event.ulid = existingUlid;
+
+      event.generateUlid();
+
+      expect(event.ulid).toBe(existingUlid);
+    });
+  });
+});

--- a/src/group/infrastructure/persistence/relational/entities/group.entity.spec.ts
+++ b/src/group/infrastructure/persistence/relational/entities/group.entity.spec.ts
@@ -1,0 +1,130 @@
+import { GroupEntity } from './group.entity';
+import { SLUG_REGEX } from '../../../../../core/constants/constant';
+import * as shortCodeModule from '../../../../../utils/short-code';
+
+describe('GroupEntity', () => {
+  describe('generateSlug', () => {
+    it('should generate a valid slug from a simple name', () => {
+      const group = new GroupEntity();
+      group.name = 'Test Group';
+
+      group.generateSlug();
+
+      // Slug should be "test-group-XXXXXX" where XXXXXX is a short code
+      expect(group.slug).toMatch(/^test-group-[a-z0-9_-]+$/);
+      expect(SLUG_REGEX.test(group.slug)).toBe(true);
+    });
+
+    it('should generate a valid slug from a name ending with special characters', () => {
+      const group = new GroupEntity();
+      group.name = 'Test Group!';
+
+      group.generateSlug();
+
+      // Slug should NOT have trailing hyphen before the short code
+      // i.e., should be "test-group-XXXXXX" not "test-group--XXXXXX"
+      expect(group.slug).not.toContain('--');
+      expect(SLUG_REGEX.test(group.slug)).toBe(true);
+    });
+
+    it('should generate a valid slug from a name ending with multiple special characters', () => {
+      const group = new GroupEntity();
+      group.name = 'Test Group!!!';
+
+      group.generateSlug();
+
+      // Slug should NOT have trailing hyphens before the short code
+      expect(group.slug).not.toContain('--');
+      expect(SLUG_REGEX.test(group.slug)).toBe(true);
+    });
+
+    it('should generate a valid slug from a name with trailing spaces', () => {
+      const group = new GroupEntity();
+      group.name = 'Test Group   ';
+
+      group.generateSlug();
+
+      expect(group.slug).not.toContain('--');
+      expect(SLUG_REGEX.test(group.slug)).toBe(true);
+    });
+
+    it('should generate a valid slug from a name with special characters throughout', () => {
+      const group = new GroupEntity();
+      group.name = 'Test & Group @ Here!';
+
+      group.generateSlug();
+
+      // Should handle special characters without creating double hyphens
+      expect(group.slug).not.toMatch(/--+/);
+      expect(SLUG_REGEX.test(group.slug)).toBe(true);
+    });
+
+    it('should NOT overwrite existing slug', () => {
+      const group = new GroupEntity();
+      group.slug = 'existing-slug-abc123';
+      group.name = 'New Name';
+
+      group.generateSlug();
+
+      expect(group.slug).toBe('existing-slug-abc123');
+    });
+
+    it('should strip trailing hyphens when short code ends with hyphen', () => {
+      // Mock generateShortCode to return a value ending with hyphen
+      const spy = jest
+        .spyOn(shortCodeModule, 'generateShortCode')
+        .mockReturnValue('abc12-');
+
+      const group = new GroupEntity();
+      group.name = 'Test Group';
+
+      group.generateSlug();
+
+      // Slug should NOT end with a hyphen - SLUG_REGEX rejects trailing hyphens
+      expect(group.slug).not.toMatch(/-$/);
+      expect(SLUG_REGEX.test(group.slug)).toBe(true);
+
+      spy.mockRestore();
+    });
+
+    it('should strip multiple trailing hyphens when short code ends with multiple hyphens', () => {
+      // Mock generateShortCode to return a value ending with multiple hyphens
+      const spy = jest
+        .spyOn(shortCodeModule, 'generateShortCode')
+        .mockReturnValue('ab---');
+
+      const group = new GroupEntity();
+      group.name = 'Test Group';
+
+      group.generateSlug();
+
+      // Slug should NOT end with hyphens
+      expect(group.slug).not.toMatch(/-$/);
+      expect(SLUG_REGEX.test(group.slug)).toBe(true);
+
+      spy.mockRestore();
+    });
+  });
+
+  describe('generateUlid', () => {
+    it('should generate ulid when not set', () => {
+      const group = new GroupEntity();
+
+      group.generateUlid();
+
+      expect(group.ulid).toBeDefined();
+      expect(group.ulid).toHaveLength(26);
+      expect(group.ulid).toMatch(/^[0-9a-z]{26}$/);
+    });
+
+    it('should NOT overwrite existing ulid', () => {
+      const group = new GroupEntity();
+      const existingUlid = '01hqvxz6j8k9m0n1p2q3r4s5t6';
+      group.ulid = existingUlid;
+
+      group.generateUlid();
+
+      expect(group.ulid).toBe(existingUlid);
+    });
+  });
+});

--- a/src/group/infrastructure/persistence/relational/entities/group.entity.ts
+++ b/src/group/infrastructure/persistence/relational/entities/group.entity.ts
@@ -149,7 +149,11 @@ export class GroupEntity extends EntityRelationalHelper {
   @BeforeInsert()
   generateSlug() {
     if (!this.slug) {
-      this.slug = `${slugify(this.name, { strict: true, lower: true })}-${generateShortCode().toLowerCase()}`;
+      this.slug =
+        `${slugify(this.name, { strict: true, lower: true })}-${generateShortCode().toLowerCase()}`.replace(
+          /-+$/,
+          '',
+        );
     }
   }
 


### PR DESCRIPTION
## Summary
- Fix GroupEntity slug generation to strip trailing hyphens that can occur when `generateShortCode()` returns a value ending with `-`
- Add comprehensive entity tests for slug generation in group, event, and event-series entities

## Problem
`generateShortCode()` uses nanoid's `urlAlphabet` which includes `-`. When the short code ends with a hyphen, the concatenated slug (e.g., `test-group-abc12-`) fails SLUG_REGEX validation.

## Solution
Add `.replace(/-+$/, '')` to strip trailing hyphens from generated slugs in `group.entity.ts`.

Note: Event and EventSeries entities use a different pattern (concatenate before slugify) which handles this automatically.

## Test plan
- [x] Added unit tests for trailing hyphen scenarios in group entity
- [x] Added unit tests documenting event and event-series slug behavior
- [x] All 24 entity slug tests pass

Fixes #460