### PR TITLE
feat(atproto): use granular OAuth scopes instead of transition:generic

### DIFF
--- a/src/auth-bluesky/auth-bluesky.service.ts
+++ b/src/auth-bluesky/auth-bluesky.service.ts
@@ -235,7 +235,7 @@ export class AuthBlueskyService {
       );
     }
 
-    // Get email from session using transition:email scope
+    // Get email from session using account:email scope
     let email: string | undefined;
     let emailConfirmed: boolean = false;
 

--- a/src/utils/bluesky.ts
+++ b/src/utils/bluesky.ts
@@ -64,7 +64,8 @@ export async function initializeOAuthClient(
       redirect_uris: [`${baseUrl}/api/v1/auth/bluesky/t/${tenantId}/callback`],
       grant_types: ['authorization_code', 'refresh_token'],
       response_types: ['code'],
-      scope: 'atproto transition:generic transition:email',
+      scope:
+        'atproto account:email repo:community.lexicon.calendar.event repo:community.lexicon.calendar.rsvp',
       application_type: 'web',
       token_endpoint_auth_method: 'private_key_jwt',
       token_endpoint_auth_signing_alg: 'ES256',


### PR DESCRIPTION
## Summary

Narrows AT Protocol OAuth permissions from broad `transition:generic` to specific collection-level access:

**Before:** `atproto transition:generic transition:email`

**After:** `atproto account:email repo:community.lexicon.calendar.event repo:community.lexicon.calendar.rsvp`

This follows the [AT Protocol granular permissions spec](https://atproto.com/specs/permission) and matches the pattern used by Smokesignal.

## Why

- Users are no longer granting OpenMeet permission to write arbitrary records to their PDS
- Only requests access to calendar event and RSVP collections
- Uses `account:email` (granular) instead of `transition:email` (transitional)
- Better security posture and user trust

## Test plan

- [ ] AT Protocol OAuth login still works
- [ ] Email is retrieved from session
- [ ] Event publishing to PDS works
- [ ] RSVP publishing to PDS works

Ref: om-h2mn