### PR TITLE
fix(attendee): include atprotoUri in showEventAttendees response

### DIFF
--- a/src/event-attendee/event-attendee.service.ts
+++ b/src/event-attendee/event-attendee.service.ts
@@ -373,6 +373,7 @@ export class EventAttendeeService {
       .leftJoin('eventAttendee.user', 'user')
       .leftJoin('user.photo', 'photo')
       .addSelect([
+        'eventAttendee.atprotoUri',
         'user.name',
         'user.slug',
         'user.provider',


### PR DESCRIPTION
## Summary
- Adds `eventAttendee.atprotoUri` to the select fields in `showEventAttendees`
- Enables frontend to display AT Protocol links (@) next to RSVPs

## Problem
The frontend has code to show an @ icon linking to pds.ls for RSVPs published to AT Protocol, but `atprotoUri` was not being returned by the API. The field existed on the entity but wasn't selected in the query builder.

## Test plan
- [x] Unit test added verifying `atprotoUri` is in selected fields
- [ ] After merge + deploy, verify @ icons appear on event attendees page for RSVPs with `atprotoUri`

Fixes: om-icyw