### PR TITLE
fix(event): preserve host role for event creators on RSVP

### DIFF
--- a/src/event/services/event-management.service.spec.ts
+++ b/src/event/services/event-management.service.spec.ts
@@ -211,6 +211,7 @@ describe('EventManagementService', () => {
               .fn()
               .mockImplementation((attendee) => Promise.resolve(attendee)),
             reactivateEventAttendance: jest.fn(),
+            reactivateEventAttendanceBySlug: jest.fn(),
             findOne: jest.fn(),
           },
         },
@@ -1024,6 +1025,7 @@ describe('EventManagementService', () => {
           visibility: EventVisibility.Private,
           group: { id: 123, slug: 'test-group' },
           groupId: 123,
+          user: { id: 99999 } as UserEntity, // Different user than mockUser (not the creator)
         } as EventEntity;
 
         const currentMockEventAttendee = {
@@ -1144,6 +1146,205 @@ describe('EventManagementService', () => {
         await expect(
           service.attendEvent(privateGroupEvent.slug, mockUser.id, attendeeDto),
         ).rejects.toThrow('You must be invited to RSVP to this private event');
+      });
+    });
+
+    describe('Creator host role preservation', () => {
+      it('should assign host role when event creator RSVPs to their own event', async () => {
+        // findOneMockEventEntity.user.id === TESTING_USER_ID === mockUser.id
+        // so the creator IS the user RSVPing
+        const targetEvent = findOneMockEventEntity;
+
+        jest.spyOn(service, 'attendEvent').mockRestore();
+
+        mockRepository.findOne.mockResolvedValueOnce(targetEvent);
+
+        const mockUserService = service[
+          'userService'
+        ] as jest.Mocked<UserService>;
+        mockUserService.getUserById.mockResolvedValueOnce(mockUser as any);
+
+        const mockEventAttendeeService = service[
+          'eventAttendeeService'
+        ] as jest.Mocked<EventAttendeeService>;
+        mockEventAttendeeService.findEventAttendeeByUserId.mockResolvedValueOnce(
+          null,
+        );
+
+        const mockEventRoleService = service[
+          'eventRoleService'
+        ] as jest.Mocked<EventRoleService>;
+        mockEventRoleService.getRoleByName.mockResolvedValueOnce({
+          id: 2,
+          name: EventAttendeeRole.Host,
+          attendees: [],
+          permissions: [],
+        } as any);
+
+        mockEventAttendeeService.showEventAttendeesCount.mockResolvedValueOnce(0);
+
+        const createdAttendee = {
+          id: 1,
+          status: EventAttendeeStatus.Confirmed,
+          role: { id: 2, name: EventAttendeeRole.Host },
+        } as any;
+        mockEventAttendeeService.create.mockResolvedValueOnce(createdAttendee);
+
+        const mockEventMailService = service[
+          'eventMailService'
+        ] as jest.Mocked<EventMailService>;
+        mockEventMailService.sendMailAttendeeGuestJoined.mockResolvedValueOnce();
+
+        mockEventAttendeeService.findEventAttendeeByUserId.mockResolvedValueOnce(
+          createdAttendee,
+        );
+
+        const attendeeDto = {};
+
+        await service.attendEvent(targetEvent.slug, mockUser.id, attendeeDto);
+
+        // The key assertion: getRoleByName should be called with Host, not Participant
+        expect(mockEventRoleService.getRoleByName).toHaveBeenCalledWith(
+          EventAttendeeRole.Host,
+        );
+      });
+
+      it('should assign host role when event creator re-RSVPs after cancellation', async () => {
+        const targetEvent = findOneMockEventEntity;
+
+        jest.spyOn(service, 'attendEvent').mockRestore();
+
+        mockRepository.findOne.mockResolvedValueOnce(targetEvent);
+
+        const mockUserService = service[
+          'userService'
+        ] as jest.Mocked<UserService>;
+        mockUserService.getUserById.mockResolvedValueOnce({
+          ...mockUser,
+          slug: 'test-user',
+        } as any);
+
+        // Existing cancelled attendee record
+        const cancelledAttendee = {
+          id: 1,
+          status: EventAttendeeStatus.Cancelled,
+          role: { id: 1, name: EventAttendeeRole.Participant },
+        } as any;
+
+        const mockEventAttendeeService = service[
+          'eventAttendeeService'
+        ] as jest.Mocked<EventAttendeeService>;
+        mockEventAttendeeService.findEventAttendeeByUserId.mockResolvedValueOnce(
+          cancelledAttendee,
+        );
+
+        const mockEventRoleService = service[
+          'eventRoleService'
+        ] as jest.Mocked<EventRoleService>;
+        mockEventRoleService.getRoleByName.mockResolvedValueOnce({
+          id: 2,
+          name: EventAttendeeRole.Host,
+          attendees: [],
+          permissions: [],
+        } as any);
+
+        mockEventAttendeeService.showEventAttendeesCount.mockResolvedValueOnce(0);
+
+        const reactivatedAttendee = {
+          id: 1,
+          status: EventAttendeeStatus.Confirmed,
+          role: { id: 2, name: EventAttendeeRole.Host },
+        } as any;
+        mockEventAttendeeService.reactivateEventAttendanceBySlug.mockResolvedValueOnce(
+          reactivatedAttendee,
+        );
+
+        const mockEventMailService = service[
+          'eventMailService'
+        ] as jest.Mocked<EventMailService>;
+        mockEventMailService.sendMailAttendeeGuestJoined.mockResolvedValueOnce();
+
+        mockEventAttendeeService.findEventAttendeeByUserId.mockResolvedValueOnce(
+          reactivatedAttendee,
+        );
+
+        const attendeeDto = {};
+
+        await service.attendEvent(targetEvent.slug, mockUser.id, attendeeDto);
+
+        // The key assertion: getRoleByName should be called with Host
+        expect(mockEventRoleService.getRoleByName).toHaveBeenCalledWith(
+          EventAttendeeRole.Host,
+        );
+        // And reactivation should use the host role id
+        expect(
+          mockEventAttendeeService.reactivateEventAttendanceBySlug,
+        ).toHaveBeenCalledWith(
+          targetEvent.slug,
+          'test-user',
+          EventAttendeeStatus.Confirmed,
+          2, // host role id
+        );
+      });
+
+      it('should assign participant role when non-creator RSVPs to an event', async () => {
+        const nonCreatorEvent = {
+          ...findOneMockEventEntity,
+          user: { id: 99999 } as UserEntity, // Different user than mockUser
+        } as EventEntity;
+
+        jest.spyOn(service, 'attendEvent').mockRestore();
+
+        mockRepository.findOne.mockResolvedValueOnce(nonCreatorEvent);
+
+        const mockUserService = service[
+          'userService'
+        ] as jest.Mocked<UserService>;
+        mockUserService.getUserById.mockResolvedValueOnce(mockUser as any);
+
+        const mockEventAttendeeService = service[
+          'eventAttendeeService'
+        ] as jest.Mocked<EventAttendeeService>;
+        mockEventAttendeeService.findEventAttendeeByUserId.mockResolvedValueOnce(
+          null,
+        );
+
+        const mockEventRoleService = service[
+          'eventRoleService'
+        ] as jest.Mocked<EventRoleService>;
+        mockEventRoleService.getRoleByName.mockResolvedValueOnce({
+          id: 1,
+          name: EventAttendeeRole.Participant,
+          attendees: [],
+          permissions: [],
+        } as any);
+
+        mockEventAttendeeService.showEventAttendeesCount.mockResolvedValueOnce(0);
+
+        const createdAttendee = {
+          id: 1,
+          status: EventAttendeeStatus.Confirmed,
+          role: { id: 1, name: EventAttendeeRole.Participant },
+        } as any;
+        mockEventAttendeeService.create.mockResolvedValueOnce(createdAttendee);
+
+        const mockEventMailService = service[
+          'eventMailService'
+        ] as jest.Mocked<EventMailService>;
+        mockEventMailService.sendMailAttendeeGuestJoined.mockResolvedValueOnce();
+
+        mockEventAttendeeService.findEventAttendeeByUserId.mockResolvedValueOnce(
+          createdAttendee,
+        );
+
+        const attendeeDto = {};
+
+        await service.attendEvent(nonCreatorEvent.slug, mockUser.id, attendeeDto);
+
+        // The key assertion: getRoleByName should be called with Participant, not Host
+        expect(mockEventRoleService.getRoleByName).toHaveBeenCalledWith(
+          EventAttendeeRole.Participant,
+        );
       });
     });
   });

--- a/src/event/services/event-management.service.ts
+++ b/src/event/services/event-management.service.ts
@@ -1716,11 +1716,14 @@ export class EventManagementService {
       );
     }
 
-    // Determine the appropriate role based on group membership
+    // Determine the appropriate role based on event ownership and group membership
     let attendeeRole = EventAttendeeRole.Participant; // Default role
 
-    // If event belongs to a group, check if user is owner/admin
-    if (event.group && event.group.id) {
+    // Event creator always gets host role
+    if (event.user && event.user.id === userId) {
+      attendeeRole = EventAttendeeRole.Host;
+    } else if (event.group && event.group.id) {
+      // If event belongs to a group, check if user is owner/admin
       const userGroupMember =
         await this.groupMemberQueryService.findGroupMemberByUserId(
           event.group.id,


### PR DESCRIPTION
## Summary

- Event creators now correctly receive the "host" role when RSVPing to their own event
- Previously, creators who RSVP'd → cancelled → re-RSVP'd lost their host role and became "participants", preventing them from editing their own event
- Root cause: `attendEvent()` only checked group membership for host role assignment, never checked if the user was the event creator

## Changes

- Added creator check before group membership check in role assignment logic (`event-management.service.ts`)
- Added 3 unit tests covering: creator initial RSVP, creator re-RSVP after cancel, non-creator gets participant role

## Test plan

- [x] Unit tests pass (53/53)
- [ ] Verify on dev: create event → RSVP → cancel → re-RSVP → confirm role is "host"
- [ ] Verify on dev: non-creator RSVP still gets "participant" role