### PR TITLE
perf(category): remove cache:true and eager ManyToMany loading

### DIFF
--- a/src/category/category.service.spec.ts
+++ b/src/category/category.service.spec.ts
@@ -50,7 +50,7 @@ describe('CategoryService', () => {
   });
 
   describe('findAll', () => {
-    it('should return all categories with minimal fields when loadRelations is false', async () => {
+    it('should return all categories with only id and name selected and no relations or cache', async () => {
       const mockCategories = [
         { id: 1, name: 'Category 1' },
         { id: 2, name: 'Category 2' },
@@ -59,31 +59,11 @@ describe('CategoryService', () => {
       (mockCategoryRepository.find as jest.Mock).mockResolvedValue(
         mockCategories,
       );
-      const result = await service.findAll(false);
-      expect(result).toEqual(mockCategories);
-    });
 
-    it('should return categories with relations when loadRelations is true', async () => {
-      const mockCategories = [
-        {
-          id: 1,
-          name: 'Category 1',
-          subCategories: [],
-          events: [],
-          groups: [],
-        },
-      ];
-
-      (mockCategoryRepository.find as jest.Mock).mockResolvedValue(
-        mockCategories,
-      );
-
-      const result = await service.findAll(true);
+      const result = await service.findAll();
 
       expect(mockCategoryRepository.find).toHaveBeenCalledWith({
         select: ['id', 'name'],
-        relations: ['subCategories', 'events', 'groups'],
-        cache: true,
       });
       expect(result).toEqual(mockCategories);
     });
@@ -92,7 +72,37 @@ describe('CategoryService', () => {
       const mockError = new Error('Database error');
       (mockCategoryRepository.find as jest.Mock).mockRejectedValue(mockError);
 
-      await expect(service.findAll(false)).rejects.toThrow(mockError);
+      await expect(service.findAll()).rejects.toThrow(mockError);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should load only subCategories relation, not events or groups', async () => {
+      const mockCategory = {
+        id: 1,
+        name: 'Category 1',
+        subCategories: [],
+      };
+
+      (mockCategoryRepository.findOne as jest.Mock).mockResolvedValue(
+        mockCategory,
+      );
+
+      const result = await service.findOne(1);
+
+      expect(mockCategoryRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 1 },
+        relations: ['subCategories'],
+      });
+      expect(result).toEqual(mockCategory);
+    });
+
+    it('should return null when category is not found', async () => {
+      (mockCategoryRepository.findOne as jest.Mock).mockResolvedValue(null);
+
+      const result = await service.findOne(999);
+
+      expect(result).toBeNull();
     });
   });
 

--- a/src/category/category.service.ts
+++ b/src/category/category.service.ts
@@ -34,7 +34,7 @@ export class CategoryService {
   }
 
   @Trace('category.findAll')
-  async findAll(loadRelations = false): Promise<CategoryEntity[]> {
+  async findAll(): Promise<CategoryEntity[]> {
     await this.getTenantSpecificCategoryRepository();
     return await this.tracer.startActiveSpan(
       'category.service.findAll',
@@ -44,16 +44,8 @@ export class CategoryService {
             'category.service.findAll.query',
           );
 
-          // Only load relations if explicitly requested
-          const relations = loadRelations
-            ? ['subCategories', 'events', 'groups']
-            : [];
-
-          // Select only necessary fields for the filter
           const categories = await this.categoryRepository.find({
             select: ['id', 'name'],
-            relations,
-            cache: true,
           });
 
           querySpan.end();
@@ -94,7 +86,7 @@ export class CategoryService {
           );
           const category = await this.categoryRepository.findOne({
             where: { id },
-            relations: ['subCategories', 'events', 'groups'],
+            relations: ['subCategories'],
           });
           querySpan.end();
 


### PR DESCRIPTION
## Summary
- Remove `cache: true` from `findAll()` — TypeORM generates subqueries when combining cache with `select` clauses
- Remove dead `loadRelations` parameter from `findAll()` — nobody calls `findAll(true)` anywhere in the codebase
- Change `findOne()` to only load `subCategories` relation instead of `['subCategories', 'events', 'groups']` — the ManyToMany joins through `eventCategories` and group pivot tables were causing cartesian products

## Context
pg_stat_statements showed category queries averaging 113ms with 840ms max spikes. The root cause was:
1. TypeORM's `cache: true` with `select` clause generating inefficient subqueries
2. `findOne()` eagerly loading all events and groups through ManyToMany pivot tables, producing cartesian products across 4,500+ events

Relates to om-zzhr

## Test plan
- [x] Unit tests updated and passing (`npm run test -- src/category/category.service.spec.ts`)
- [ ] Verify p95/p99 SELECT latency drops on Grafana dashboard after deploy