### PR TITLE
fix(atproto): use PDS session for event deletion

### DIFF
--- a/src/atproto-publisher/atproto-publisher.service.ts
+++ b/src/atproto-publisher/atproto-publisher.service.ts
@@ -364,7 +364,12 @@ export class AtprotoPublisherService {
       );
     }
 
-    await this.blueskyService.deleteEventRecord(event, session.did, tenantId);
+    await this.blueskyService.deleteEventRecord(
+      event,
+      session.did,
+      tenantId,
+      session.agent, // Use PDS session agent instead of legacy Bluesky OAuth
+    );
 
     this.logger.debug(`Successfully deleted event ${event.slug} from PDS`);
 

--- a/src/bluesky/bluesky.service.ts
+++ b/src/bluesky/bluesky.service.ts
@@ -492,6 +492,7 @@ export class BlueskyService {
     event: EventEntity,
     did: string,
     tenantId: string,
+    providedAgent?: Agent,
   ): Promise<{ success: boolean; message: string }> {
     const rkey =
       (event.sourceData?.rkey as string | undefined) || event.atprotoRkey;
@@ -501,7 +502,8 @@ export class BlueskyService {
       );
     }
 
-    const agent = await this.resumeSession(tenantId, did);
+    // Use provided agent (from PDS session) or fall back to legacy Bluesky OAuth
+    const agent = providedAgent || (await this.resumeSession(tenantId, did));
 
     try {
       // When deleting a record, ensure that the repo information is included


### PR DESCRIPTION
## Summary

Use PDS session agent for event deletion instead of legacy Bluesky OAuth.

## Changes

- Add optional `providedAgent` parameter to `BlueskyService.deleteEventRecord()`
- `AtprotoPublisherService.doDeleteEvent()` now passes `session.agent`
- Falls back to legacy OAuth if no agent provided (backwards compatible)

## Why

Events published via `AtprotoPublisherService` use PDS sessions. Deletion
was using legacy Bluesky OAuth (`resumeSession`), which requires different
OAuth keys. This caused silent deletion failures in CI.

Closes: om-jl1n