### PR TITLE
fix(atproto): remove 24hr TTL from OAuth session storage

### DIFF
--- a/src/auth-bluesky/stores/elasticache-stores.ts
+++ b/src/auth-bluesky/stores/elasticache-stores.ts
@@ -35,8 +35,8 @@ export class ElastiCacheSessionStore implements NodeSavedSessionStore {
   async set(sub: string, data: NodeSavedSession) {
     const key = `bluesky:session:${sub}`;
     console.log('Setting session in Redis:', { key, sub });
-    // Set session with 24 hour TTL
-    await this.elasticache.set(key, data, 86400);
+    // No TTL - let AT Protocol's native token expiry be the limit
+    await this.elasticache.set(key, data);
   }
 
   async get(sub: string): Promise<NodeSavedSession | undefined> {
@@ -44,10 +44,6 @@ export class ElastiCacheSessionStore implements NodeSavedSessionStore {
     console.log('Getting session from Redis:', key);
     const result = await this.elasticache.get<NodeSavedSession>(key);
     console.log('Retrieved session:', { key, found: !!result });
-    if (result) {
-      // Refresh TTL by setting the value again
-      await this.elasticache.set(key, result, 86400);
-    }
     return result ?? undefined;
   }
 


### PR DESCRIPTION
## Summary

Remove artificial 24-hour TTL from AT Protocol OAuth session storage. Sessions now persist until tokens naturally expire.

## Changes

- Remove 86400 second TTL from `ElastiCacheSessionStore.set()`
- Remove TTL refresh on `get()` (no longer needed)
- State store keeps 10 minute TTL (appropriate for OAuth flow)

## Rationale

AT Protocol refresh tokens can be valid for months. The 24-hour TTL was artificially short, causing unnecessary re-authentication for users inactive for more than a day.

## Trade-offs

- Redis restart still requires re-auth (accepted - Redis is stable)
- Sessions persist longer in Redis (acceptable memory trade-off)

Closes: om-p27t