### PR TITLE
chore: update copyright year to 2026

### DIFF
--- a/src/mail/mail-templates/default.hbs
+++ b/src/mail/mail-templates/default.hbs
@@ -150,7 +150,7 @@
     </div>
 
     <div class="footer">
-      <p>© 2024 {{tenantConfig.name}}. All rights reserved.</p>
+      <p>© 2026 {{tenantConfig.name}}. All rights reserved.</p>
       <p>
         <a href="{{tenantConfig.companyDomain}}/privacy" style="color: var(--q-grey-4)">Privacy Policy</a> |
         <a href="{{tenantConfig.companyDomain}}/terms" style="color: var(--q-grey-4)">Terms of Service</a>


### PR DESCRIPTION
## Summary
- Update hardcoded copyright year from 2024 to 2026 in `src/mail/mail-templates/default.hbs`
- The newer MJML email template already uses dynamic `currentYear` — no change needed there

Fixes #441

## Test plan
- [x] `npm run build` passes
- [x] Verified only copyright year in email footer changed