### PR TITLE
perf(atproto): increase handle cache TTL from 15 minutes to 4 hours

### DIFF
--- a/src/bluesky/atproto-handle-cache.service.spec.ts
+++ b/src/bluesky/atproto-handle-cache.service.spec.ts
@@ -235,6 +235,26 @@ describe('AtprotoHandleCacheService - Behavior', () => {
     });
   });
 
+  describe('Cache TTL', () => {
+    it('should cache resolved handles with a 4-hour TTL (14400 seconds)', async () => {
+      // Arrange
+      const did = 'did:plc:abc123';
+      blueskyIdentity.extractHandleFromDid.mockResolvedValue(
+        'alice.bsky.social',
+      );
+
+      // Act
+      await service.resolveHandle(did);
+
+      // Assert - cache.set should be called with TTL of 14400 (4 hours)
+      expect(elastiCache.set).toHaveBeenCalledWith(
+        expect.any(String),
+        'alice.bsky.social',
+        14400,
+      );
+    });
+  });
+
   describe('invalidate - Cache Invalidation', () => {
     it('should force re-resolution after cache invalidation', async () => {
       // Arrange

--- a/src/bluesky/atproto-handle-cache.service.ts
+++ b/src/bluesky/atproto-handle-cache.service.ts
@@ -21,7 +21,7 @@ export class AtprotoHandleCacheService {
   private readonly logger = new Logger(AtprotoHandleCacheService.name);
   private readonly tracer = trace.getTracer('atproto-handle-cache');
   private readonly CACHE_PREFIX = 'atproto:handle:';
-  private readonly CACHE_TTL = 900; // 15 minutes (in seconds)
+  private readonly CACHE_TTL = 14400; // 4 hours (in seconds)
 
   // DID validation pattern (plc and web methods only)
   private readonly DID_PATTERN = /^did:(plc|web):[a-zA-Z0-9._-]{1,100}$/;


### PR DESCRIPTION
## Summary
- Increase ATProto handle resolution cache TTL from 900s (15 min) to 14400s (4 hours)
- ATProto handles change very rarely (monthly at most) — 15 minutes was unnecessarily aggressive
- The `invalidate()` method exists for explicit cache busting when handle changes are detected

## Context
Prometheus showed ATProto handle resolution at 420ms p95, with only 33% cache hit rate on one pod vs 100% on the other. Both pods share the same Redis (ElastiCache) backend. A longer TTL means entries persist longer, increasing cache hit rates across all pods and reducing the number of expensive external resolution calls (DNS + HTTP + DB).

Relates to om-pvf0

## Test plan
- [x] New test asserting 4-hour TTL value
- [x] All 13 existing tests passing
- [ ] Monitor cache hit rate on Grafana after deploy — expect both pods to converge toward higher hit rates