### PR TITLE
fix(atproto): use getSession() for session verification

### DIFF
--- a/src/bluesky/bluesky.service.spec.ts
+++ b/src/bluesky/bluesky.service.spec.ts
@@ -120,6 +120,11 @@ const mockAgentImplementation = {
   getProfile: jest.fn().mockResolvedValue({}),
   com: {
     atproto: {
+      server: {
+        getSession: jest.fn().mockResolvedValue({
+          data: { did: 'test-did', handle: 'test.handle' },
+        }),
+      },
       repo: {
         getRecord: jest.fn(),
         putRecord: jest.fn().mockResolvedValue({
@@ -400,6 +405,30 @@ describe('BlueskyService', () => {
 
         // Assert
         expect(result).toBeDefined();
+      });
+
+      it('should verify session using getSession instead of getProfile', async () => {
+        // Act
+        await service.tryResumeSession('test-tenant', 'test-did');
+
+        // Assert - getSession should be called for session verification (PDS-only)
+        expect(
+          mockAgentImplementation.com.atproto.server.getSession,
+        ).toHaveBeenCalled();
+        // getProfile should NOT be called (it proxies through AppView)
+        expect(mockAgentImplementation.getProfile).not.toHaveBeenCalled();
+      });
+
+      it('should verify session using getSession in resumeSession with retries', async () => {
+        // Act
+        await service.resumeSession('test-tenant', 'test-did');
+
+        // Assert - getSession should be called for session verification (PDS-only)
+        expect(
+          mockAgentImplementation.com.atproto.server.getSession,
+        ).toHaveBeenCalled();
+        // getProfile should NOT be called (it proxies through AppView)
+        expect(mockAgentImplementation.getProfile).not.toHaveBeenCalled();
       });
 
       it('should handle session errors gracefully', async () => {

--- a/src/bluesky/bluesky.service.ts
+++ b/src/bluesky/bluesky.service.ts
@@ -69,8 +69,10 @@ export class BlueskyService {
         }
 
         const agent = new Agent(session);
-        // Verify the session is valid
-        await agent.getProfile({ actor: did });
+        // Verify the session is valid by calling getSession on the PDS directly.
+        // This avoids proxying through the AppView (api.bsky.app) which can't
+        // resolve DIDs registered on private PLC servers.
+        await agent.com.atproto.server.getSession();
         return agent;
       } catch (error) {
         const isSessionDeletedError = error.message?.includes(
@@ -476,8 +478,10 @@ export class BlueskyService {
         throw new Error('No session found');
       }
       const agent = new Agent(session);
-      // Verify the session is valid
-      await agent.getProfile({ actor: did });
+      // Verify the session is valid by calling getSession on the PDS directly.
+      // This avoids proxying through the AppView (api.bsky.app) which can't
+      // resolve DIDs registered on private PLC servers.
+      await agent.com.atproto.server.getSession();
       return agent;
     } catch (error) {
       // Log the error but with a cleaner message


### PR DESCRIPTION
## Summary

- Replace `agent.getProfile()` with `agent.com.atproto.server.getSession()` in `resumeSession()` and `tryResumeSession()` for session verification
- `getProfile()` proxies through the AppView (`api.bsky.app`) which can't resolve DIDs registered on private PLC servers, causing "identity unknown" errors
- `getSession()` validates directly against the PDS — no AppView involvement

Fixes the re-link flow (TC2.3) where session appeared expired after successful re-authentication.

Related: om-jqm7, #495, #496

## Test plan

- [x] Unit tests updated and passing (29/29 in bluesky.service.spec.ts)
- [ ] Deploy to dev, re-test TC2.3 Re-link Account flow
- [ ] Verify session persists after re-link (no "session expired" message)