### PR TITLE
feat(atproto): actionable error for orphan state (no OAuth session)

### DIFF
--- a/src/atproto-publisher/interfaces/publish-result.interface.ts
+++ b/src/atproto-publisher/interfaces/publish-result.interface.ts
@@ -7,14 +7,21 @@
  * - 'deleted': Record deleted from PDS
  * - 'skipped': Record not eligible for publishing (not an error)
  * - 'pending': Reserved for future background processing
+ * - 'error': Publishing failed with an actionable error message
  */
 export interface PublishResult {
   /** What action was taken - primary indicator of result */
-  action: 'published' | 'updated' | 'deleted' | 'skipped' | 'pending';
+  action: 'published' | 'updated' | 'deleted' | 'skipped' | 'pending' | 'error';
 
   /** The AT Protocol URI of the published record (e.g., at://did:plc:xxx/community.lexicon.calendar.event/rkey) */
   atprotoUri?: string;
 
   /** The record key used in the AT Protocol URI */
   atprotoRkey?: string;
+
+  /** Error message when action is 'error' */
+  error?: string;
+
+  /** Indicates the user needs to re-link their AT Protocol account via OAuth */
+  needsOAuthLink?: boolean;
 }

--- a/src/pds/pds.errors.ts
+++ b/src/pds/pds.errors.ts
@@ -47,3 +47,25 @@ export class PdsSessionError extends Error {
     this.name = 'PdsSessionError';
   }
 }
+
+/**
+ * Error thrown when a session cannot be obtained for an AT Protocol identity.
+ *
+ * This specifically indicates that the user needs to re-link their account
+ * via OAuth. Common scenarios:
+ * - Orphan account: User took ownership of custodial account but no OAuth session exists
+ * - OAuth session expired: User's OAuth session in Redis has expired and needs refresh
+ *
+ * The `needsOAuthLink` flag indicates the user should be prompted to
+ * re-authenticate via the AT Protocol OAuth flow.
+ */
+export class SessionUnavailableError extends Error {
+  constructor(
+    message: string,
+    public readonly needsOAuthLink: boolean = true,
+    public readonly did?: string,
+  ) {
+    super(message);
+    this.name = 'SessionUnavailableError';
+  }
+}


### PR DESCRIPTION
## Summary

When a user takes ownership of their AT Protocol account (via password reset) but hasn't completed OAuth linking, publishing would silently fail. Now users get a clear, actionable error message.

- **SessionUnavailableError** thrown when OAuth session cannot be restored
- **AtprotoPublisherService** catches this and returns actionable error: "Link your AT Protocol account to publish events"
- **PublishResult interface** extended with `'error'` action type and `needsOAuthLink` flag

## Changes

| File | Change |
|------|--------|
| `src/pds/pds.errors.ts` | Added `SessionUnavailableError` with `needsOAuthLink` and `did` properties |
| `src/pds/pds-session.service.ts` | Throws `SessionUnavailableError` when OAuth session restoration fails |
| `src/atproto-publisher/atproto-publisher.service.ts` | Catches `SessionUnavailableError`, returns error result with actionable message |
| `src/atproto-publisher/interfaces/publish-result.interface.ts` | Added `'error'` action, `error` message, `needsOAuthLink` fields |

## Test plan

- [x] Unit tests for `SessionUnavailableError` thrown in orphan state
- [x] Unit tests for `SessionUnavailableError` thrown when OAuth restoration fails
- [x] Unit tests for `AtprotoPublisherService` returning error result with actionable message
- [x] All 56 tests in affected files passing

## Related

- Closes: om-x764 (Orphan state: clear error message with link to OAuth)
- Follows: #478 (identity linking, hasActiveSession, handle change)