### PR TITLE
feat(atproto): use userAtprotoIdentities as primary login lookup

### DIFF
--- a/src/atproto-publisher/atproto-publisher.service.ts
+++ b/src/atproto-publisher/atproto-publisher.service.ts
@@ -158,7 +158,9 @@ export class AtprotoPublisherService {
       return false;
     }
 
-    this.logger.debug(`[shouldPublishEvent] ${event.slug}: ELIGIBLE for publishing`);
+    this.logger.debug(
+      `[shouldPublishEvent] ${event.slug}: ELIGIBLE for publishing`,
+    );
     return true;
   }
 

--- a/src/event/services/event-management.service.spec.ts
+++ b/src/event/services/event-management.service.spec.ts
@@ -1637,9 +1637,7 @@ describe('EventManagementService', () => {
       ] as jest.Mocked<AtprotoPublisherService>;
 
       // Setup common mock responses
-      jest
-        .spyOn(service['categoryService'], 'findByIds')
-        .mockResolvedValue([]);
+      jest.spyOn(service['categoryService'], 'findByIds').mockResolvedValue([]);
       jest
         .spyOn(eventAttendeeService, 'create')
         .mockResolvedValue({} as EventAttendeesEntity);

--- a/src/test/mocks/mocks.ts
+++ b/src/test/mocks/mocks.ts
@@ -223,5 +223,7 @@ export const mockAtprotoPublisherService = {
   publishEvent: jest.fn().mockResolvedValue({ action: 'skipped' }),
   deleteEvent: jest.fn().mockResolvedValue({ action: 'skipped' }),
   publishRsvp: jest.fn().mockResolvedValue({ action: 'skipped' }),
-  ensurePublishingCapability: jest.fn().mockResolvedValue({ did: 'did:plc:test', required: true }),
+  ensurePublishingCapability: jest
+    .fn()
+    .mockResolvedValue({ did: 'did:plc:test', required: true }),
 };


### PR DESCRIPTION
## Summary

- Refactor AT Protocol OAuth login to use `userAtprotoIdentities` table as the primary lookup source
- Add fallback to legacy `socialId + provider='bluesky'` lookup for backwards compatibility  
- Enable login via AT Protocol OAuth for users who linked external accounts or took ownership of custodial identities

## Changes

- Add `findUserByAtprotoIdentity()` method with two-tier lookup strategy
- Update `handleAuthCallback()` to use the new lookup method
- Only create identity records when found via legacy lookup (skip when already exists)
- Add 5 new unit tests for lookup behavior

## Why This Matters

After this change, ALL these users can login via AT Protocol OAuth:
- Native Bluesky users (provider=bluesky, migrated to identity table)
- Google/GitHub/Email users who linked external bsky.social account
- Users who took ownership of custodial accounts

The `userAtprotoIdentities` table becomes the source of truth for AT Protocol identity lookups.

## Test plan

- [x] Unit tests pass (29/29)
- [x] E2E: Native Bluesky user can login
- [ ] E2E: User with linked external AT Protocol identity can login via OAuth
- [x] E2E: New user signup still works

Closes: om-bxrh