### PR TITLE
fix(atproto): fix calendar event record schema validation

### DIFF
--- a/src/bluesky/BlueskyTypes.ts
+++ b/src/bluesky/BlueskyTypes.ts
@@ -17,6 +17,7 @@ export interface BlueskyUriLocation {
 export type BlueskyLocation = BlueskyGeoLocation | BlueskyUriLocation;
 
 export interface BlueskyEventUri {
+  $type?: 'community.lexicon.calendar.event#uri';
   uri: string;
   name?: string;
 }

--- a/src/bluesky/bluesky.service.spec.ts
+++ b/src/bluesky/bluesky.service.spec.ts
@@ -104,7 +104,16 @@ const mockBlueskyIdentityService = {
 };
 
 const mockConfigService = {
-  get: jest.fn(),
+  get: jest.fn().mockImplementation((key: string) => {
+    const map: Record<string, string | undefined> = {
+      'file.cloudfrontDistributionDomain': 'cdn.example.com',
+      'file.driver': 'cloudfront',
+      'app.backendDomain': 'https://api.openmeet.net',
+      APP_URL: 'https://platform.openmeet.net',
+      BACKEND_DOMAIN: 'https://api.openmeet.net',
+    };
+    return map[key];
+  }),
 };
 
 const mockTenantConnectionService = {
@@ -1016,8 +1025,8 @@ describe('BlueskyService', () => {
     });
 
     it('should preserve existing rkey when updating events', async () => {
-      // Arrange - event with existing rkey in sourceData
-      const existingRkey = 'existing-rkey-123';
+      // Arrange - event with existing valid TID rkey in sourceData
+      const existingRkey = '3ktest1234abc';
       const event = {
         name: 'Test Event Update',
         description: 'Test Description',
@@ -1084,8 +1093,8 @@ describe('BlueskyService', () => {
     });
 
     it('should use sourceData.rkey when atprotoRkey is not set', async () => {
-      // Arrange - event with only sourceData.rkey
-      const sourceDataRkey = 'source-data-rkey';
+      // Arrange - event with only sourceData.rkey (valid TID)
+      const sourceDataRkey = '3kabcdefghijk';
       const event = {
         name: 'Test Event with Source Data',
         description: 'Test Description',
@@ -1115,6 +1124,304 @@ describe('BlueskyService', () => {
 
       // Assert - should use sourceData.rkey
       expect(result.rkey).toBe(sourceDataRkey);
+    });
+
+    // Bug 1: Image URI should be a full URL, not raw DB path
+    it('should transform image path to a full URL using instanceToPlain', async () => {
+      // Arrange - event with a raw DB path (tenantId/filename.jpg)
+      const event = {
+        name: 'Test Event with Image',
+        description: 'Test Description',
+        startDate: new Date('2023-12-01T12:00:00Z'),
+        endDate: new Date('2023-12-01T14:00:00Z'),
+        type: EventType.InPerson,
+        status: EventStatus.Published,
+        createdAt: new Date('2023-11-01T00:00:00Z'),
+        slug: 'test-event-image',
+        image: {
+          path: 'lsdfaopkljdfs/f1fd62ebcddf53472a2ab.jpg',
+        },
+      } as EventEntity;
+
+      const did = 'test-did';
+      const handle = 'test.handle';
+      const tenantId = 'test-tenant';
+
+      // Act
+      await service.createEventRecord(event, did, handle, tenantId);
+
+      // Assert - the image URI should NOT be the raw DB path
+      const putRecordCall =
+        mockAgentImplementation.com.atproto.repo.putRecord.mock.calls[0][0];
+      const imageUri = putRecordCall.record.uris.find(
+        (u: any) => u.name === 'Event Image',
+      );
+      expect(imageUri).toBeDefined();
+      // The raw path should have been transformed - it should NOT be the bare DB value
+      expect(imageUri.uri).not.toBe('lsdfaopkljdfs/f1fd62ebcddf53472a2ab.jpg');
+      // It should be a full CloudFront URL
+      expect(imageUri.uri).toBe(
+        'https://cdn.example.com/lsdfaopkljdfs/f1fd62ebcddf53472a2ab.jpg',
+      );
+    });
+
+    // Bug 2: locationOnline should be normalized to include protocol
+    it('should normalize locationOnline to include https:// protocol in uris array', async () => {
+      // Arrange - event with locationOnline missing protocol
+      const event = {
+        name: 'Test Event Online',
+        description: 'Test Description',
+        startDate: new Date('2023-12-01T12:00:00Z'),
+        endDate: new Date('2023-12-01T14:00:00Z'),
+        type: EventType.Online,
+        status: EventStatus.Published,
+        createdAt: new Date('2023-11-01T00:00:00Z'),
+        slug: 'test-event-online-noproto',
+        locationOnline: 'npmx.dev',
+      } as EventEntity;
+
+      const did = 'test-did';
+      const handle = 'test.handle';
+      const tenantId = 'test-tenant';
+
+      // Act
+      await service.createEventRecord(event, did, handle, tenantId);
+
+      // Assert - the online meeting link in uris should have https:// prefix
+      const putRecordCall =
+        mockAgentImplementation.com.atproto.repo.putRecord.mock.calls[0][0];
+      const onlineUri = putRecordCall.record.uris.find(
+        (u: any) => u.name === 'Online Meeting Link',
+      );
+      expect(onlineUri).toBeDefined();
+      expect(onlineUri.uri).toBe('https://npmx.dev');
+    });
+
+    it('should not double-prefix locationOnline that already has https://', async () => {
+      // Arrange - event with locationOnline that already has protocol
+      const event = {
+        name: 'Test Event Online',
+        description: 'Test Description',
+        startDate: new Date('2023-12-01T12:00:00Z'),
+        endDate: new Date('2023-12-01T14:00:00Z'),
+        type: EventType.Online,
+        status: EventStatus.Published,
+        createdAt: new Date('2023-11-01T00:00:00Z'),
+        slug: 'test-event-online-withproto',
+        locationOnline: 'https://zoom.us/j/123',
+      } as EventEntity;
+
+      const did = 'test-did';
+      const handle = 'test.handle';
+      const tenantId = 'test-tenant';
+
+      // Act
+      await service.createEventRecord(event, did, handle, tenantId);
+
+      // Assert - should not double-prefix
+      const putRecordCall =
+        mockAgentImplementation.com.atproto.repo.putRecord.mock.calls[0][0];
+      const onlineUri = putRecordCall.record.uris.find(
+        (u: any) => u.name === 'Online Meeting Link',
+      );
+      expect(onlineUri).toBeDefined();
+      expect(onlineUri.uri).toBe('https://zoom.us/j/123');
+    });
+
+    // Bug 3: null values should be stripped from the record
+    it('should strip null values from the record before publishing', async () => {
+      // Arrange - event with null endDate (like an open-ended event)
+      const event = {
+        name: 'Test Event No End',
+        description: 'Test Description',
+        startDate: new Date('2023-12-01T12:00:00Z'),
+        endDate: null,
+        type: EventType.InPerson,
+        status: EventStatus.Published,
+        createdAt: new Date('2023-11-01T00:00:00Z'),
+        slug: 'test-event-no-end',
+      } as unknown as EventEntity;
+
+      const did = 'test-did';
+      const handle = 'test.handle';
+      const tenantId = 'test-tenant';
+
+      // Act
+      await service.createEventRecord(event, did, handle, tenantId);
+
+      // Assert - the record should NOT have endsAt: null
+      const putRecordCall =
+        mockAgentImplementation.com.atproto.repo.putRecord.mock.calls[0][0];
+      const record = putRecordCall.record;
+      expect(record).not.toHaveProperty('endsAt');
+      // Other fields should still be present
+      expect(record).toHaveProperty('startsAt');
+      expect(record).toHaveProperty('name');
+    });
+
+    it('should strip undefined values from the record before publishing', async () => {
+      // Arrange - event with undefined description
+      const event = {
+        name: 'Test Event No Desc',
+        description: undefined,
+        startDate: new Date('2023-12-01T12:00:00Z'),
+        endDate: new Date('2023-12-01T14:00:00Z'),
+        type: EventType.InPerson,
+        status: EventStatus.Published,
+        createdAt: new Date('2023-11-01T00:00:00Z'),
+        slug: 'test-event-no-desc',
+      } as unknown as EventEntity;
+
+      const did = 'test-did';
+      const handle = 'test.handle';
+      const tenantId = 'test-tenant';
+
+      // Act
+      await service.createEventRecord(event, did, handle, tenantId);
+
+      // Assert - the record should NOT have description: undefined
+      const putRecordCall =
+        mockAgentImplementation.com.atproto.repo.putRecord.mock.calls[0][0];
+      const record = putRecordCall.record;
+      expect(record).not.toHaveProperty('description');
+    });
+
+    // Bug 4: Online location URI in locations array should also be normalized
+    it('should normalize locationOnline URI in the locations array', async () => {
+      // Arrange - event with locationOnline missing protocol
+      const event = {
+        name: 'Test Hybrid Event No Proto',
+        description: 'Test Description',
+        startDate: new Date('2023-12-01T12:00:00Z'),
+        endDate: new Date('2023-12-01T14:00:00Z'),
+        type: EventType.Hybrid,
+        status: EventStatus.Published,
+        createdAt: new Date('2023-11-01T00:00:00Z'),
+        slug: 'test-hybrid-noproto',
+        location: 'Conference Center',
+        lat: 51.5074,
+        lon: -0.1278,
+        locationOnline: 'meet.example.com/room',
+      } as EventEntity;
+
+      const did = 'test-did';
+      const handle = 'test.handle';
+      const tenantId = 'test-tenant';
+
+      // Act
+      await service.createEventRecord(event, did, handle, tenantId);
+
+      // Assert - the locations array URI entry should have the protocol
+      const putRecordCall =
+        mockAgentImplementation.com.atproto.repo.putRecord.mock.calls[0][0];
+      const uriLocation = putRecordCall.record.locations.find(
+        (loc: any) => loc.$type === 'community.lexicon.calendar.event#uri',
+      );
+      expect(uriLocation).toBeDefined();
+      expect(uriLocation.uri).toBe('https://meet.example.com/room');
+    });
+
+    // Bug 5: sourceData.rkey should be validated as a TID
+    it('should use non-TID sourceData.rkey as-is to preserve record identity', async () => {
+      // Arrange - event with a non-TID rkey in sourceData (e.g., from an external source)
+      const event = {
+        name: 'Test Event Non-TID Rkey',
+        description: 'Test Description',
+        startDate: new Date('2023-12-01T12:00:00Z'),
+        endDate: new Date('2023-12-01T14:00:00Z'),
+        type: EventType.InPerson,
+        status: EventStatus.Published,
+        createdAt: new Date('2023-11-01T00:00:00Z'),
+        slug: 'test-event-non-tid-rkey',
+        atprotoRkey: null,
+        sourceData: {
+          rkey: 'my-custom-rkey',
+        },
+      } as EventEntity;
+
+      const did = 'test-did';
+      const handle = 'test.handle';
+      const tenantId = 'test-tenant';
+
+      // Act
+      const result = await service.createEventRecord(
+        event,
+        did,
+        handle,
+        tenantId,
+      );
+
+      // Assert - should use the rkey as-is to preserve record identity
+      expect(result.rkey).toBe('my-custom-rkey');
+    });
+
+    it('should accept valid TID in sourceData.rkey', async () => {
+      // Arrange - event with a valid TID rkey in sourceData
+      // A valid TID is 13 chars of base32-sort characters
+      const validTid = '3ktest1234abc';
+      const event = {
+        name: 'Test Event Good Rkey',
+        description: 'Test Description',
+        startDate: new Date('2023-12-01T12:00:00Z'),
+        endDate: new Date('2023-12-01T14:00:00Z'),
+        type: EventType.InPerson,
+        status: EventStatus.Published,
+        createdAt: new Date('2023-11-01T00:00:00Z'),
+        slug: 'test-event-good-rkey',
+        atprotoRkey: null,
+        sourceData: {
+          rkey: validTid,
+        },
+      } as EventEntity;
+
+      const did = 'test-did';
+      const handle = 'test.handle';
+      const tenantId = 'test-tenant';
+
+      // Act
+      const result = await service.createEventRecord(
+        event,
+        did,
+        handle,
+        tenantId,
+      );
+
+      // Assert - should use the valid TID rkey
+      expect(result.rkey).toBe(validTid);
+    });
+
+    // Bug 2+4 combined: uris array items should all have $type
+    it('should include $type on all uri entries in the uris array', async () => {
+      // Arrange
+      const event = {
+        name: 'Test Event URIs Type',
+        description: 'Test Description',
+        startDate: new Date('2023-12-01T12:00:00Z'),
+        endDate: new Date('2023-12-01T14:00:00Z'),
+        type: EventType.Online,
+        status: EventStatus.Published,
+        createdAt: new Date('2023-11-01T00:00:00Z'),
+        slug: 'test-event-uris-type',
+        locationOnline: 'https://zoom.us/j/123',
+      } as EventEntity;
+
+      const did = 'test-did';
+      const handle = 'test.handle';
+      const tenantId = 'test-tenant';
+
+      // Act
+      await service.createEventRecord(event, did, handle, tenantId);
+
+      // Assert - all uris entries should have $type
+      const putRecordCall =
+        mockAgentImplementation.com.atproto.repo.putRecord.mock.calls[0][0];
+      const uris = putRecordCall.record.uris;
+      for (const uri of uris) {
+        expect(uri).toHaveProperty(
+          '$type',
+          'community.lexicon.calendar.event#uri',
+        );
+      }
     });
   });
 });

--- a/src/bluesky/bluesky.service.ts
+++ b/src/bluesky/bluesky.service.ts
@@ -6,6 +6,7 @@ import { UserEntity } from '../user/infrastructure/persistence/relational/entiti
 import { Agent } from '@atproto/api';
 import { NodeOAuthClient } from '@atproto/oauth-client-node';
 import { TID } from '@atproto/common-web';
+import { instanceToPlain } from 'class-transformer';
 import { initializeOAuthClient } from '../utils/bluesky';
 import { ElastiCacheService } from '../elasticache/elasticache.service';
 import { delay } from '../utils/delay';
@@ -20,6 +21,27 @@ import { REQUEST } from '@nestjs/core';
 import { TenantConnectionService } from '../tenant/tenant.service';
 import { BlueskyIdService } from './bluesky-id.service';
 import { BlueskyIdentityService } from './bluesky-identity.service';
+
+/**
+ * Ensure a URL string has a protocol prefix.
+ * If no protocol is present, prepends https://.
+ */
+function ensureUri(url: string): string {
+  if (!/^https?:\/\//i.test(url)) {
+    return `https://${url}`;
+  }
+  return url;
+}
+
+/**
+ * Remove all properties with null or undefined values from an object.
+ * AT Protocol does not allow null for optional fields -- they must be omitted.
+ */
+function stripNullish(obj: Record<string, any>): Record<string, any> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, v]) => v !== null && v !== undefined),
+  );
+}
 
 @Injectable()
 export class BlueskyService {
@@ -49,6 +71,37 @@ export class BlueskyService {
       this.configService,
       this.elasticacheService,
     );
+  }
+
+  /**
+   * Build a full URL for an image path.
+   * If the path is already a full URL, return it as-is.
+   * Otherwise, construct from CloudFront or backend domain config.
+   */
+  private buildImageUrl(path: string): string {
+    // Already a full URL
+    if (/^https?:\/\//i.test(path)) {
+      return path;
+    }
+
+    const cloudfrontDomain = this.configService.get<string>(
+      'file.cloudfrontDistributionDomain',
+      { infer: true },
+    );
+    if (cloudfrontDomain) {
+      return `https://${cloudfrontDomain}/${path}`;
+    }
+
+    const backendDomain =
+      this.configService.get<string>('app.backendDomain', { infer: true }) ||
+      this.configService.get<string>('BACKEND_DOMAIN', { infer: true });
+    if (backendDomain) {
+      const separator = path.startsWith('/') ? '' : '/';
+      return `${backendDomain}${separator}${path}`;
+    }
+
+    // Last resort: prepend https://
+    return `https://${path}`;
   }
 
   async resumeSession(tenantId: string, did: string): Promise<Agent> {
@@ -264,7 +317,6 @@ export class BlueskyService {
         });
 
         // Use instanceToPlain to force the Transform decorator to run
-        const { instanceToPlain } = await import('class-transformer');
         event.image = instanceToPlain(event.image) as any;
 
         this.logger.debug('Transformed image', {
@@ -310,7 +362,7 @@ export class BlueskyService {
       if (event.locationOnline) {
         locations.push({
           $type: 'community.lexicon.calendar.event#uri',
-          uri: event.locationOnline,
+          uri: ensureUri(event.locationOnline),
           name: 'Online Meeting Link',
         });
       }
@@ -326,7 +378,13 @@ export class BlueskyService {
         this.logger.debug(`Using pre-generated atprotoRkey: ${rkey}`);
       } else if (event.sourceData?.rkey) {
         rkey = event.sourceData.rkey as string;
-        this.logger.debug(`Using existing sourceData.rkey: ${rkey}`);
+        if (!TID.is(rkey)) {
+          this.logger.warn(
+            `sourceData.rkey "${rkey}" is not a valid TID — using as-is to preserve record identity`,
+          );
+        } else {
+          this.logger.debug(`Using existing sourceData.rkey: ${rkey}`);
+        }
       } else {
         rkey = TID.nextStr();
         this.logger.warn(
@@ -337,8 +395,13 @@ export class BlueskyService {
       // Prepare uris array with image if it exists
       const uris: BlueskyEventUri[] = [];
       if (event.image?.path) {
+        // Build the full image URL from the raw DB path.
+        // instanceToPlain may not fire @Transform on plain objects, so we
+        // construct the URL using config -- the same approach as embed.service.ts.
+        const imageUrl = this.buildImageUrl(event.image.path);
         uris.push({
-          uri: event.image.path,
+          $type: 'community.lexicon.calendar.event#uri',
+          uri: imageUrl,
           name: 'Event Image',
         });
       } else if (event.image) {
@@ -352,7 +415,8 @@ export class BlueskyService {
       // Add online location to uris if it exists
       if (event.locationOnline) {
         uris.push({
-          uri: event.locationOnline,
+          $type: 'community.lexicon.calendar.event#uri',
+          uri: ensureUri(event.locationOnline),
           name: 'Online Meeting Link',
         });
       }
@@ -373,6 +437,7 @@ export class BlueskyService {
       if (!existingOpenMeetUri) {
         this.logger.debug(`Adding OpenMeet event URL: ${openmeetEventUrl}`);
         uris.push({
+          $type: 'community.lexicon.calendar.event#uri',
           uri: openmeetEventUrl,
           name: 'OpenMeet Event',
         });
@@ -382,7 +447,7 @@ export class BlueskyService {
         );
       }
 
-      const recordData: any = {
+      const recordData: any = stripNullish({
         $type: 'community.lexicon.calendar.event',
         name: event.name,
         description: event.description,
@@ -402,7 +467,7 @@ export class BlueskyService {
         status: statusMap[event.status] || statusMap['published'],
         locations,
         uris,
-      };
+      });
 
       // Add openmeet-specific metadata in record
       if (event.series) {


### PR DESCRIPTION
## Summary
- Fix AT Protocol calendar event records failing schema validation on PDS
- Image URIs now use full URLs (CloudFront/backend domain) instead of raw DB paths
- `locationOnline` values normalized with `https://` prefix when protocol is missing
- Null/undefined values stripped from records (AT Protocol requires field omission, not null)
- Added `$type: 'community.lexicon.calendar.event#uri'` to all URI objects
- Non-TID `sourceData.rkey` preserved as-is with warning (avoids creating duplicate records)

## Test plan
- [x] 9 new unit tests covering all 5 fixes (38 total passing)
- [ ] Create event with image on dev — verify `uris[0].uri` is a full URL
- [ ] Create event with online location like `zoom.us/meeting/123` — verify URI has `https://` prefix
- [ ] Create event without end date — verify `endsAt` is omitted, not null
- [ ] Check record on PDS inspector — verify schema validation passes