### PR TITLE
perf(events): replace loadRelationCountAndMap with batch attendee count fetching

### DIFF
--- a/src/event/services/event-query.service.spec.ts
+++ b/src/event/services/event-query.service.spec.ts
@@ -242,20 +242,9 @@ describe('EventQueryService', () => {
 
   describe('getHomePageFeaturedEvents', () => {
     it('should return featured events', async () => {
-      // Mock the event attendee service
-      jest
-        .spyOn(
-          service['eventAttendeeService'],
-          'showConfirmedEventAttendeesCount',
-        )
-        .mockResolvedValue(5);
-
-      // No need to mock recurrence service anymore as we now generate the description directly
-
-      const mockQueryBuilder = {
+      const mockEventQueryBuilder = {
         select: jest.fn().mockReturnThis(),
         leftJoinAndSelect: jest.fn().mockReturnThis(),
-        loadRelationCountAndMap: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
@@ -263,24 +252,278 @@ describe('EventQueryService', () => {
         getMany: jest.fn().mockResolvedValue([mockEventEntity]),
       };
 
+      const mockAttendeeQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([{ eventId: 1, count: '5' }]),
+      };
+
       jest
         .spyOn(service['tenantConnectionService'], 'getTenantConnection')
         .mockResolvedValue({
-          getRepository: jest.fn().mockReturnValue({
-            createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+          getRepository: jest.fn().mockImplementation((entity) => {
+            if (entity.name === 'EventAttendeesEntity') {
+              return {
+                createQueryBuilder: jest
+                  .fn()
+                  .mockReturnValue(mockAttendeeQueryBuilder),
+              };
+            }
+            return {
+              createQueryBuilder: jest
+                .fn()
+                .mockReturnValue(mockEventQueryBuilder),
+            };
           }),
         } as any);
 
-      // Mock the attendee count service call which is used to enrich event data
-      jest
-        .spyOn(
-          service['eventAttendeeService'],
-          'showConfirmedEventAttendeesCount',
-        )
-        .mockResolvedValue(5);
-
       const result = await service.getHomePageFeaturedEvents();
       expect(Array.isArray(result)).toBe(true);
+    });
+
+    it('should use batch attendee count query instead of loadRelationCountAndMap', async () => {
+      const mockEvents = [
+        { ...mockEventEntity, id: 1 },
+        { ...mockEventEntity, id: 2, slug: 'event-2' },
+      ];
+
+      // Track whether loadRelationCountAndMap is called on the event query builder
+      const loadRelationCountAndMapFn = jest.fn().mockReturnThis();
+      const mockEventQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        loadRelationCountAndMap: loadRelationCountAndMapFn,
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue(mockEvents),
+      };
+
+      // Mock the batch attendee count query builder
+      const mockGetRawMany = jest.fn().mockResolvedValue([
+        { eventId: 1, count: '3' },
+        { eventId: 2, count: '7' },
+      ]);
+      const mockAttendeeQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: mockGetRawMany,
+      };
+
+      jest
+        .spyOn(service['tenantConnectionService'], 'getTenantConnection')
+        .mockResolvedValue({
+          getRepository: jest.fn().mockImplementation((entity) => {
+            if (entity.name === 'EventAttendeesEntity') {
+              return {
+                createQueryBuilder: jest
+                  .fn()
+                  .mockReturnValue(mockAttendeeQueryBuilder),
+              };
+            }
+            return {
+              createQueryBuilder: jest
+                .fn()
+                .mockReturnValue(mockEventQueryBuilder),
+            };
+          }),
+        } as any);
+
+      const result = await service.getHomePageFeaturedEvents();
+
+      // loadRelationCountAndMap should NOT be called (batch pattern used instead)
+      expect(loadRelationCountAndMapFn).not.toHaveBeenCalled();
+
+      // Batch attendee count query SHOULD be called
+      expect(mockGetRawMany).toHaveBeenCalled();
+
+      // Results should have attendeesCount set
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('getHomePageUserNextHostedEvent', () => {
+    it('should use batch attendee count query instead of loadRelationCountAndMap', async () => {
+      const mockEvent = { ...mockEventEntity, id: 42 };
+
+      const loadRelationCountAndMapFn = jest.fn().mockReturnThis();
+      const mockEventQueryBuilder = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        loadRelationCountAndMap: loadRelationCountAndMapFn,
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(mockEvent),
+      };
+
+      // Mock the batch attendee count query for a single event
+      const mockGetRawOne = jest.fn().mockResolvedValue({ count: '5' });
+      const mockAttendeeQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawOne: mockGetRawOne,
+      };
+
+      jest
+        .spyOn(service['tenantConnectionService'], 'getTenantConnection')
+        .mockResolvedValue({
+          getRepository: jest.fn().mockImplementation((entity) => {
+            if (entity.name === 'EventAttendeesEntity') {
+              return {
+                createQueryBuilder: jest
+                  .fn()
+                  .mockReturnValue(mockAttendeeQueryBuilder),
+              };
+            }
+            return {
+              createQueryBuilder: jest
+                .fn()
+                .mockReturnValue(mockEventQueryBuilder),
+            };
+          }),
+        } as any);
+
+      const result = await service.getHomePageUserNextHostedEvent(1);
+
+      // loadRelationCountAndMap should NOT be called
+      expect(loadRelationCountAndMapFn).not.toHaveBeenCalled();
+
+      // Batch attendee count query SHOULD be called
+      expect(mockGetRawOne).toHaveBeenCalled();
+
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('getHomePageUserRecentEventDrafts', () => {
+    it('should use batch attendee count query instead of loadRelationCountAndMap', async () => {
+      const mockEvents = [
+        { ...mockEventEntity, id: 1 },
+        { ...mockEventEntity, id: 2, slug: 'draft-2' },
+      ];
+
+      const loadRelationCountAndMapFn = jest.fn().mockReturnThis();
+      const mockEventQueryBuilder = {
+        loadRelationCountAndMap: loadRelationCountAndMapFn,
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue(mockEvents),
+      };
+
+      const mockGetRawMany = jest.fn().mockResolvedValue([
+        { eventId: 1, count: '2' },
+        { eventId: 2, count: '4' },
+      ]);
+      const mockAttendeeQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: mockGetRawMany,
+      };
+
+      jest
+        .spyOn(service['tenantConnectionService'], 'getTenantConnection')
+        .mockResolvedValue({
+          getRepository: jest.fn().mockImplementation((entity) => {
+            if (entity.name === 'EventAttendeesEntity') {
+              return {
+                createQueryBuilder: jest
+                  .fn()
+                  .mockReturnValue(mockAttendeeQueryBuilder),
+              };
+            }
+            return {
+              createQueryBuilder: jest
+                .fn()
+                .mockReturnValue(mockEventQueryBuilder),
+            };
+          }),
+        } as any);
+
+      const result = await service.getHomePageUserRecentEventDrafts(1);
+
+      // loadRelationCountAndMap should NOT be called
+      expect(loadRelationCountAndMapFn).not.toHaveBeenCalled();
+
+      // Batch attendee count query SHOULD be called
+      expect(mockGetRawMany).toHaveBeenCalled();
+
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('getHomePageUserUpcomingEvents - batch count', () => {
+    it('should use batch attendee count query instead of loadRelationCountAndMap', async () => {
+      const mockEvents = [
+        { ...mockEventEntity, id: 10 },
+        { ...mockEventEntity, id: 20, slug: 'upcoming-2' },
+      ];
+
+      const loadRelationCountAndMapFn = jest.fn().mockReturnThis();
+      const mockEventQueryBuilder = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        loadRelationCountAndMap: loadRelationCountAndMapFn,
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue(mockEvents),
+      };
+
+      const mockGetRawMany = jest.fn().mockResolvedValue([
+        { eventId: 10, count: '8' },
+        { eventId: 20, count: '12' },
+      ]);
+      const mockAttendeeQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: mockGetRawMany,
+      };
+
+      jest
+        .spyOn(service['tenantConnectionService'], 'getTenantConnection')
+        .mockResolvedValue({
+          getRepository: jest.fn().mockImplementation((entity) => {
+            if (entity.name === 'EventAttendeesEntity') {
+              return {
+                createQueryBuilder: jest
+                  .fn()
+                  .mockReturnValue(mockAttendeeQueryBuilder),
+              };
+            }
+            return {
+              createQueryBuilder: jest
+                .fn()
+                .mockReturnValue(mockEventQueryBuilder),
+            };
+          }),
+        } as any);
+
+      const result = await service.getHomePageUserUpcomingEvents(1);
+
+      // loadRelationCountAndMap should NOT be called
+      expect(loadRelationCountAndMapFn).not.toHaveBeenCalled();
+
+      // Batch attendee count query SHOULD be called
+      expect(mockGetRawMany).toHaveBeenCalled();
+
+      expect(result).toHaveLength(2);
     });
   });
 
@@ -351,9 +594,8 @@ describe('EventQueryService', () => {
     beforeEach(() => {
       // Set up the event repository mock to return our fixture
       const mockEvent = createMockEventWithImage();
-      const mockQueryBuilder = {
+      const mockEventQueryBuilder = {
         leftJoinAndSelect: jest.fn().mockReturnThis(),
-        loadRelationCountAndMap: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
@@ -361,20 +603,35 @@ describe('EventQueryService', () => {
         getMany: jest.fn().mockResolvedValue([mockEvent]),
       };
 
+      const mockAttendeeQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest
+          .fn()
+          .mockResolvedValue([{ eventId: mockEvent.id, count: '5' }]),
+      };
+
       jest
         .spyOn(service['tenantConnectionService'], 'getTenantConnection')
         .mockResolvedValue({
-          getRepository: jest.fn().mockReturnValue({
-            createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+          getRepository: jest.fn().mockImplementation((entity) => {
+            if (entity.name === 'EventAttendeesEntity') {
+              return {
+                createQueryBuilder: jest
+                  .fn()
+                  .mockReturnValue(mockAttendeeQueryBuilder),
+              };
+            }
+            return {
+              createQueryBuilder: jest
+                .fn()
+                .mockReturnValue(mockEventQueryBuilder),
+            };
           }),
         } as any);
-
-      jest
-        .spyOn(
-          service['eventAttendeeService'],
-          'showConfirmedEventAttendeesCount',
-        )
-        .mockResolvedValue(5);
     });
 
     it('should properly serialize image.path in getHomePageUserUpcomingEvents', async () => {

--- a/src/event/services/event-query.service.ts
+++ b/src/event/services/event-query.service.ts
@@ -1050,15 +1050,6 @@ export class EventQueryService {
       .leftJoinAndSelect('event.attendees', 'attendees')
       .leftJoinAndSelect('event.categories', 'categories')
       .leftJoinAndSelect('event.image', 'image')
-      .loadRelationCountAndMap(
-        'event.attendeesCount',
-        'event.attendees',
-        'attendee',
-        (qb) =>
-          qb.where('attendee.status = :confirmedStatus', {
-            confirmedStatus: EventAttendeeStatus.Confirmed,
-          }),
-      )
       .where('event.visibility = :visibility', {
         visibility: EventVisibility.Public,
       })
@@ -1075,6 +1066,28 @@ export class EventQueryService {
       .getMany();
 
     this.logger.debug(`Found ${events.length} featured events`);
+
+    // Batch fetch attendee counts in a single query (avoids N+1)
+    if (events.length > 0) {
+      const eventIds = events.map((e) => e.id);
+      const counts = await this.eventAttendeesRepository
+        .createQueryBuilder('att')
+        .select('att.eventId', 'eventId')
+        .addSelect('COUNT(att.id)', 'count')
+        .where('att.eventId IN (:...eventIds)', { eventIds })
+        .andWhere('att.status = :status', {
+          status: EventAttendeeStatus.Confirmed,
+        })
+        .groupBy('att.eventId')
+        .getRawMany();
+
+      const countMap = new Map(
+        counts.map((c) => [c.eventId, parseInt(c.count, 10)]),
+      );
+      events.forEach((event) => {
+        (event as any).attendeesCount = countMap.get(event.id) || 0;
+      });
+    }
 
     // Debug first event image before processing
     if (events.length > 0 && events[0].image) {
@@ -1135,15 +1148,6 @@ export class EventQueryService {
     const event = await this.eventRepository
       .createQueryBuilder('event')
       .leftJoinAndSelect('event.image', 'image')
-      .loadRelationCountAndMap(
-        'event.attendeesCount',
-        'event.attendees',
-        'attendee',
-        (qb) =>
-          qb.where('attendee.status = :confirmedStatus', {
-            confirmedStatus: EventAttendeeStatus.Confirmed,
-          }),
-      )
       .where('event.user.id = :userId', { userId })
       .andWhere(
         '(event.startDate > :now OR (event.startDate <= :now AND (event.endDate > :now OR (event.endDate IS NULL AND event.startDate > :oneHourAgo))))',
@@ -1159,6 +1163,17 @@ export class EventQueryService {
     if (!event) {
       return null;
     }
+
+    // Batch fetch attendee count for this single event
+    const countResult = await this.eventAttendeesRepository
+      .createQueryBuilder('att')
+      .select('COUNT(att.id)', 'count')
+      .where('att.eventId = :eventId', { eventId: event.id })
+      .andWhere('att.status = :status', {
+        status: EventAttendeeStatus.Confirmed,
+      })
+      .getRawOne();
+    (event as any).attendeesCount = parseInt(countResult?.count || '0', 10);
 
     // Debug image before processing
     if (event.image) {
@@ -1196,23 +1211,35 @@ export class EventQueryService {
   ): Promise<EventEntity[]> {
     await this.initializeRepository();
 
-    // Use loadRelationCountAndMap to get attendee counts in a single query to avoid N+1
     const events = await this.eventRepository
       .createQueryBuilder('event')
-      .loadRelationCountAndMap(
-        'event.attendeesCount',
-        'event.attendees',
-        'attendee',
-        (qb) =>
-          qb.where('attendee.status = :confirmedStatus', {
-            confirmedStatus: EventAttendeeStatus.Confirmed,
-          }),
-      )
       .where('event.user.id = :userId', { userId })
       .andWhere('event.status = :status', { status: EventStatus.Draft })
       .orderBy('event.updatedAt', 'DESC')
       .limit(3)
       .getMany();
+
+    // Batch fetch attendee counts in a single query (avoids N+1)
+    if (events.length > 0) {
+      const eventIds = events.map((e) => e.id);
+      const counts = await this.eventAttendeesRepository
+        .createQueryBuilder('att')
+        .select('att.eventId', 'eventId')
+        .addSelect('COUNT(att.id)', 'count')
+        .where('att.eventId IN (:...eventIds)', { eventIds })
+        .andWhere('att.status = :status', {
+          status: EventAttendeeStatus.Confirmed,
+        })
+        .groupBy('att.eventId')
+        .getRawMany();
+
+      const countMap = new Map(
+        counts.map((c) => [c.eventId, parseInt(c.count, 10)]),
+      );
+      events.forEach((event) => {
+        (event as any).attendeesCount = countMap.get(event.id) || 0;
+      });
+    }
 
     // Add recurrence descriptions
     return events.map((event) => this.addRecurrenceInformation(event));
@@ -1226,15 +1253,6 @@ export class EventQueryService {
       .leftJoinAndSelect('event.attendees', 'attendee')
       .leftJoinAndSelect('event.image', 'image')
       .leftJoinAndSelect('attendee.user', 'user')
-      .loadRelationCountAndMap(
-        'event.attendeesCount',
-        'event.attendees',
-        'attendeeCount',
-        (qb) =>
-          qb.where('attendeeCount.status = :confirmedStatus', {
-            confirmedStatus: EventAttendeeStatus.Confirmed,
-          }),
-      )
       .where('attendee.user.id = :userId', { userId })
       .andWhere(
         '(event.startDate > :now OR (event.startDate <= :now AND (event.endDate > :now OR (event.endDate IS NULL AND event.startDate > :oneHourAgo))))',
@@ -1254,6 +1272,28 @@ export class EventQueryService {
     this.logger.debug(
       `Found ${events.length} upcoming events for user ${userId}`,
     );
+
+    // Batch fetch attendee counts in a single query (avoids N+1)
+    if (events.length > 0) {
+      const eventIds = events.map((e) => e.id);
+      const counts = await this.eventAttendeesRepository
+        .createQueryBuilder('att')
+        .select('att.eventId', 'eventId')
+        .addSelect('COUNT(att.id)', 'count')
+        .where('att.eventId IN (:...eventIds)', { eventIds })
+        .andWhere('att.status = :status', {
+          status: EventAttendeeStatus.Confirmed,
+        })
+        .groupBy('att.eventId')
+        .getRawMany();
+
+      const countMap = new Map(
+        counts.map((c) => [c.eventId, parseInt(c.count, 10)]),
+      );
+      events.forEach((event) => {
+        (event as any).attendeesCount = countMap.get(event.id) || 0;
+      });
+    }
 
     // Debug first event image
     if (events.length > 0 && events[0].image) {


### PR DESCRIPTION
## Summary
- Replace 4 remaining `loadRelationCountAndMap` calls with the batch-fetch pattern already used in `showAllEvents()` and `getEventsByCreator()`
- Affected methods: `getHomePageFeaturedEvents`, `getHomePageUserNextHostedEvent`, `getHomePageUserRecentEventDrafts`, `getHomePageUserUpcomingEvents`

## Context
`loadRelationCountAndMap` generates an unfiltered `GROUP BY` across ALL events:
```sql
SELECT "attendee"."eventId", COUNT(*) FROM "eventAttendees" "attendee" 
WHERE "attendee"."status" = 'confirmed' GROUP BY "attendee"."eventId"
-- Returns ~4,500 rows every call
```

The batch pattern filters to only the events being displayed:
```sql
SELECT "att"."eventId", COUNT("att"."id") FROM "eventAttendees" "att"
WHERE "att"."eventId" IN (1, 2, 3, 4) AND "att"."status" = 'confirmed'
GROUP BY "att"."eventId"
-- Returns only 4 rows
```

pg_stat_statements showed this query called 355 times returning ~4,500 rows each time (mean 6.8ms). With the batch pattern, it will return only the 3-5 rows needed per call.

Relates to om-c8xj

## Test plan
- [x] 4 new unit tests verifying batch pattern is used instead of loadRelationCountAndMap
- [x] 2 existing tests updated for new pattern
- [x] All 17 tests passing (`npm run test -- src/event/services/event-query.service.spec.ts`)
- [ ] Verify attendee counts still display correctly on home page after deploy
- [ ] Verify p95 SELECT latency reduction on Grafana