### PR TITLE
fix(slug): pass full string through slugify to prevent double hyphens

### DIFF
--- a/src/group/group.service.ts
+++ b/src/group/group.service.ts
@@ -247,10 +247,10 @@ export class GroupService {
     }
 
     const shortCode = await generateShortCode();
-    const slugifiedName = `${slugify(createGroupDto.name, {
-      strict: true,
-      lower: true,
-    })}-${shortCode.toLowerCase()}`;
+    const slugifiedName = slugify(
+      createGroupDto.name + '-' + shortCode.toLowerCase(),
+      { strict: true, lower: true },
+    );
 
     let locationPoint;
     if (createGroupDto.lat && createGroupDto.lon) {

--- a/src/group/infrastructure/persistence/relational/entities/group.entity.ts
+++ b/src/group/infrastructure/persistence/relational/entities/group.entity.ts
@@ -149,11 +149,10 @@ export class GroupEntity extends EntityRelationalHelper {
   @BeforeInsert()
   generateSlug() {
     if (!this.slug) {
-      this.slug =
-        `${slugify(this.name, { strict: true, lower: true })}-${generateShortCode().toLowerCase()}`.replace(
-          /-+$/,
-          '',
-        );
+      this.slug = slugify(this.name + '-' + generateShortCode().toLowerCase(), {
+        strict: true,
+        lower: true,
+      });
     }
   }
 

--- a/src/shadow-account/shadow-account.service.ts
+++ b/src/shadow-account/shadow-account.service.ts
@@ -134,13 +134,12 @@ export class ShadowAccountService {
           shadowUser.status = status;
 
           shadowUser.ulid = ulid().toLowerCase();
-          shadowUser.slug = `${slugify(
-            (displayName || 'shadow-user').trim().toLowerCase(),
-            {
-              strict: true,
-              lower: true,
-            },
-          )}-${generateShortCode().toLowerCase()}`;
+          shadowUser.slug = slugify(
+            (displayName || 'shadow-user').trim() +
+              '-' +
+              generateShortCode().toLowerCase(),
+            { strict: true, lower: true },
+          );
 
           // Set provider-specific preferences
           shadowUser.preferences = preferences || {};

--- a/src/user/infrastructure/persistence/relational/entities/user.entity.ts
+++ b/src/user/infrastructure/persistence/relational/entities/user.entity.ts
@@ -207,10 +207,10 @@ export class UserEntity extends EntityRelationalHelper {
   generateSlug() {
     if (!this.slug) {
       const name = `${this.firstName || ''} ${this.lastName || ''}`.trim();
-      this.slug = `${slugify(name.toLowerCase() || 'user', {
-        strict: true,
-        lower: true,
-      })}-${generateShortCode().toLowerCase()}`;
+      this.slug = slugify(
+        (name || 'user') + '-' + generateShortCode().toLowerCase(),
+        { strict: true, lower: true },
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- Several slug generators called `slugify` on the name alone, then concatenated the short code outside of slugify. Special characters in names (e.g. `Test & Group @ Here!`) produced double hyphens that survived (e.g. `test--group--here-abc12`).
- Now all 4 affected generators pass the full `name + '-' + shortCode` into `slugify()` so it handles hyphen collapsing and trimming consistently.
- Aligns with the pattern already used by `event.entity.ts` and `event-series.entity.ts`.

### Files changed
| File | Change |
|------|--------|
| `src/group/infrastructure/persistence/relational/entities/group.entity.ts` | Entity `generateSlug` |
| `src/user/infrastructure/persistence/relational/entities/user.entity.ts` | Entity `generateSlug` |
| `src/group/group.service.ts` | Service-level slug creation |
| `src/shadow-account/shadow-account.service.ts` | Shadow user slug creation |

## Test plan
- [x] All 34 entity slug spec tests pass (group, user, event, event-series)
- [x] Full test suite passes (1465 tests)
- [x] CI passes