### PR TITLE
fix(atproto): derive connected status from identity table

### DIFF
--- a/src/bluesky/bluesky.module.ts
+++ b/src/bluesky/bluesky.module.ts
@@ -12,6 +12,7 @@ import { ConfigModule } from '@nestjs/config';
 import { ShadowAccountModule } from '../shadow-account/shadow-account.module';
 import { TenantModule } from '../tenant/tenant.module';
 import { MetricsModule } from '../metrics/metrics.module';
+import { UserAtprotoIdentityModule } from '../user-atproto-identity/user-atproto-identity.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { MetricsModule } from '../metrics/metrics.module';
     ShadowAccountModule,
     TenantModule,
     MetricsModule,
+    UserAtprotoIdentityModule,
     forwardRef(() => EventModule),
   ],
   controllers: [BlueskyController],

--- a/src/event/services/event-management.service.ts
+++ b/src/event/services/event-management.service.ts
@@ -1034,8 +1034,6 @@ export class EventManagementService {
       name: event.name,
       sourceType: event.sourceType,
       sourceId: event.sourceId,
-      userBlueskyConnected:
-        !!this.request.user?.preferences?.bluesky?.connected,
     });
 
     // Get latest user data with preferences to check Bluesky connection state
@@ -1056,10 +1054,10 @@ export class EventManagementService {
       blueskyPreferences: currentUser?.preferences?.bluesky,
     });
 
-    // If the event is a Bluesky event and the user is connected to Bluesky, attempt to delete it there
+    // If the event is a Bluesky event, attempt to delete it there
+    // The remaining structural guards (sourceType, socialId, sourceId, rkey) are sufficient
     if (
       event.sourceType === EventSourceType.BLUESKY && // check if event came from Bluesky
-      currentUser?.preferences?.bluesky?.connected && // confirm user is connected to Bluesky
       currentUser?.socialId && // ensure we have user's DID
       event.sourceId && // ensure we have event creator's DID
       event.sourceData?.rkey // ensure we have the Bluesky record key

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -11,6 +11,7 @@ import { UserListener } from './user.listener';
 import { ConfigModule } from '@nestjs/config';
 import { MatrixModule } from '../matrix/matrix.module';
 import { BlueskyModule } from '../bluesky/bluesky.module';
+import { UserAtprotoIdentityModule } from '../user-atproto-identity/user-atproto-identity.module';
 
 const infrastructurePersistenceModule = RelationalUserPersistenceModule;
 
@@ -23,6 +24,7 @@ const infrastructurePersistenceModule = RelationalUserPersistenceModule;
     RoleModule,
     forwardRef(() => MatrixModule),
     BlueskyModule, // No forwardRef needed - BlueskyIdentityService has no circular dependency
+    UserAtprotoIdentityModule,
   ],
   controllers: [UserController],
   providers: [

--- a/src/user/user.service.find-by-identifier.spec.ts
+++ b/src/user/user.service.find-by-identifier.spec.ts
@@ -20,6 +20,7 @@ import { RoleService } from '../role/role.service';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { FilesS3PresignedService } from '../file/infrastructure/uploader/s3-presigned/file.service';
 import { GlobalMatrixValidationService } from '../matrix/services/global-matrix-validation.service';
+import { UserAtprotoIdentityService } from '../user-atproto-identity/user-atproto-identity.service';
 
 describe('UserService.findByIdentifier - Multi-Identifier Profile Lookup', () => {
   let userService: UserService;
@@ -106,6 +107,16 @@ describe('UserService.findByIdentifier - Multi-Identifier Profile Lookup', () =>
         {
           provide: AtprotoHandleCacheService,
           useValue: atprotoHandleCache,
+        },
+        {
+          provide: UserAtprotoIdentityService,
+          useValue: {
+            findByUserUlid: jest.fn().mockResolvedValue(null),
+            findByDid: jest.fn().mockResolvedValue(null),
+            create: jest.fn(),
+            deleteByUserUlid: jest.fn(),
+            update: jest.fn(),
+          },
         },
       ],
     }).compile();


### PR DESCRIPTION
## Summary
- Deprecates `preferences.bluesky.connected` setting in favor of deriving connected status from the `userAtprotoIdentities` table (source of truth)
- Removes `connected` check from event deletion guard in `event-management.service.ts`
- Derives `connected` from identity table in `bluesky.service.ts`, `bluesky.controller.ts`, and `user.service.ts`

Fixes OpenMeet-Team/openmeet-api#463

## Why
The `preferences.bluesky.connected` flag was unreliable — it could be lost by the shallow preferences merge in `auth.service.ts`, and historical signup code paths didn't always set it. Since every user now gets an ATProto identity, the `userAtprotoIdentities` table is the authoritative source.

## Changes
- **event-management.service.ts**: Remove `connected` preference check from Bluesky event deletion guard
- **bluesky.service.ts**: Inject `UserAtprotoIdentityService`, derive `connected` from identity table in `getConnectionStatus()`
- **bluesky.controller.ts**: Inject `UserAtprotoIdentityService`, derive `connected` from identity table in user profile response
- **bluesky.module.ts**: Add `UserAtprotoIdentityModule` import
- **user.service.ts**: Inject `UserAtprotoIdentityService`, derive `socialProfiles.atprotocol.connected` from identity table
- **user.module.ts**: Add `UserAtprotoIdentityModule` import

## Test plan
- [x] Unit tests: 1637/1637 passing (3 new bluesky.service, 1 new event-management, 2 new user.service tests)
- [x] E2e: atproto-publishing 11/11, identity-linking 11/12 (1 pre-existing infra issue)
- [x] Local Docker: avatar displays, connected status correct with prod data restore