### PR TITLE
feat(atproto): add validHandleDomains to identity response

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -383,17 +383,17 @@ services:
     ports:
       - "3101:3000"
     environment:
-      PDS_HOSTNAME: pds.test
+      PDS_HOSTNAME: ${PDS_HOSTNAME:-pds.test}
       PDS_PORT: 3000
       PDS_DATA_DIRECTORY: /pds
       PDS_BLOBSTORE_DISK_LOCATION: /pds/blocks
       PDS_DID_PLC_URL: http://plc:2582
-      PDS_SERVICE_HANDLE_DOMAINS: .pds.test
+      PDS_SERVICE_HANDLE_DOMAINS: ${PDS_SERVICE_HANDLE_DOMAINS:-.pds.test}
       PDS_JWT_SECRET: local-dev-jwt-secret-not-for-production
-      PDS_ADMIN_PASSWORD: local-dev-admin-password
+      PDS_ADMIN_PASSWORD: ${PDS_ADMIN_PASSWORD:-local-dev-admin-password}
       PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
       PDS_EMAIL_SMTP_URL: smtp://maildev:1025
-      PDS_EMAIL_FROM_ADDRESS: noreply@pds.test
+      PDS_EMAIL_FROM_ADDRESS: noreply@${PDS_HOSTNAME:-pds.test}
       PDS_DEV_MODE: "true"
       PDS_INVITE_REQUIRED: "true"
       LOG_ENABLED: "true"

--- a/src/atproto-identity/atproto-identity.controller.spec.ts
+++ b/src/atproto-identity/atproto-identity.controller.spec.ts
@@ -98,6 +98,7 @@ describe('AtprotoIdentityController', () => {
     const mockConfigService = {
       get: jest.fn().mockImplementation((key: string) => {
         if (key === 'pds.url') return 'https://pds.openmeet.net';
+        if (key === 'pds.serviceHandleDomains') return '.opnmt.me';
         return null;
       }),
     };
@@ -185,6 +186,7 @@ describe('AtprotoIdentityController', () => {
         isCustodial: true,
         isOurPds: true,
         hasActiveSession: true,
+        validHandleDomains: ['.opnmt.me'],
         createdAt: new Date('2025-01-01T00:00:00Z'),
         updatedAt: new Date('2025-01-01T00:00:00Z'),
       });
@@ -323,6 +325,7 @@ describe('AtprotoIdentityController', () => {
         isCustodial: true,
         isOurPds: true,
         hasActiveSession: true,
+        validHandleDomains: ['.opnmt.me'],
         createdAt: new Date('2025-01-01T00:00:00Z'),
         updatedAt: new Date('2025-01-01T00:00:00Z'),
       });

--- a/src/atproto-identity/atproto-identity.controller.ts
+++ b/src/atproto-identity/atproto-identity.controller.ts
@@ -391,6 +391,12 @@ export class AtprotoIdentityController {
     tenantId: string,
   ): Promise<AtprotoIdentityDto> {
     const ourPdsUrl = this.configService.get('pds.url', { infer: true });
+    const serviceHandleDomains =
+      this.configService.get('pds.serviceHandleDomains', { infer: true }) || '';
+    const validHandleDomains = serviceHandleDomains
+      .split(',')
+      .map((d: string) => d.trim())
+      .filter((d: string) => d.length > 0);
 
     let hasActiveSession = false;
     if (identity.isCustodial && identity.pdsCredentials) {
@@ -439,6 +445,7 @@ export class AtprotoIdentityController {
       isCustodial: identity.isCustodial,
       isOurPds: identity.pdsUrl === ourPdsUrl,
       hasActiveSession,
+      validHandleDomains,
       createdAt: identity.createdAt,
       updatedAt: identity.updatedAt,
     };

--- a/src/atproto-identity/dto/atproto-identity.dto.ts
+++ b/src/atproto-identity/dto/atproto-identity.dto.ts
@@ -45,6 +45,13 @@ export class AtprotoIdentityDto {
   hasActiveSession: boolean;
 
   @ApiProperty({
+    description: 'Valid handle domains for this PDS (e.g., [".bsky.dev.openmeet.net"])',
+    example: ['.bsky.dev.openmeet.net'],
+    type: [String],
+  })
+  validHandleDomains: string[];
+
+  @ApiProperty({
     description: 'When the identity was created',
   })
   createdAt: Date;

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -774,6 +774,7 @@ describe('AuthService', () => {
       );
       mockConfigService.get.mockImplementation((key: string) => {
         if (key === 'pds.url') return 'https://pds.openmeet.net';
+        if (key === 'pds.serviceHandleDomains') return '.opnmt.me';
         return null;
       });
 
@@ -792,6 +793,7 @@ describe('AuthService', () => {
         isCustodial: true,
         isOurPds: true,
         hasActiveSession: false,
+        validHandleDomains: ['.opnmt.me'],
         createdAt: new Date('2025-01-01T00:00:00Z'),
         updatedAt: new Date('2025-01-01T00:00:00Z'),
       });
@@ -832,6 +834,7 @@ describe('AuthService', () => {
       );
       mockConfigService.get.mockImplementation((key: string) => {
         if (key === 'pds.url') return 'https://pds.openmeet.net';
+        if (key === 'pds.serviceHandleDomains') return '.opnmt.me';
         return null;
       });
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -636,6 +636,12 @@ export class AuthService {
         if (identity) {
           // Map to DTO, explicitly excluding pdsCredentials
           const ourPdsUrl = this.configService.get('pds.url', { infer: true });
+          const serviceHandleDomains =
+            this.configService.get('pds.serviceHandleDomains', { infer: true }) || '';
+          const validHandleDomains = serviceHandleDomains
+            .split(',')
+            .map((d: string) => d.trim())
+            .filter((d: string) => d.length > 0);
 
           // Determine hasActiveSession based on identity type
           let hasActiveSession = false;
@@ -663,6 +669,7 @@ export class AuthService {
             isCustodial: identity.isCustodial,
             isOurPds: identity.pdsUrl === ourPdsUrl,
             hasActiveSession,
+            validHandleDomains,
             createdAt: identity.createdAt,
             updatedAt: identity.updatedAt,
           };


### PR DESCRIPTION
## Summary

- Add `validHandleDomains: string[]` field to `AtprotoIdentityDto`
- Populated from `PDS_SERVICE_HANDLE_DOMAINS` config (comma-separated)
- Update `docker-compose-dev.yml` to read PDS config from env vars with defaults
- Platform can now detect valid handle domains from server instead of hardcoding

## Related

- Platform PR: OpenMeet-Team/openmeet-platform#367
- Closes: om-0c2w

## Test plan

- [ ] Verify `/api/atproto/identity` returns `validHandleDomains` array
- [ ] Verify `/api/v1/auth/me` returns `validHandleDomains` in `atprotoIdentity`
- [ ] Run unit tests: `npm run test:local` (120 suites passing)