### PR TITLE
fix(db): redact tenant secrets from migration runner logs

### DIFF
--- a/src/database/run-multi-tenant-migrations.ts
+++ b/src/database/run-multi-tenant-migrations.ts
@@ -4,7 +4,10 @@ import { fetchTenants } from '../utils/tenant-config';
 
 async function runMigrationsForAllTenants() {
   const tenants = fetchTenants();
-  console.log('Tenants:', tenants);
+  console.log(
+    'Tenants:',
+    tenants.map((t) => t.id),
+  );
   console.log('Starting migrations for all tenants:', tenants.length);
 
   // First do a dry run to check if migrations would succeed


### PR DESCRIPTION
## Summary
- Migration runner (`run-multi-tenant-migrations.ts`) was logging full `TenantConfig` objects including `googleClientSecret`, `githubClientSecret`, Matrix bot/admin passwords, and appservice tokens
- Changed to log only tenant IDs: `tenants.map((t) => t.id)`

## Test plan
- [x] Verified no other database scripts log full tenant objects (all use `tenant.id` or `tenantId`)
- [ ] Run migration on dev, verify `kubectl logs` shows only tenant IDs

Closes om-2jmn