### PR TITLE
refactor: extract markAtprotoSynced() helper to fix double-publish bug

### DIFF
--- a/src/atproto-publisher/atproto-sync-scheduler.spec.ts
+++ b/src/atproto-publisher/atproto-sync-scheduler.spec.ts
@@ -43,6 +43,7 @@ describe('AtprotoSyncScheduler', () => {
   let mockEventRepository: {
     createQueryBuilder: jest.Mock;
     update: jest.Mock;
+    target: typeof EventEntity;
   };
   let mockQueryBuilder: Record<string, jest.Mock>;
   let mockUpdateQueryBuilder: Record<string, jest.Mock>;
@@ -74,6 +75,7 @@ describe('AtprotoSyncScheduler', () => {
         return mockUpdateQueryBuilder;
       }),
       update: jest.fn().mockResolvedValue(undefined),
+      target: EventEntity,
     };
 
     const mockTenantConnectionService = {

--- a/src/atproto-publisher/atproto-sync-scheduler.ts
+++ b/src/atproto-publisher/atproto-sync-scheduler.ts
@@ -5,6 +5,7 @@ import { TenantConnectionService } from '../tenant/tenant.service';
 import { ElastiCacheService } from '../elasticache/elasticache.service';
 import { AtprotoPublisherService } from './atproto-publisher.service';
 import { EventEntity } from '../event/infrastructure/persistence/relational/entities/event.entity';
+import { markAtprotoSynced } from './atproto-sync.utils';
 
 @Injectable()
 export class AtprotoSyncScheduler {
@@ -95,36 +96,18 @@ export class AtprotoSyncScheduler {
         );
 
         if (result.action === 'updated' || result.action === 'published') {
-          // Use QueryBuilder with raw SQL now() so that atprotoSyncedAt and
-          // @UpdateDateColumn's updatedAt get the same database timestamp.
-          // Using new Date() from JS creates a 1-7ms gap where updatedAt
-          // (set by the DB) is always slightly ahead, causing infinite re-syncs.
-          await eventRepository
-            .createQueryBuilder()
-            .update(EventEntity)
-            .set({
-              atprotoUri: result.atprotoUri,
-              atprotoRkey: result.atprotoRkey,
-              atprotoCid: result.atprotoCid,
-              atprotoSyncedAt: () => 'now()',
-            })
-            .where('id = :id', { id: event.id })
-            .execute();
+          await markAtprotoSynced(eventRepository, event.id, {
+            atprotoUri: result.atprotoUri,
+            atprotoRkey: result.atprotoRkey,
+            atprotoCid: result.atprotoCid,
+          });
           this.logger.log(`Retry-synced event ${event.slug} to ATProto`);
         }
 
         if (result.action === 'conflict') {
           // Stop retrying — accept that PDS has diverged.
           // Firehose will deliver the PDS version for reconciliation.
-          // Use raw SQL now() to match @UpdateDateColumn's timestamp (see above).
-          await eventRepository
-            .createQueryBuilder()
-            .update(EventEntity)
-            .set({
-              atprotoSyncedAt: () => 'now()',
-            })
-            .where('id = :id', { id: event.id })
-            .execute();
+          await markAtprotoSynced(eventRepository, event.id);
           this.logger.warn(
             `Conflict retrying event ${event.slug} — PDS record was modified externally. Marked as synced to stop retry loop.`,
             { tenantId, slug: event.slug },

--- a/src/atproto-publisher/atproto-sync.utils.spec.ts
+++ b/src/atproto-publisher/atproto-sync.utils.spec.ts
@@ -1,0 +1,80 @@
+import { markAtprotoSynced } from './atproto-sync.utils';
+import { EventEntity } from '../event/infrastructure/persistence/relational/entities/event.entity';
+
+describe('markAtprotoSynced', () => {
+  let mockQueryBuilder: Record<string, jest.Mock>;
+  let mockRepo: {
+    createQueryBuilder: jest.Mock;
+    target: typeof EventEntity;
+  };
+
+  beforeEach(() => {
+    mockQueryBuilder = {
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      execute: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockRepo = {
+      createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+      target: EventEntity,
+    };
+  });
+
+  it('should use QueryBuilder with raw SQL now() for atprotoSyncedAt', async () => {
+    await markAtprotoSynced(mockRepo as any, 42);
+
+    expect(mockRepo.createQueryBuilder).toHaveBeenCalledWith();
+    expect(mockQueryBuilder.update).toHaveBeenCalledWith(EventEntity);
+
+    const setArg = mockQueryBuilder.set.mock.calls[0][0];
+    expect(typeof setArg.atprotoSyncedAt).toBe('function');
+    expect(setArg.atprotoSyncedAt()).toBe('now()');
+
+    expect(mockQueryBuilder.where).toHaveBeenCalledWith('id = :id', { id: 42 });
+    expect(mockQueryBuilder.execute).toHaveBeenCalled();
+  });
+
+  it('should include optional fields when provided', async () => {
+    await markAtprotoSynced(mockRepo as any, 7, {
+      atprotoUri: 'at://did:plc:abc/community.lexicon.calendar.event/rkey1',
+      atprotoRkey: 'rkey1',
+      atprotoCid: 'cid-123',
+    });
+
+    const setArg = mockQueryBuilder.set.mock.calls[0][0];
+    expect(setArg.atprotoUri).toBe(
+      'at://did:plc:abc/community.lexicon.calendar.event/rkey1',
+    );
+    expect(setArg.atprotoRkey).toBe('rkey1');
+    expect(setArg.atprotoCid).toBe('cid-123');
+    expect(typeof setArg.atprotoSyncedAt).toBe('function');
+    expect(setArg.atprotoSyncedAt()).toBe('now()');
+  });
+
+  it('should only set atprotoSyncedAt when no fields provided', async () => {
+    await markAtprotoSynced(mockRepo as any, 99);
+
+    const setArg = mockQueryBuilder.set.mock.calls[0][0];
+    // Should only have atprotoSyncedAt, no uri/rkey/cid
+    expect(Object.keys(setArg)).toEqual(['atprotoSyncedAt']);
+    expect(typeof setArg.atprotoSyncedAt).toBe('function');
+    expect(setArg.atprotoSyncedAt()).toBe('now()');
+  });
+
+  it('should support partial fields (e.g., only uri and rkey, no cid)', async () => {
+    await markAtprotoSynced(mockRepo as any, 5, {
+      atprotoUri: 'at://did:plc:xyz/community.lexicon.calendar.event/rkey2',
+      atprotoRkey: 'rkey2',
+    });
+
+    const setArg = mockQueryBuilder.set.mock.calls[0][0];
+    expect(setArg.atprotoUri).toBe(
+      'at://did:plc:xyz/community.lexicon.calendar.event/rkey2',
+    );
+    expect(setArg.atprotoRkey).toBe('rkey2');
+    expect(setArg.atprotoCid).toBeUndefined();
+    expect(typeof setArg.atprotoSyncedAt).toBe('function');
+  });
+});

--- a/src/atproto-publisher/atproto-sync.utils.ts
+++ b/src/atproto-publisher/atproto-sync.utils.ts
@@ -1,0 +1,28 @@
+import { Repository } from 'typeorm';
+import { EventEntity } from '../event/infrastructure/persistence/relational/entities/event.entity';
+
+/**
+ * Update an event's ATProto sync metadata using database now() so that
+ * atprotoSyncedAt and @UpdateDateColumn's updatedAt get the same timestamp.
+ * Using new Date() from JS creates a 1-7ms gap where updatedAt (set by the DB)
+ * is always slightly ahead, causing the sync scheduler to re-process the event.
+ */
+export async function markAtprotoSynced(
+  repo: Repository<EventEntity>,
+  id: number,
+  fields?: {
+    atprotoUri?: string;
+    atprotoRkey?: string;
+    atprotoCid?: string;
+  },
+): Promise<void> {
+  await repo
+    .createQueryBuilder()
+    .update(repo.target)
+    .set({
+      ...fields,
+      atprotoSyncedAt: () => 'now()',
+    })
+    .where('id = :id', { id })
+    .execute();
+}

--- a/src/event/services/event-management.service.ts
+++ b/src/event/services/event-management.service.ts
@@ -49,6 +49,7 @@ import { GroupRole } from '../../core/constants/constant';
 import { EventQueryService } from '../services/event-query.service';
 import { BLUESKY_COLLECTIONS } from '../../bluesky/BlueskyTypes';
 import { AtprotoPublisherService } from '../../atproto-publisher/atproto-publisher.service';
+import { markAtprotoSynced } from '../../atproto-publisher/atproto-sync.utils';
 import { SyncAtprotoResponseDto } from '../dto/sync-atproto-response.dto';
 import { TID } from '@atproto/common-web';
 
@@ -508,15 +509,11 @@ export class EventManagementService {
         publishResult.action === 'updated'
       ) {
         // Save AT Protocol metadata to database
-        await this.eventRepository.update(
-          { id: eventToPublish.id },
-          {
-            atprotoUri: publishResult.atprotoUri,
-            atprotoRkey: publishResult.atprotoRkey,
-            atprotoCid: publishResult.atprotoCid,
-            atprotoSyncedAt: new Date(),
-          },
-        );
+        await markAtprotoSynced(this.eventRepository, eventToPublish.id, {
+          atprotoUri: publishResult.atprotoUri,
+          atprotoRkey: publishResult.atprotoRkey,
+          atprotoCid: publishResult.atprotoCid,
+        });
 
         this.logger.debug(
           `Published event ${eventToPublish.slug} to AT Protocol: ${publishResult.atprotoUri}`,
@@ -1013,15 +1010,11 @@ export class EventManagementService {
           publishResult.action === 'updated'
         ) {
           // Save AT Protocol metadata to database
-          await this.eventRepository.update(
-            { id: updatedEvent.id },
-            {
-              atprotoUri: publishResult.atprotoUri,
-              atprotoRkey: publishResult.atprotoRkey,
-              atprotoCid: publishResult.atprotoCid,
-              atprotoSyncedAt: new Date(),
-            },
-          );
+          await markAtprotoSynced(this.eventRepository, updatedEvent.id, {
+            atprotoUri: publishResult.atprotoUri,
+            atprotoRkey: publishResult.atprotoRkey,
+            atprotoCid: publishResult.atprotoCid,
+          });
 
           this.logger.debug(
             `Published event ${updatedEvent.slug} to AT Protocol: ${publishResult.atprotoUri}`,
@@ -2418,15 +2411,11 @@ export class EventManagementService {
 
     // If publish succeeded, update the event with AT Protocol metadata
     if (action === 'created' || action === 'updated') {
-      await this.eventRepository.update(
-        { id: event.id },
-        {
-          atprotoUri: publishResult.atprotoUri,
-          atprotoRkey: publishResult.atprotoRkey,
-          atprotoCid: publishResult.atprotoCid,
-          atprotoSyncedAt: new Date(),
-        },
-      );
+      await markAtprotoSynced(this.eventRepository, event.id, {
+        atprotoUri: publishResult.atprotoUri,
+        atprotoRkey: publishResult.atprotoRkey,
+        atprotoCid: publishResult.atprotoCid,
+      });
 
       this.logger.debug(
         `Synced event ${slug} to AT Protocol: ${publishResult.atprotoUri}`,


### PR DESCRIPTION
## Summary

- Extracts a `markAtprotoSynced()` helper that uses database `now()` instead of JavaScript `new Date()` for `atprotoSyncedAt` timestamps
- Fixes 3 call sites in `event-management.service.ts` that caused every event to be double-published (once directly, once by the sync scheduler)
- Refactors 2 already-correct sites in `atproto-sync-scheduler.ts` to use the same helper

### Root cause

PR #524 fixed the sync scheduler's `atprotoSyncedAt` writes to use DB `now()`, but the **direct publish path** in `event-management.service.ts` still used `new Date()` (JS clock). TypeORM's `@UpdateDateColumn` sets `updatedAt` via DB `now()`, creating a 1-7ms gap where `updatedAt > atprotoSyncedAt` — making every freshly-published event appear "stale" to the sync scheduler.

### Verified in dev

After deploying PR #524, both `first-icefie` and `second-ffmf0` events were published directly then re-synced on the next scheduler cycle. This PR eliminates that double-publish.

## Test plan

- [x] 4 new unit tests for `markAtprotoSynced()` helper
- [x] Updated mocks in `event-management.service.spec.ts` and `atproto-sync-scheduler.spec.ts`
- [x] All 1798 tests passing (134 suites)
- [ ] After deploy to dev: create an event, verify no "Retry-synced" log appears on next scheduler cycle