### PR TITLE
feat(contrail): RSVP support for Contrail-only ATProto events

### DIFF
--- a/src/bluesky/bluesky-rsvp.service.spec.ts
+++ b/src/bluesky/bluesky-rsvp.service.spec.ts
@@ -799,4 +799,334 @@ describe('BlueskyRsvpService', () => {
       });
     });
   });
+
+  describe('createRsvpByUri', () => {
+    const eventUri =
+      'at://did:plc:organizer/community.lexicon.calendar.event/tid999';
+    const userDid = 'did:plc:attendee';
+    const tenantId = 'tenant123';
+
+    it('should create an RSVP using a raw event URI (no EventEntity)', async () => {
+      const mockRsvpUri =
+        'at://did:plc:attendee/community.lexicon.calendar.rsvp/rsvphash';
+      blueskyIdService.createUri.mockReturnValueOnce(mockRsvpUri);
+
+      const mockAgent = {
+        com: {
+          atproto: {
+            repo: {
+              putRecord: jest.fn().mockResolvedValue({
+                data: { uri: mockRsvpUri, cid: 'rsvpcid001' },
+              }),
+            },
+          },
+        },
+      };
+      blueskyService.resumeSession.mockResolvedValue(
+        mockAgent as unknown as Agent,
+      );
+
+      const result = await service.createRsvpByUri(
+        eventUri,
+        'going',
+        userDid,
+        tenantId,
+      );
+
+      // Should build record with uri-only subject (no CID)
+      expect(mockAgent.com.atproto.repo.putRecord).toHaveBeenCalledWith({
+        repo: userDid,
+        collection: 'community.lexicon.calendar.rsvp',
+        rkey: expect.any(String),
+        record: {
+          $type: 'community.lexicon.calendar.rsvp',
+          subject: { uri: eventUri },
+          status: 'community.lexicon.calendar.rsvp#going',
+          createdAt: expect.any(String),
+        },
+      });
+
+      expect(result).toEqual({
+        success: true,
+        rsvpUri: mockRsvpUri,
+        rsvpCid: 'rsvpcid001',
+      });
+    });
+
+    it('should use providedAgent instead of resumeSession when given', async () => {
+      const mockRsvpUri =
+        'at://did:plc:attendee/community.lexicon.calendar.rsvp/rsvphash';
+      blueskyIdService.createUri.mockReturnValueOnce(mockRsvpUri);
+
+      const providedAgent = {
+        com: {
+          atproto: {
+            repo: {
+              putRecord: jest.fn().mockResolvedValue({
+                data: { uri: mockRsvpUri, cid: 'rsvpcid002' },
+              }),
+            },
+          },
+        },
+      };
+
+      await service.createRsvpByUri(
+        eventUri,
+        'interested',
+        userDid,
+        tenantId,
+        providedAgent as unknown as Agent,
+      );
+
+      expect(blueskyService.resumeSession).not.toHaveBeenCalled();
+      expect(providedAgent.com.atproto.repo.putRecord).toHaveBeenCalled();
+    });
+
+    it('should throw when session cannot be created', async () => {
+      blueskyService.resumeSession.mockResolvedValue(null as unknown as Agent);
+
+      await expect(
+        service.createRsvpByUri(eventUri, 'going', userDid, tenantId),
+      ).rejects.toThrow(/Failed to create Bluesky session/);
+    });
+
+    it('should throw when lexicon validation fails', async () => {
+      const mockAgent = {
+        com: {
+          atproto: {
+            repo: {
+              putRecord: jest.fn(),
+            },
+          },
+        },
+      };
+      blueskyService.resumeSession.mockResolvedValue(
+        mockAgent as unknown as Agent,
+      );
+
+      atprotoLexiconService.validate.mockReturnValueOnce({
+        success: false,
+        error: { message: 'Invalid record' },
+      } as any);
+
+      await expect(
+        service.createRsvpByUri(eventUri, 'going', userDid, tenantId),
+      ).rejects.toThrow('AT Protocol record validation failed');
+
+      expect(mockAgent.com.atproto.repo.putRecord).not.toHaveBeenCalled();
+    });
+
+    it('should increment metrics on success', async () => {
+      const mockRsvpUri =
+        'at://did:plc:attendee/community.lexicon.calendar.rsvp/rsvphash';
+      blueskyIdService.createUri.mockReturnValueOnce(mockRsvpUri);
+
+      const mockAgent = {
+        com: {
+          atproto: {
+            repo: {
+              putRecord: jest.fn().mockResolvedValue({
+                data: { uri: mockRsvpUri, cid: 'cid' },
+              }),
+            },
+          },
+        },
+      };
+      blueskyService.resumeSession.mockResolvedValue(
+        mockAgent as unknown as Agent,
+      );
+
+      await service.createRsvpByUri(eventUri, 'going', userDid, tenantId);
+
+      expect(rsvpOperationsCounter.inc).toHaveBeenCalledWith({
+        tenant: tenantId,
+        operation: 'create',
+        status: 'going',
+      });
+    });
+
+    it('should use deterministic rkey from eventUri', async () => {
+      const mockRsvpUri =
+        'at://did:plc:attendee/community.lexicon.calendar.rsvp/rsvphash';
+      blueskyIdService.createUri.mockReturnValueOnce(mockRsvpUri);
+
+      const mockAgent = {
+        com: {
+          atproto: {
+            repo: {
+              putRecord: jest.fn().mockResolvedValue({
+                data: { uri: mockRsvpUri, cid: 'cid' },
+              }),
+            },
+          },
+        },
+      };
+      blueskyService.resumeSession.mockResolvedValue(
+        mockAgent as unknown as Agent,
+      );
+
+      // Call twice with same eventUri - rkey should be identical
+      await service.createRsvpByUri(eventUri, 'going', userDid, tenantId);
+
+      const firstCallRkey =
+        mockAgent.com.atproto.repo.putRecord.mock.calls[0][0].rkey;
+
+      // Reset mocks for second call
+      blueskyIdService.createUri.mockReturnValueOnce(mockRsvpUri);
+      mockAgent.com.atproto.repo.putRecord.mockResolvedValue({
+        data: { uri: mockRsvpUri, cid: 'cid' },
+      });
+
+      await service.createRsvpByUri(eventUri, 'interested', userDid, tenantId);
+
+      const secondCallRkey =
+        mockAgent.com.atproto.repo.putRecord.mock.calls[1][0].rkey;
+
+      expect(firstCallRkey).toBe(secondCallRkey);
+      expect(firstCallRkey).toHaveLength(13); // SHA-256 hash substring
+    });
+  });
+
+  describe('deleteRsvpByUri', () => {
+    const eventUri =
+      'at://did:plc:organizer/community.lexicon.calendar.event/tid999';
+    const userDid = 'did:plc:attendee';
+    const tenantId = 'tenant123';
+
+    it('should delete an RSVP by deriving rkey from eventUri', async () => {
+      const mockAgent = {
+        com: {
+          atproto: {
+            repo: {
+              deleteRecord: jest.fn().mockResolvedValue({}),
+            },
+          },
+        },
+      };
+      blueskyService.resumeSession.mockResolvedValue(
+        mockAgent as unknown as Agent,
+      );
+
+      const result = await service.deleteRsvpByUri(eventUri, userDid, tenantId);
+
+      expect(mockAgent.com.atproto.repo.deleteRecord).toHaveBeenCalledWith({
+        repo: userDid,
+        collection: 'community.lexicon.calendar.rsvp',
+        rkey: expect.any(String),
+      });
+      expect(result).toEqual({ success: true });
+    });
+
+    it('should use providedAgent instead of resumeSession when given', async () => {
+      const providedAgent = {
+        com: {
+          atproto: {
+            repo: {
+              deleteRecord: jest.fn().mockResolvedValue({}),
+            },
+          },
+        },
+      };
+
+      await service.deleteRsvpByUri(
+        eventUri,
+        userDid,
+        tenantId,
+        providedAgent as unknown as Agent,
+      );
+
+      expect(blueskyService.resumeSession).not.toHaveBeenCalled();
+      expect(providedAgent.com.atproto.repo.deleteRecord).toHaveBeenCalled();
+    });
+
+    it('should increment metrics on success', async () => {
+      const mockAgent = {
+        com: {
+          atproto: {
+            repo: {
+              deleteRecord: jest.fn().mockResolvedValue({}),
+            },
+          },
+        },
+      };
+      blueskyService.resumeSession.mockResolvedValue(
+        mockAgent as unknown as Agent,
+      );
+
+      await service.deleteRsvpByUri(eventUri, userDid, tenantId);
+
+      expect(rsvpOperationsCounter.inc).toHaveBeenCalledWith({
+        tenant: tenantId,
+        operation: 'delete',
+      });
+    });
+
+    it('should use the same deterministic rkey as createRsvpByUri', async () => {
+      // Create RSVP first
+      const mockRsvpUri =
+        'at://did:plc:attendee/community.lexicon.calendar.rsvp/rsvphash';
+      blueskyIdService.createUri.mockReturnValueOnce(mockRsvpUri);
+
+      const mockCreateAgent = {
+        com: {
+          atproto: {
+            repo: {
+              putRecord: jest.fn().mockResolvedValue({
+                data: { uri: mockRsvpUri, cid: 'cid' },
+              }),
+            },
+          },
+        },
+      };
+      blueskyService.resumeSession.mockResolvedValueOnce(
+        mockCreateAgent as unknown as Agent,
+      );
+
+      await service.createRsvpByUri(eventUri, 'going', userDid, tenantId);
+      const createRkey =
+        mockCreateAgent.com.atproto.repo.putRecord.mock.calls[0][0].rkey;
+
+      // Delete RSVP
+      const mockDeleteAgent = {
+        com: {
+          atproto: {
+            repo: {
+              deleteRecord: jest.fn().mockResolvedValue({}),
+            },
+          },
+        },
+      };
+      blueskyService.resumeSession.mockResolvedValueOnce(
+        mockDeleteAgent as unknown as Agent,
+      );
+
+      await service.deleteRsvpByUri(eventUri, userDid, tenantId);
+      const deleteRkey =
+        mockDeleteAgent.com.atproto.repo.deleteRecord.mock.calls[0][0].rkey;
+
+      // The rkeys should match - both derived from the same eventUri
+      expect(createRkey).toBe(deleteRkey);
+    });
+
+    it('should throw when PDS delete fails', async () => {
+      const mockAgent = {
+        com: {
+          atproto: {
+            repo: {
+              deleteRecord: jest
+                .fn()
+                .mockRejectedValue(new Error('Record not found')),
+            },
+          },
+        },
+      };
+      blueskyService.resumeSession.mockResolvedValue(
+        mockAgent as unknown as Agent,
+      );
+
+      await expect(
+        service.deleteRsvpByUri(eventUri, userDid, tenantId),
+      ).rejects.toThrow(/Failed to delete Bluesky RSVP/);
+    });
+  });
 });

--- a/src/bluesky/bluesky-rsvp.service.ts
+++ b/src/bluesky/bluesky-rsvp.service.ts
@@ -330,7 +330,7 @@ export class BlueskyRsvpService {
         agent = resumedAgent;
       }
 
-      // Build RSVP record — include CID in subject if available
+      // Build RSVP record — subject is a StrongRef requiring both uri and cid
       const recordData: Record<string, unknown> = {
         $type: BLUESKY_COLLECTIONS.RSVP,
         subject: {

--- a/src/bluesky/bluesky-rsvp.service.ts
+++ b/src/bluesky/bluesky-rsvp.service.ts
@@ -300,6 +300,7 @@ export class BlueskyRsvpService {
     did: string,
     tenantId: string,
     providedAgent?: Agent,
+    eventCid?: string,
   ): Promise<{ success: boolean; rsvpUri: string; rsvpCid?: string }> {
     const timer = this.processingDuration.startTimer({
       tenant: tenantId,
@@ -329,10 +330,13 @@ export class BlueskyRsvpService {
         agent = resumedAgent;
       }
 
-      // Build RSVP record with uri-only subject (no CID for Contrail-only events)
+      // Build RSVP record — include CID in subject if available
       const recordData: Record<string, unknown> = {
         $type: BLUESKY_COLLECTIONS.RSVP,
-        subject: { uri: eventUri },
+        subject: {
+          uri: eventUri,
+          ...(eventCid && { cid: eventCid }),
+        },
         status: RSVP_STATUS[status],
         createdAt: new Date().toISOString(),
       };

--- a/src/bluesky/bluesky-rsvp.service.ts
+++ b/src/bluesky/bluesky-rsvp.service.ts
@@ -282,6 +282,198 @@ export class BlueskyRsvpService {
   }
 
   /**
+   * Creates or updates an RSVP for a Contrail-only event using a raw AT URI.
+   * Unlike createRsvp(), this does not require an EventEntity — it works with
+   * events that exist only in Contrail tables (no tenant DB row).
+   * No CID lookup is performed; the subject uses uri-only reference.
+   *
+   * @param eventUri The AT Protocol URI of the event
+   * @param status The RSVP status (going, interested, or notgoing)
+   * @param did The user's Bluesky DID
+   * @param tenantId The tenant ID
+   * @param providedAgent Optional pre-authenticated agent
+   */
+  @Trace('bluesky-rsvp.createRsvpByUri')
+  async createRsvpByUri(
+    eventUri: string,
+    status: RsvpStatusShort,
+    did: string,
+    tenantId: string,
+    providedAgent?: Agent,
+  ): Promise<{ success: boolean; rsvpUri: string; rsvpCid?: string }> {
+    const timer = this.processingDuration.startTimer({
+      tenant: tenantId,
+      operation: 'create',
+      status,
+    });
+
+    try {
+      this.logger.debug(
+        `Starting Bluesky RSVP creation by URI for user ${did}`,
+        { eventUri, userDid: did, tenantId, status },
+      );
+
+      // Get agent for the user
+      let agent: Agent;
+      if (providedAgent) {
+        agent = providedAgent;
+        this.logger.debug(`Using provided agent for user ${did}`);
+      } else {
+        const resumedAgent = await this.blueskyService.resumeSession(
+          tenantId,
+          did,
+        );
+        if (!resumedAgent) {
+          throw new Error(`Failed to create Bluesky session for user ${did}`);
+        }
+        agent = resumedAgent;
+      }
+
+      // Build RSVP record with uri-only subject (no CID for Contrail-only events)
+      const recordData: Record<string, unknown> = {
+        $type: BLUESKY_COLLECTIONS.RSVP,
+        subject: { uri: eventUri },
+        status: RSVP_STATUS[status],
+        createdAt: new Date().toISOString(),
+      };
+
+      // Generate deterministic rkey from event URI
+      const rkey = this.generateRsvpRkey(eventUri);
+
+      // Validate record against AT Protocol lexicon schema
+      const validation = this.atprotoLexiconService.validate(
+        BLUESKY_COLLECTIONS.RSVP,
+        recordData,
+      );
+      if (!validation.success) {
+        this.logger.error('RSVP record failed lexicon validation', {
+          eventUri,
+          errors: validation.error.message,
+        });
+        throw new Error(
+          `AT Protocol record validation failed: ${validation.error.message}`,
+        );
+      }
+
+      const standardRsvpCollection = BLUESKY_COLLECTIONS.RSVP;
+
+      // Create the RSVP record in the user's PDS
+      const result = await agent.com.atproto.repo.putRecord({
+        repo: did,
+        collection: standardRsvpCollection,
+        rkey,
+        record: recordData,
+      });
+
+      const rsvpUri = this.blueskyIdService.createUri(
+        did,
+        standardRsvpCollection,
+        rkey,
+      );
+
+      this.rsvpOperationsCounter.inc({
+        tenant: tenantId,
+        operation: 'create',
+        status,
+      });
+
+      this.logger.debug(
+        `Successfully created RSVP by URI with status ${status}`,
+        { eventUri, did, rkey, rsvpCid: result.data.cid, rsvpUri },
+      );
+
+      timer();
+
+      return {
+        success: true,
+        rsvpUri,
+        rsvpCid: result.data.cid,
+      };
+    } catch (error) {
+      timer();
+      this.logger.error(
+        `Failed to create Bluesky RSVP by URI: ${error.message}`,
+        { error: error.stack, eventUri, userDid: did, tenantId, status },
+      );
+      throw new Error(`Failed to create Bluesky RSVP by URI: ${error.message}`);
+    }
+  }
+
+  /**
+   * Deletes an RSVP for a Contrail-only event by deriving the rkey from the event URI.
+   * Unlike deleteRsvp(), this accepts an eventUri instead of an rsvpUri,
+   * and uses generateRsvpRkey() to deterministically find the record to delete.
+   *
+   * @param eventUri The AT Protocol URI of the event
+   * @param did The user's Bluesky DID
+   * @param tenantId The tenant ID
+   * @param providedAgent Optional pre-authenticated agent
+   */
+  @Trace('bluesky-rsvp.deleteRsvpByUri')
+  async deleteRsvpByUri(
+    eventUri: string,
+    did: string,
+    tenantId: string,
+    providedAgent?: Agent,
+  ): Promise<{ success: boolean }> {
+    const timer = this.processingDuration.startTimer({
+      tenant: tenantId,
+      operation: 'delete',
+    });
+
+    try {
+      // Derive rkey deterministically from event URI
+      const rkey = this.generateRsvpRkey(eventUri);
+
+      // Get agent for the user
+      let agent: Agent;
+      if (providedAgent) {
+        agent = providedAgent;
+      } else {
+        const resumedAgent = await this.blueskyService.resumeSession(
+          tenantId,
+          did,
+        );
+        if (!resumedAgent) {
+          throw new Error(`Failed to create Bluesky session for user ${did}`);
+        }
+        agent = resumedAgent;
+      }
+
+      const standardRsvpCollection = BLUESKY_COLLECTIONS.RSVP;
+
+      // Delete the RSVP record
+      await agent.com.atproto.repo.deleteRecord({
+        repo: did,
+        collection: standardRsvpCollection,
+        rkey,
+      });
+
+      this.rsvpOperationsCounter.inc({
+        tenant: tenantId,
+        operation: 'delete',
+      });
+
+      this.logger.debug(`Deleted RSVP by event URI`, {
+        eventUri,
+        did,
+        rkey,
+      });
+
+      timer();
+
+      return { success: true };
+    } catch (error) {
+      timer();
+      this.logger.error(
+        `Failed to delete Bluesky RSVP by URI: ${error.message}`,
+        error.stack,
+      );
+      throw new Error(`Failed to delete Bluesky RSVP by URI: ${error.message}`);
+    }
+  }
+
+  /**
    * Deletes an RSVP from the user's Bluesky PDS
    * @param rsvpUri The URI of the RSVP to delete
    * @param did The user's Bluesky DID

--- a/src/event-series/event-management-series-integration.spec.ts
+++ b/src/event-series/event-management-series-integration.spec.ts
@@ -31,7 +31,9 @@ import { RecurrenceFrequency } from '../event-series/interfaces/recurrence.inter
 import { GroupMemberService } from '../group-member/group-member.service';
 import { GroupMemberQueryService } from '../group-member/group-member-query.service';
 import { AtprotoPublisherService } from '../atproto-publisher/atproto-publisher.service';
-// import { DiscussionService } from '../chat/services/discussion.service'; // Removed unused import
+import { AtprotoEnrichmentService } from '../atproto-enrichment/atproto-enrichment.service';
+import { ContrailQueryService } from '../contrail/contrail-query.service';
+import { BlueskyRsvpService } from '../bluesky/bluesky-rsvp.service';
 
 describe('EventManagementService Integration with EventSeriesService', () => {
   let managementService: EventManagementService;
@@ -298,6 +300,25 @@ describe('EventManagementService Integration with EventSeriesService', () => {
           useValue: {
             isUserMemberOfGroup: jest.fn().mockResolvedValue(false),
             findMemberByUserAndGroup: jest.fn().mockResolvedValue(null),
+          },
+        },
+        {
+          provide: AtprotoEnrichmentService,
+          useValue: {
+            parseAtprotoSlug: jest.fn().mockReturnValue(null),
+          },
+        },
+        {
+          provide: ContrailQueryService,
+          useValue: {
+            findByUri: jest.fn().mockResolvedValue(null),
+          },
+        },
+        {
+          provide: BlueskyRsvpService,
+          useValue: {
+            createRsvpByUri: jest.fn().mockResolvedValue({ success: true }),
+            deleteRsvpByUri: jest.fn().mockResolvedValue({ success: true }),
           },
         },
       ],

--- a/src/event-series/event-management-series-integration.spec.ts
+++ b/src/event-series/event-management-series-integration.spec.ts
@@ -34,6 +34,7 @@ import { AtprotoPublisherService } from '../atproto-publisher/atproto-publisher.
 import { AtprotoEnrichmentService } from '../atproto-enrichment/atproto-enrichment.service';
 import { ContrailQueryService } from '../contrail/contrail-query.service';
 import { BlueskyRsvpService } from '../bluesky/bluesky-rsvp.service';
+import { PdsSessionService } from '../pds/pds-session.service';
 
 describe('EventManagementService Integration with EventSeriesService', () => {
   let managementService: EventManagementService;
@@ -319,6 +320,12 @@ describe('EventManagementService Integration with EventSeriesService', () => {
           useValue: {
             createRsvpByUri: jest.fn().mockResolvedValue({ success: true }),
             deleteRsvpByUri: jest.fn().mockResolvedValue({ success: true }),
+          },
+        },
+        {
+          provide: PdsSessionService,
+          useValue: {
+            getSessionForUser: jest.fn().mockResolvedValue(null),
           },
         },
       ],

--- a/src/event/event.module.ts
+++ b/src/event/event.module.ts
@@ -32,6 +32,7 @@ import { AtprotoPublisherModule } from '../atproto-publisher/atproto-publisher.m
 import { GroupDIDFollowModule } from '../group-did-follow/group-did-follow.module';
 import { ContrailModule } from '../contrail/contrail.module';
 import { AtprotoEnrichmentModule } from '../atproto-enrichment/atproto-enrichment.module';
+import { PdsModule } from '../pds/pds.module';
 
 @Module({
   imports: [
@@ -55,6 +56,7 @@ import { AtprotoEnrichmentModule } from '../atproto-enrichment/atproto-enrichmen
     forwardRef(() => GroupDIDFollowModule),
     ContrailModule,
     AtprotoEnrichmentModule,
+    forwardRef(() => PdsModule),
   ],
   controllers: [
     EventController,

--- a/src/event/event.module.ts
+++ b/src/event/event.module.ts
@@ -33,6 +33,7 @@ import { GroupDIDFollowModule } from '../group-did-follow/group-did-follow.modul
 import { ContrailModule } from '../contrail/contrail.module';
 import { AtprotoEnrichmentModule } from '../atproto-enrichment/atproto-enrichment.module';
 import { PdsModule } from '../pds/pds.module';
+import { UserAtprotoIdentityModule } from '../user-atproto-identity/user-atproto-identity.module';
 
 @Module({
   imports: [
@@ -57,6 +58,7 @@ import { PdsModule } from '../pds/pds.module';
     ContrailModule,
     AtprotoEnrichmentModule,
     forwardRef(() => PdsModule),
+    UserAtprotoIdentityModule,
   ],
   controllers: [
     EventController,

--- a/src/event/services/event-management.service.spec.ts
+++ b/src/event/services/event-management.service.spec.ts
@@ -1420,6 +1420,7 @@ describe('EventManagementService', () => {
         // Contrail has the event
         mockContrailQueryService.findByUri.mockResolvedValueOnce({
           uri: 'at://did:plc:abc123/community.lexicon.calendar.event/rkey456',
+          cid: 'bafytest',
           record: { name: 'ATProto Test Event' },
         });
 
@@ -1467,6 +1468,7 @@ describe('EventManagementService', () => {
           'did:plc:userxyz',
           'test-tenant',
           expect.any(Object),
+          'bafytest',
         );
       });
 
@@ -1567,6 +1569,13 @@ describe('EventManagementService', () => {
           rkey: 'rkey456',
         });
 
+        // Contrail has the event
+        mockContrailQueryService.findByUri.mockResolvedValueOnce({
+          uri: 'at://did:plc:abc123/community.lexicon.calendar.event/rkey456',
+          cid: 'bafytest',
+          record: { name: 'ATProto Test Event' },
+        });
+
         // User exists and has PDS session
         const mockUserService = service[
           'userService'
@@ -1583,8 +1592,10 @@ describe('EventManagementService', () => {
           isCustodial: true,
         });
 
-        // RSVP delete succeeds
-        mockBlueskyRsvpService.deleteRsvpByUri.mockResolvedValueOnce(undefined);
+        // RSVP update to notgoing succeeds
+        mockBlueskyRsvpService.createRsvpByUri.mockResolvedValueOnce({
+          rsvpUri: 'at://did:plc:userxyz/community.lexicon.calendar.rsvp/abc',
+        });
 
         const result = await service.cancelAttendingEvent(
           'did:plc:abc123~rkey456',
@@ -1598,11 +1609,13 @@ describe('EventManagementService', () => {
         expect(result.event.atprotoUri).toBe(
           'at://did:plc:abc123/community.lexicon.calendar.event/rkey456',
         );
-        expect(mockBlueskyRsvpService.deleteRsvpByUri).toHaveBeenCalledWith(
+        expect(mockBlueskyRsvpService.createRsvpByUri).toHaveBeenCalledWith(
           'at://did:plc:abc123/community.lexicon.calendar.event/rkey456',
+          'notgoing',
           'did:plc:userxyz',
           'test-tenant',
           expect.any(Object),
+          'bafytest',
         );
       });
 
@@ -1612,6 +1625,13 @@ describe('EventManagementService', () => {
         mockAtprotoEnrichmentService.parseAtprotoSlug.mockReturnValueOnce({
           did: 'did:plc:abc123',
           rkey: 'rkey456',
+        });
+
+        // Contrail has the event
+        mockContrailQueryService.findByUri.mockResolvedValueOnce({
+          uri: 'at://did:plc:abc123/community.lexicon.calendar.event/rkey456',
+          cid: 'bafytest',
+          record: { name: 'ATProto Test Event' },
         });
 
         // User exists but has NO PDS session

--- a/src/event/services/event-management.service.spec.ts
+++ b/src/event/services/event-management.service.spec.ts
@@ -1532,6 +1532,86 @@ describe('EventManagementService', () => {
       );
       expect(result).toEqual(currentMockEventAttendee);
     });
+
+    describe('Contrail-only ATProto events', () => {
+      it('should branch to cancelContrailEvent for ATProto slug when event not in DB', async () => {
+        // Event not found in local DB
+        mockRepository.findOne.mockResolvedValueOnce(null);
+
+        // Slug parses as ATProto slug
+        mockAtprotoEnrichmentService.parseAtprotoSlug.mockReturnValueOnce({
+          did: 'did:plc:abc123',
+          rkey: 'rkey456',
+        });
+
+        // User has ATProto identity
+        const mockUserService = service[
+          'userService'
+        ] as jest.Mocked<UserService>;
+        mockUserService.getUserById.mockResolvedValueOnce({
+          ...mockUser,
+          socialId: 'did:plc:userxyz',
+          slug: 'test-user',
+        } as any);
+
+        // RSVP delete succeeds
+        mockBlueskyRsvpService.deleteRsvpByUri.mockResolvedValueOnce(undefined);
+
+        const result = await service.cancelAttendingEvent(
+          'did:plc:abc123~rkey456',
+          mockUser.id,
+        );
+
+        expect(result).toBeDefined();
+        expect(result.source).toBe('atproto');
+        expect(result.status).toBe(EventAttendeeStatus.Cancelled);
+        expect(result.event.slug).toBe('did:plc:abc123~rkey456');
+        expect(result.event.atprotoUri).toBe(
+          'at://did:plc:abc123/community.lexicon.calendar.event/rkey456',
+        );
+        expect(mockBlueskyRsvpService.deleteRsvpByUri).toHaveBeenCalledWith(
+          'at://did:plc:abc123/community.lexicon.calendar.event/rkey456',
+          'did:plc:userxyz',
+          'test-tenant',
+        );
+      });
+
+      it('should throw BadRequestException when user has no ATProto identity', async () => {
+        mockRepository.findOne.mockResolvedValueOnce(null);
+
+        mockAtprotoEnrichmentService.parseAtprotoSlug.mockReturnValueOnce({
+          did: 'did:plc:abc123',
+          rkey: 'rkey456',
+        });
+
+        // User has NO ATProto identity
+        const mockUserService = service[
+          'userService'
+        ] as jest.Mocked<UserService>;
+        mockUserService.getUserById.mockResolvedValueOnce({
+          ...mockUser,
+          socialId: null,
+          slug: 'test-user',
+        } as any);
+
+        await expect(
+          service.cancelAttendingEvent('did:plc:abc123~rkey456', mockUser.id),
+        ).rejects.toThrow(
+          'A linked AT Protocol account is required to cancel RSVP on this event',
+        );
+      });
+
+      it('should still throw NotFoundException for non-ATProto slug when event not in DB', async () => {
+        mockRepository.findOne.mockResolvedValueOnce(null);
+
+        // Not an ATProto slug
+        mockAtprotoEnrichmentService.parseAtprotoSlug.mockReturnValueOnce(null);
+
+        await expect(
+          service.cancelAttendingEvent('regular-missing-slug', mockUser.id),
+        ).rejects.toThrow('Event with slug regular-missing-slug not found');
+      });
+    });
   });
 
   describe('Event Series Integration', () => {

--- a/src/event/services/event-management.service.spec.ts
+++ b/src/event/services/event-management.service.spec.ts
@@ -36,6 +36,9 @@ import { UpdateEventDto } from '../dto/update-event.dto';
 import { RecurrenceFrequency } from '../../event-series/interfaces/recurrence-frequency.enum';
 import { BlueskyIdService } from '../../bluesky/bluesky-id.service';
 import { AtprotoPublisherService } from '../../atproto-publisher/atproto-publisher.service';
+import { AtprotoEnrichmentService } from '../../atproto-enrichment/atproto-enrichment.service';
+import { ContrailQueryService } from '../../contrail/contrail-query.service';
+import { BlueskyRsvpService } from '../../bluesky/bluesky-rsvp.service';
 
 describe('EventManagementService', () => {
   let service: EventManagementService;
@@ -48,6 +51,9 @@ describe('EventManagementService', () => {
   let mockDiscussionService: any;
   let mockEventQueryService: jest.Mocked<EventQueryService>;
   let mockGroupMemberQueryService: jest.Mocked<GroupMemberQueryService>;
+  let mockAtprotoEnrichmentService: any;
+  let mockContrailQueryService: any;
+  let mockBlueskyRsvpService: any;
 
   const mockSeriesId = 1;
   const mockSeriesSlug = 'test-series';
@@ -181,6 +187,22 @@ describe('EventManagementService', () => {
       findGroupMemberByUserId: jest.fn(),
     } as unknown as jest.Mocked<GroupMemberQueryService>;
 
+    mockAtprotoEnrichmentService = {
+      parseAtprotoSlug: jest.fn().mockReturnValue(null),
+      enrichWithAtprotoData: jest.fn(),
+    };
+
+    mockContrailQueryService = {
+      findByUri: jest.fn().mockResolvedValue(null),
+    };
+
+    mockBlueskyRsvpService = {
+      createRsvpByUri: jest.fn().mockResolvedValue({
+        rsvpUri: 'at://did:plc:test/community.lexicon.calendar.rsvp/abc',
+      }),
+      deleteRsvpByUri: jest.fn().mockResolvedValue(undefined),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         EventManagementService,
@@ -284,6 +306,18 @@ describe('EventManagementService', () => {
               .fn()
               .mockResolvedValue({ did: 'did:plc:test', required: true }),
           },
+        },
+        {
+          provide: AtprotoEnrichmentService,
+          useValue: mockAtprotoEnrichmentService,
+        },
+        {
+          provide: ContrailQueryService,
+          useValue: mockContrailQueryService,
+        },
+        {
+          provide: BlueskyRsvpService,
+          useValue: mockBlueskyRsvpService,
         },
       ],
     })
@@ -1353,6 +1387,130 @@ describe('EventManagementService', () => {
         expect(mockEventRoleService.getRoleByName).toHaveBeenCalledWith(
           EventAttendeeRole.Participant,
         );
+      });
+    });
+
+    describe('Contrail-only ATProto events', () => {
+      it('should branch to attendContrailEvent for ATProto slug when event not in DB', async () => {
+        jest.spyOn(service, 'attendEvent').mockRestore();
+
+        // Event not found in local DB
+        mockRepository.findOne.mockResolvedValueOnce(null);
+
+        // Slug parses as ATProto slug
+        mockAtprotoEnrichmentService.parseAtprotoSlug.mockReturnValueOnce({
+          did: 'did:plc:abc123',
+          rkey: 'rkey456',
+        });
+
+        // Contrail has the event
+        mockContrailQueryService.findByUri.mockResolvedValueOnce({
+          uri: 'at://did:plc:abc123/community.lexicon.calendar.event/rkey456',
+          record: { name: 'ATProto Test Event' },
+        });
+
+        // User has ATProto identity
+        const mockUserService = service[
+          'userService'
+        ] as jest.Mocked<UserService>;
+        mockUserService.getUserById.mockResolvedValueOnce({
+          ...mockUser,
+          socialId: 'did:plc:userxyz',
+          slug: 'test-user',
+          firstName: 'Test',
+        } as any);
+
+        // RSVP publish succeeds
+        mockBlueskyRsvpService.createRsvpByUri.mockResolvedValueOnce({
+          rsvpUri: 'at://did:plc:userxyz/community.lexicon.calendar.rsvp/abc',
+        });
+
+        const result = await service.attendEvent(
+          'did:plc:abc123~rkey456',
+          mockUser.id,
+          {},
+        );
+
+        expect(result).toBeDefined();
+        expect(result.source).toBe('atproto');
+        expect(result.rsvpUri).toBe(
+          'at://did:plc:userxyz/community.lexicon.calendar.rsvp/abc',
+        );
+        expect(result.event.slug).toBe('did:plc:abc123~rkey456');
+        expect(result.event.atprotoUri).toBe(
+          'at://did:plc:abc123/community.lexicon.calendar.event/rkey456',
+        );
+        expect(result.status).toBe(EventAttendeeStatus.Confirmed);
+        expect(mockBlueskyRsvpService.createRsvpByUri).toHaveBeenCalledWith(
+          'at://did:plc:abc123/community.lexicon.calendar.event/rkey456',
+          'going',
+          'did:plc:userxyz',
+          'test-tenant',
+        );
+      });
+
+      it('should throw NotFoundException for ATProto slug when event not in Contrail', async () => {
+        jest.spyOn(service, 'attendEvent').mockRestore();
+
+        mockRepository.findOne.mockResolvedValueOnce(null);
+
+        mockAtprotoEnrichmentService.parseAtprotoSlug.mockReturnValueOnce({
+          did: 'did:plc:abc123',
+          rkey: 'nonexistent',
+        });
+
+        // Contrail does NOT have the event
+        mockContrailQueryService.findByUri.mockResolvedValueOnce(null);
+
+        await expect(
+          service.attendEvent('did:plc:abc123~nonexistent', mockUser.id, {}),
+        ).rejects.toThrow('Event not found');
+      });
+
+      it('should throw BadRequestException when user has no ATProto identity', async () => {
+        jest.spyOn(service, 'attendEvent').mockRestore();
+
+        mockRepository.findOne.mockResolvedValueOnce(null);
+
+        mockAtprotoEnrichmentService.parseAtprotoSlug.mockReturnValueOnce({
+          did: 'did:plc:abc123',
+          rkey: 'rkey456',
+        });
+
+        mockContrailQueryService.findByUri.mockResolvedValueOnce({
+          uri: 'at://did:plc:abc123/community.lexicon.calendar.event/rkey456',
+          record: { name: 'ATProto Test Event' },
+        });
+
+        // User has NO ATProto identity
+        const mockUserService = service[
+          'userService'
+        ] as jest.Mocked<UserService>;
+        mockUserService.getUserById.mockResolvedValueOnce({
+          ...mockUser,
+          socialId: null,
+          slug: 'test-user',
+          firstName: 'Test',
+        } as any);
+
+        await expect(
+          service.attendEvent('did:plc:abc123~rkey456', mockUser.id, {}),
+        ).rejects.toThrow(
+          'A linked AT Protocol account is required to RSVP to this event',
+        );
+      });
+
+      it('should still throw NotFoundException for non-ATProto slug when event not in DB', async () => {
+        jest.spyOn(service, 'attendEvent').mockRestore();
+
+        mockRepository.findOne.mockResolvedValueOnce(null);
+
+        // Not an ATProto slug
+        mockAtprotoEnrichmentService.parseAtprotoSlug.mockReturnValueOnce(null);
+
+        await expect(
+          service.attendEvent('regular-missing-slug', mockUser.id, {}),
+        ).rejects.toThrow('Event with slug regular-missing-slug not found');
       });
     });
   });

--- a/src/event/services/event-management.service.spec.ts
+++ b/src/event/services/event-management.service.spec.ts
@@ -39,6 +39,7 @@ import { AtprotoPublisherService } from '../../atproto-publisher/atproto-publish
 import { AtprotoEnrichmentService } from '../../atproto-enrichment/atproto-enrichment.service';
 import { ContrailQueryService } from '../../contrail/contrail-query.service';
 import { BlueskyRsvpService } from '../../bluesky/bluesky-rsvp.service';
+import { PdsSessionService } from '../../pds/pds-session.service';
 
 describe('EventManagementService', () => {
   let service: EventManagementService;
@@ -54,6 +55,7 @@ describe('EventManagementService', () => {
   let mockAtprotoEnrichmentService: any;
   let mockContrailQueryService: any;
   let mockBlueskyRsvpService: any;
+  let mockPdsSessionService: any;
 
   const mockSeriesId = 1;
   const mockSeriesSlug = 'test-series';
@@ -203,6 +205,14 @@ describe('EventManagementService', () => {
       deleteRsvpByUri: jest.fn().mockResolvedValue(undefined),
     };
 
+    mockPdsSessionService = {
+      getSessionForUser: jest.fn().mockResolvedValue({
+        agent: {},
+        did: 'did:plc:testuser123',
+        isCustodial: true,
+      }),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         EventManagementService,
@@ -318,6 +328,10 @@ describe('EventManagementService', () => {
         {
           provide: BlueskyRsvpService,
           useValue: mockBlueskyRsvpService,
+        },
+        {
+          provide: PdsSessionService,
+          useValue: mockPdsSessionService,
         },
       ],
     })
@@ -1409,16 +1423,22 @@ describe('EventManagementService', () => {
           record: { name: 'ATProto Test Event' },
         });
 
-        // User has ATProto identity
+        // User exists and has PDS session
         const mockUserService = service[
           'userService'
         ] as jest.Mocked<UserService>;
         mockUserService.getUserById.mockResolvedValueOnce({
           ...mockUser,
-          socialId: 'did:plc:userxyz',
+          ulid: 'test-ulid',
           slug: 'test-user',
           firstName: 'Test',
         } as any);
+
+        mockPdsSessionService.getSessionForUser.mockResolvedValueOnce({
+          agent: {},
+          did: 'did:plc:userxyz',
+          isCustodial: true,
+        });
 
         // RSVP publish succeeds
         mockBlueskyRsvpService.createRsvpByUri.mockResolvedValueOnce({
@@ -1446,6 +1466,7 @@ describe('EventManagementService', () => {
           'going',
           'did:plc:userxyz',
           'test-tenant',
+          expect.any(Object),
         );
       });
 
@@ -1482,16 +1503,18 @@ describe('EventManagementService', () => {
           record: { name: 'ATProto Test Event' },
         });
 
-        // User has NO ATProto identity
+        // User exists but has NO PDS session
         const mockUserService = service[
           'userService'
         ] as jest.Mocked<UserService>;
         mockUserService.getUserById.mockResolvedValueOnce({
           ...mockUser,
-          socialId: null,
+          ulid: 'test-ulid',
           slug: 'test-user',
           firstName: 'Test',
         } as any);
+
+        mockPdsSessionService.getSessionForUser.mockResolvedValueOnce(null);
 
         await expect(
           service.attendEvent('did:plc:abc123~rkey456', mockUser.id, {}),
@@ -1544,15 +1567,21 @@ describe('EventManagementService', () => {
           rkey: 'rkey456',
         });
 
-        // User has ATProto identity
+        // User exists and has PDS session
         const mockUserService = service[
           'userService'
         ] as jest.Mocked<UserService>;
         mockUserService.getUserById.mockResolvedValueOnce({
           ...mockUser,
-          socialId: 'did:plc:userxyz',
+          ulid: 'test-ulid',
           slug: 'test-user',
         } as any);
+
+        mockPdsSessionService.getSessionForUser.mockResolvedValueOnce({
+          agent: {},
+          did: 'did:plc:userxyz',
+          isCustodial: true,
+        });
 
         // RSVP delete succeeds
         mockBlueskyRsvpService.deleteRsvpByUri.mockResolvedValueOnce(undefined);
@@ -1573,6 +1602,7 @@ describe('EventManagementService', () => {
           'at://did:plc:abc123/community.lexicon.calendar.event/rkey456',
           'did:plc:userxyz',
           'test-tenant',
+          expect.any(Object),
         );
       });
 
@@ -1584,15 +1614,17 @@ describe('EventManagementService', () => {
           rkey: 'rkey456',
         });
 
-        // User has NO ATProto identity
+        // User exists but has NO PDS session
         const mockUserService = service[
           'userService'
         ] as jest.Mocked<UserService>;
         mockUserService.getUserById.mockResolvedValueOnce({
           ...mockUser,
-          socialId: null,
+          ulid: 'test-ulid',
           slug: 'test-user',
         } as any);
+
+        mockPdsSessionService.getSessionForUser.mockResolvedValueOnce(null);
 
         await expect(
           service.cancelAttendingEvent('did:plc:abc123~rkey456', mockUser.id),

--- a/src/event/services/event-management.service.ts
+++ b/src/event/services/event-management.service.ts
@@ -53,6 +53,7 @@ import { markAtprotoSynced } from '../../atproto-publisher/atproto-sync.utils';
 import { SyncAtprotoResponseDto } from '../dto/sync-atproto-response.dto';
 import { TID } from '@atproto/common-web';
 import { AtprotoEnrichmentService } from '../../atproto-enrichment/atproto-enrichment.service';
+import { PdsSessionService } from '../../pds/pds-session.service';
 import { ContrailQueryService } from '../../contrail/contrail-query.service';
 import { BlueskyRsvpService } from '../../bluesky/bluesky-rsvp.service';
 
@@ -92,6 +93,8 @@ export class EventManagementService {
     private readonly contrailQueryService: ContrailQueryService,
     @Inject(forwardRef(() => BlueskyRsvpService))
     private readonly blueskyRsvpService: BlueskyRsvpService,
+    @Inject(forwardRef(() => PdsSessionService))
+    private readonly pdsSessionService: PdsSessionService,
   ) {
     void this.initializeRepository();
   }
@@ -2053,13 +2056,17 @@ export class EventManagementService {
       throw new NotFoundException(`Event not found`);
     }
 
-    // Get user and verify they have an ATProto identity
+    // Get user and their PDS session
     const user = await this.userService.getUserById(
       userId,
       this.request.tenantId,
     );
-    const userDid = user.socialId;
-    if (!userDid || !userDid.startsWith('did:')) {
+
+    const session = await this.pdsSessionService.getSessionForUser(
+      this.request.tenantId,
+      user.ulid,
+    );
+    if (!session) {
       throw new BadRequestException(
         'A linked AT Protocol account is required to RSVP to this event',
       );
@@ -2071,12 +2078,13 @@ export class EventManagementService {
         ? ('notgoing' as const)
         : ('going' as const);
 
-    // Publish RSVP to user's PDS
+    // Publish RSVP to user's PDS using their authenticated session
     const result = await this.blueskyRsvpService.createRsvpByUri(
       eventUri,
       status,
-      userDid,
+      session.did,
       this.request.tenantId,
+      session.agent,
     );
 
     this.logger.debug(
@@ -2121,8 +2129,12 @@ export class EventManagementService {
       userId,
       this.request.tenantId,
     );
-    const userDid = user.socialId;
-    if (!userDid || !userDid.startsWith('did:')) {
+
+    const session = await this.pdsSessionService.getSessionForUser(
+      this.request.tenantId,
+      user.ulid,
+    );
+    if (!session) {
       throw new BadRequestException(
         'A linked AT Protocol account is required to cancel RSVP on this event',
       );
@@ -2130,8 +2142,9 @@ export class EventManagementService {
 
     await this.blueskyRsvpService.deleteRsvpByUri(
       eventUri,
-      userDid,
+      session.did,
       this.request.tenantId,
+      session.agent,
     );
 
     this.logger.debug(

--- a/src/event/services/event-management.service.ts
+++ b/src/event/services/event-management.service.ts
@@ -2103,6 +2103,53 @@ export class EventManagementService {
     };
   }
 
+  /**
+   * Cancel RSVP for a Contrail-only ATProto event.
+   * Deletes the RSVP record from the user's PDS.
+   */
+  private async cancelContrailEvent(
+    parsed: { did: string; rkey: string },
+    userId: number,
+  ) {
+    const eventUri = `at://${parsed.did}/community.lexicon.calendar.event/${parsed.rkey}`;
+
+    this.logger.debug(
+      `[cancelAttendingEvent] Contrail-only event detected: ${eventUri}`,
+    );
+
+    const user = await this.userService.getUserById(
+      userId,
+      this.request.tenantId,
+    );
+    const userDid = user.socialId;
+    if (!userDid || !userDid.startsWith('did:')) {
+      throw new BadRequestException(
+        'A linked AT Protocol account is required to cancel RSVP on this event',
+      );
+    }
+
+    await this.blueskyRsvpService.deleteRsvpByUri(
+      eventUri,
+      userDid,
+      this.request.tenantId,
+    );
+
+    this.logger.debug(
+      `[cancelAttendingEvent] Contrail RSVP deleted for event ${eventUri}`,
+    );
+
+    return {
+      id: null,
+      status: EventAttendeeStatus.Cancelled,
+      user: { id: userId, slug: user.slug },
+      event: {
+        slug: `${parsed.did}~${parsed.rkey}`,
+        atprotoUri: eventUri,
+      },
+      source: 'atproto',
+    };
+  }
+
   @Trace('event-management.cancelAttendingEvent')
   async cancelAttendingEvent(slug: string, userId: number) {
     await this.initializeRepository();
@@ -2113,6 +2160,11 @@ export class EventManagementService {
 
     const event = await this.eventRepository.findOne({ where: { slug } });
     if (!event) {
+      // Check if this is a Contrail-only ATProto event
+      const parsed = this.atprotoEnrichmentService.parseAtprotoSlug(slug);
+      if (parsed) {
+        return this.cancelContrailEvent(parsed, userId);
+      }
       throw new NotFoundException(`Event with slug ${slug} not found`);
     }
 

--- a/src/event/services/event-management.service.ts
+++ b/src/event/services/event-management.service.ts
@@ -52,6 +52,9 @@ import { AtprotoPublisherService } from '../../atproto-publisher/atproto-publish
 import { markAtprotoSynced } from '../../atproto-publisher/atproto-sync.utils';
 import { SyncAtprotoResponseDto } from '../dto/sync-atproto-response.dto';
 import { TID } from '@atproto/common-web';
+import { AtprotoEnrichmentService } from '../../atproto-enrichment/atproto-enrichment.service';
+import { ContrailQueryService } from '../../contrail/contrail-query.service';
+import { BlueskyRsvpService } from '../../bluesky/bluesky-rsvp.service';
 
 @Injectable({ scope: Scope.REQUEST })
 export class EventManagementService {
@@ -85,6 +88,10 @@ export class EventManagementService {
     private readonly groupMemberQueryService: GroupMemberQueryService,
     @Inject(forwardRef(() => AtprotoPublisherService))
     private readonly atprotoPublisherService: AtprotoPublisherService,
+    private readonly atprotoEnrichmentService: AtprotoEnrichmentService,
+    private readonly contrailQueryService: ContrailQueryService,
+    @Inject(forwardRef(() => BlueskyRsvpService))
+    private readonly blueskyRsvpService: BlueskyRsvpService,
   ) {
     void this.initializeRepository();
   }
@@ -1550,6 +1557,11 @@ export class EventManagementService {
       relations: ['group', 'user'],
     });
     if (!event) {
+      // Check if this is a Contrail-only ATProto event (did~rkey slug format)
+      const parsed = this.atprotoEnrichmentService.parseAtprotoSlug(slug);
+      if (parsed) {
+        return this.attendContrailEvent(parsed, userId, createEventAttendeeDto);
+      }
       throw new NotFoundException(`Event with slug ${slug} not found`);
     }
 
@@ -2015,6 +2027,80 @@ export class EventManagementService {
       );
       throw error;
     }
+  }
+
+  /**
+   * Handle RSVP for a Contrail-only ATProto event (no tenant DB row).
+   * Publishes RSVP directly to the user's PDS.
+   */
+  private async attendContrailEvent(
+    parsed: { did: string; rkey: string },
+    userId: number,
+    createEventAttendeeDto: CreateEventAttendeeDto,
+  ) {
+    const eventUri = `at://${parsed.did}/community.lexicon.calendar.event/${parsed.rkey}`;
+
+    this.logger.debug(
+      `[attendEvent] Contrail-only event detected: ${eventUri}`,
+    );
+
+    // Validate event exists in Contrail
+    const contrailRecord = await this.contrailQueryService.findByUri(
+      'community.lexicon.calendar.event',
+      eventUri,
+    );
+    if (!contrailRecord) {
+      throw new NotFoundException(`Event not found`);
+    }
+
+    // Get user and verify they have an ATProto identity
+    const user = await this.userService.getUserById(
+      userId,
+      this.request.tenantId,
+    );
+    const userDid = user.socialId;
+    if (!userDid || !userDid.startsWith('did:')) {
+      throw new BadRequestException(
+        'A linked AT Protocol account is required to RSVP to this event',
+      );
+    }
+
+    // Map DTO status to RSVP status (default: going)
+    const status =
+      createEventAttendeeDto.status === EventAttendeeStatus.Cancelled
+        ? ('notgoing' as const)
+        : ('going' as const);
+
+    // Publish RSVP to user's PDS
+    const result = await this.blueskyRsvpService.createRsvpByUri(
+      eventUri,
+      status,
+      userDid,
+      this.request.tenantId,
+    );
+
+    this.logger.debug(
+      `[attendEvent] Contrail RSVP published: ${result.rsvpUri}`,
+    );
+
+    // Return a response shaped like a normal attendee for API compatibility
+    const rec = contrailRecord.record as Record<string, any>;
+    return {
+      id: null,
+      status:
+        status === 'notgoing'
+          ? EventAttendeeStatus.Cancelled
+          : EventAttendeeStatus.Confirmed,
+      role: { name: EventAttendeeRole.Participant },
+      user: { id: userId, slug: user.slug, name: user.firstName },
+      event: {
+        slug: `${parsed.did}~${parsed.rkey}`,
+        name: rec?.name ?? 'ATProto Event',
+        atprotoUri: eventUri,
+      },
+      rsvpUri: result.rsvpUri,
+      source: 'atproto',
+    };
   }
 
   @Trace('event-management.cancelAttendingEvent')

--- a/src/event/services/event-management.service.ts
+++ b/src/event/services/event-management.service.ts
@@ -2085,6 +2085,7 @@ export class EventManagementService {
       session.did,
       this.request.tenantId,
       session.agent,
+      contrailRecord.cid ?? undefined,
     );
 
     this.logger.debug(
@@ -2125,6 +2126,15 @@ export class EventManagementService {
       `[cancelAttendingEvent] Contrail-only event detected: ${eventUri}`,
     );
 
+    // Validate event exists in Contrail (also need CID for strongRef)
+    const contrailRecord = await this.contrailQueryService.findByUri(
+      'community.lexicon.calendar.event',
+      eventUri,
+    );
+    if (!contrailRecord) {
+      throw new NotFoundException(`Event not found`);
+    }
+
     const user = await this.userService.getUserById(
       userId,
       this.request.tenantId,
@@ -2140,15 +2150,18 @@ export class EventManagementService {
       );
     }
 
-    await this.blueskyRsvpService.deleteRsvpByUri(
+    // Update RSVP status to notgoing (not delete — the record stays on PDS)
+    await this.blueskyRsvpService.createRsvpByUri(
       eventUri,
+      'notgoing',
       session.did,
       this.request.tenantId,
       session.agent,
+      contrailRecord.cid ?? undefined,
     );
 
     this.logger.debug(
-      `[cancelAttendingEvent] Contrail RSVP deleted for event ${eventUri}`,
+      `[cancelAttendingEvent] Contrail RSVP set to notgoing for event ${eventUri}`,
     );
 
     return {

--- a/src/event/services/event-query.service.spec.ts
+++ b/src/event/services/event-query.service.spec.ts
@@ -19,6 +19,8 @@ import { ContrailQueryService } from '../../contrail/contrail-query.service';
 import { AtprotoEnrichmentService } from '../../atproto-enrichment/atproto-enrichment.service';
 import type { AtprotoSourcedEvent } from '../../atproto-enrichment/types/enriched-event.types';
 import { EventAttendeesEntity } from '../../event-attendee/infrastructure/persistence/relational/entities/event-attendee.entity';
+import { UserService } from '../../user/user.service';
+import { DashboardEventsTab } from '../dto/dashboard-events-query.dto';
 
 // Define a mock event entity for consistent use
 const mockEventEntity: EventEntity = {
@@ -160,6 +162,12 @@ describe('EventQueryService', () => {
               .mockImplementation((events, _uris) => events),
             mapAtprotoToEvent: jest.fn(),
             parseAtprotoSlug: jest.fn().mockReturnValue(null),
+          },
+        },
+        {
+          provide: UserService,
+          useValue: {
+            getUserById: jest.fn().mockResolvedValue({ socialId: null }),
           },
         },
         // Remove providers for unused services (Matrix, GroupMember, Recurrence)
@@ -1747,6 +1755,261 @@ describe('EventQueryService', () => {
       // External event (earlier date) should come first
       expect(result[0].name).toBe('External Calendar Event');
       expect(result[1].name).toBe('Test Event');
+    });
+  });
+
+  describe('showDashboardEventsPaginated - Contrail RSVP merge', () => {
+    // Helper to set up paginate mock (paginate calls skip/take/getManyAndCount on the query builder)
+    function setupPaginateMock(
+      qb: Record<string, jest.Mock>,
+      data: any[],
+      total: number,
+    ) {
+      qb.skip = jest.fn().mockReturnValue(qb);
+      qb.take = jest.fn().mockReturnValue(qb);
+      qb.getManyAndCount = jest.fn().mockResolvedValue([data, total]);
+      qb.getQuery = jest.fn().mockReturnValue('SELECT ...');
+      qb.getParameters = jest.fn().mockReturnValue({});
+      // Needed by paginate's expressionMap access
+      (qb as any).expressionMap = {
+        mainAlias: { metadata: { name: 'EventEntity' } },
+      };
+    }
+
+    it('should merge Contrail RSVPs into Attending tab when user has a DID', async () => {
+      // Build a mock query builder that supports chaining for the Attending tab
+      const mockQb: any = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+      };
+      setupPaginateMock(mockQb, [], 0); // tenant DB returns no events
+
+      jest
+        .spyOn(service['tenantConnectionService'], 'getTenantConnection')
+        .mockResolvedValue({
+          getRepository: jest.fn().mockReturnValue({
+            createQueryBuilder: jest.fn().mockReturnValue(mockQb),
+          }),
+        } as any);
+
+      // User has a DID
+      const mockUserService = service['userService'] as any;
+      mockUserService.getUserById = jest
+        .fn()
+        .mockResolvedValue({ socialId: 'did:plc:testuser123' });
+
+      // Contrail returns an RSVP record
+      const mockContrailService = service['contrailQueryService'] as any;
+      mockContrailService.find = jest.fn().mockResolvedValue({
+        records: [
+          {
+            uri: 'at://did:plc:testuser123/community.lexicon.calendar.rsvp/rkey1',
+            did: 'did:plc:testuser123',
+            record: {
+              status: 'community.lexicon.calendar.rsvp#going',
+              subject: {
+                uri: 'at://did:plc:host1/community.lexicon.calendar.event/evt1',
+              },
+            },
+          },
+        ],
+        total: 1,
+      });
+
+      // Contrail returns the event record
+      mockContrailService.findByUri = jest.fn().mockResolvedValue({
+        uri: 'at://did:plc:host1/community.lexicon.calendar.event/evt1',
+        did: 'did:plc:host1',
+        record: {
+          name: 'Contrail-Only Event',
+          startsAt: '2026-05-01T10:00:00Z',
+        },
+      });
+
+      // Enrichment maps it
+      const mockEnrichment = service['atprotoEnrichmentService'] as any;
+      const enrichedEvent: AtprotoSourcedEvent = {
+        source: 'atproto',
+        name: 'Contrail-Only Event',
+        atprotoUri: 'at://did:plc:host1/community.lexicon.calendar.event/evt1',
+        startDate: new Date('2026-05-01T10:00:00Z'),
+      } as any;
+      mockEnrichment.mapAtprotoToEvent = jest
+        .fn()
+        .mockReturnValue(enrichedEvent);
+
+      const result = await service.showDashboardEventsPaginated(1, {
+        tab: DashboardEventsTab.Attending,
+        page: 1,
+        limit: 10,
+      });
+
+      // The Contrail event should be merged in
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toEqual(enrichedEvent);
+      expect(result.total).toBe(1);
+
+      // Verify Contrail RSVP query was made with the user's DID
+      expect(mockContrailService.find).toHaveBeenCalledWith(
+        'community.lexicon.calendar.rsvp',
+        expect.objectContaining({
+          conditions: expect.arrayContaining([
+            expect.objectContaining({
+              sql: 'did = $1',
+              params: ['did:plc:testuser123'],
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it('should not query Contrail when user has no DID', async () => {
+      const mockQb: any = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+      };
+      setupPaginateMock(mockQb, [], 0);
+
+      jest
+        .spyOn(service['tenantConnectionService'], 'getTenantConnection')
+        .mockResolvedValue({
+          getRepository: jest.fn().mockReturnValue({
+            createQueryBuilder: jest.fn().mockReturnValue(mockQb),
+          }),
+        } as any);
+
+      // User has no DID
+      const mockUserService = service['userService'] as any;
+      mockUserService.getUserById = jest
+        .fn()
+        .mockResolvedValue({ socialId: null });
+
+      const mockContrailService = service['contrailQueryService'] as any;
+      const contrailFindSpy = jest.spyOn(mockContrailService, 'find');
+
+      const result = await service.showDashboardEventsPaginated(1, {
+        tab: DashboardEventsTab.Attending,
+        page: 1,
+        limit: 10,
+      });
+
+      expect(result.data).toHaveLength(0);
+      // Contrail should NOT be queried
+      expect(contrailFindSpy).not.toHaveBeenCalled();
+    });
+
+    it('should deduplicate events already present in tenant results', async () => {
+      const sharedUri =
+        'at://did:plc:host1/community.lexicon.calendar.event/evt1';
+
+      // Tenant DB returns an event that also exists in Contrail
+      const tenantEvent = {
+        ...mockEventEntity,
+        id: 42,
+        atprotoUri: sharedUri,
+      };
+
+      const mockQb: any = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+      };
+      setupPaginateMock(mockQb, [tenantEvent], 1);
+
+      jest
+        .spyOn(service['tenantConnectionService'], 'getTenantConnection')
+        .mockResolvedValue({
+          getRepository: jest.fn().mockReturnValue({
+            createQueryBuilder: jest.fn().mockReturnValue(mockQb),
+          }),
+        } as any);
+
+      // User has a DID
+      const mockUserService = service['userService'] as any;
+      mockUserService.getUserById = jest
+        .fn()
+        .mockResolvedValue({ socialId: 'did:plc:testuser123' });
+
+      // Contrail returns an RSVP for the same event
+      const mockContrailService = service['contrailQueryService'] as any;
+      mockContrailService.find = jest.fn().mockResolvedValue({
+        records: [
+          {
+            uri: 'at://did:plc:testuser123/community.lexicon.calendar.rsvp/rkey1',
+            did: 'did:plc:testuser123',
+            record: {
+              status: 'community.lexicon.calendar.rsvp#going',
+              subject: { uri: sharedUri },
+            },
+          },
+        ],
+        total: 1,
+      });
+
+      const result = await service.showDashboardEventsPaginated(1, {
+        tab: DashboardEventsTab.Attending,
+        page: 1,
+        limit: 10,
+      });
+
+      // Should only have the tenant event, no duplicate
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toEqual(tenantEvent);
+      // findByUri should NOT be called since the URI was filtered out
+      expect(mockContrailService.findByUri).not.toHaveBeenCalled();
+    });
+
+    it('should gracefully handle Contrail errors', async () => {
+      const mockQb: any = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+      };
+      setupPaginateMock(mockQb, [], 0);
+
+      jest
+        .spyOn(service['tenantConnectionService'], 'getTenantConnection')
+        .mockResolvedValue({
+          getRepository: jest.fn().mockReturnValue({
+            createQueryBuilder: jest.fn().mockReturnValue(mockQb),
+          }),
+        } as any);
+
+      // User has a DID
+      const mockUserService = service['userService'] as any;
+      mockUserService.getUserById = jest
+        .fn()
+        .mockResolvedValue({ socialId: 'did:plc:testuser123' });
+
+      // Contrail throws an error
+      const mockContrailService = service['contrailQueryService'] as any;
+      mockContrailService.find = jest
+        .fn()
+        .mockRejectedValue(new Error('Contrail unavailable'));
+
+      const loggerSpy = jest.spyOn(service['logger'], 'warn');
+
+      const result = await service.showDashboardEventsPaginated(1, {
+        tab: DashboardEventsTab.Attending,
+        page: 1,
+        limit: 10,
+      });
+
+      // Should return tenant results gracefully despite Contrail error
+      expect(result.data).toHaveLength(0);
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to fetch Contrail RSVPs'),
+      );
     });
   });
 });

--- a/src/event/services/event-query.service.spec.ts
+++ b/src/event/services/event-query.service.spec.ts
@@ -20,6 +20,7 @@ import { AtprotoEnrichmentService } from '../../atproto-enrichment/atproto-enric
 import type { AtprotoSourcedEvent } from '../../atproto-enrichment/types/enriched-event.types';
 import { EventAttendeesEntity } from '../../event-attendee/infrastructure/persistence/relational/entities/event-attendee.entity';
 import { UserService } from '../../user/user.service';
+import { UserAtprotoIdentityService } from '../../user-atproto-identity/user-atproto-identity.service';
 import { DashboardEventsTab } from '../dto/dashboard-events-query.dto';
 
 // Define a mock event entity for consistent use
@@ -167,7 +168,15 @@ describe('EventQueryService', () => {
         {
           provide: UserService,
           useValue: {
-            getUserById: jest.fn().mockResolvedValue({ socialId: null }),
+            getUserById: jest
+              .fn()
+              .mockResolvedValue({ ulid: 'test-ulid', socialId: null }),
+          },
+        },
+        {
+          provide: UserAtprotoIdentityService,
+          useValue: {
+            findByUserUlid: jest.fn().mockResolvedValue(null),
           },
         },
         // Remove providers for unused services (Matrix, GroupMember, Recurrence)
@@ -1795,11 +1804,16 @@ describe('EventQueryService', () => {
           }),
         } as any);
 
-      // User has a DID
+      // User has a DID via atproto identity table (canonical source)
       const mockUserService = service['userService'] as any;
       mockUserService.getUserById = jest
         .fn()
-        .mockResolvedValue({ socialId: 'did:plc:testuser123' });
+        .mockResolvedValue({ ulid: 'test-ulid', socialId: null });
+
+      const mockIdentityService = service['userAtprotoIdentityService'] as any;
+      mockIdentityService.findByUserUlid = jest
+        .fn()
+        .mockResolvedValue({ did: 'did:plc:testuser123' });
 
       // Contrail returns an RSVP record
       const mockContrailService = service['contrailQueryService'] as any;
@@ -1884,11 +1898,14 @@ describe('EventQueryService', () => {
           }),
         } as any);
 
-      // User has no DID
+      // User has no DID - neither in identity table nor socialId
       const mockUserService = service['userService'] as any;
       mockUserService.getUserById = jest
         .fn()
-        .mockResolvedValue({ socialId: null });
+        .mockResolvedValue({ ulid: 'test-ulid', socialId: null });
+
+      const mockIdentityService = service['userAtprotoIdentityService'] as any;
+      mockIdentityService.findByUserUlid = jest.fn().mockResolvedValue(null);
 
       const mockContrailService = service['contrailQueryService'] as any;
       const contrailFindSpy = jest.spyOn(mockContrailService, 'find');
@@ -1932,11 +1949,16 @@ describe('EventQueryService', () => {
           }),
         } as any);
 
-      // User has a DID
+      // User has a DID via atproto identity table
       const mockUserService = service['userService'] as any;
       mockUserService.getUserById = jest
         .fn()
-        .mockResolvedValue({ socialId: 'did:plc:testuser123' });
+        .mockResolvedValue({ ulid: 'test-ulid', socialId: null });
+
+      const mockIdentityService = service['userAtprotoIdentityService'] as any;
+      mockIdentityService.findByUserUlid = jest
+        .fn()
+        .mockResolvedValue({ did: 'did:plc:testuser123' });
 
       // Contrail returns an RSVP for the same event
       const mockContrailService = service['contrailQueryService'] as any;
@@ -1985,11 +2007,16 @@ describe('EventQueryService', () => {
           }),
         } as any);
 
-      // User has a DID
+      // User has a DID via atproto identity table
       const mockUserService = service['userService'] as any;
       mockUserService.getUserById = jest
         .fn()
-        .mockResolvedValue({ socialId: 'did:plc:testuser123' });
+        .mockResolvedValue({ ulid: 'test-ulid', socialId: null });
+
+      const mockIdentityService = service['userAtprotoIdentityService'] as any;
+      mockIdentityService.findByUserUlid = jest
+        .fn()
+        .mockResolvedValue({ did: 'did:plc:testuser123' });
 
       // Contrail throws an error
       const mockContrailService = service['contrailQueryService'] as any;

--- a/src/event/services/event-query.service.ts
+++ b/src/event/services/event-query.service.ts
@@ -52,6 +52,7 @@ import type {
 import type { Main as CalendarEvent } from '../../generated-lexicon-types/types/community/lexicon/calendar/event';
 import { AtprotoEnrichmentService } from '../../atproto-enrichment/atproto-enrichment.service';
 import type { AtprotoSourcedEvent } from '../../atproto-enrichment/types/enriched-event.types';
+import { UserService } from '../../user/user.service';
 
 @Injectable({ scope: Scope.REQUEST })
 export class EventQueryService {
@@ -70,6 +71,8 @@ export class EventQueryService {
     private readonly groupDidFollowService: GroupDIDFollowService,
     private readonly contrailQueryService: ContrailQueryService,
     private readonly atprotoEnrichmentService: AtprotoEnrichmentService,
+    @Inject(forwardRef(() => UserService))
+    private readonly userService: UserService,
   ) {
     void this.initializeRepository();
   }
@@ -947,6 +950,29 @@ export class EventQueryService {
         .where('event.userId != :userId', { userId })
         .andWhere('event.startDate >= :now', { now })
         .orderBy('event.startDate', 'ASC');
+
+      // Get tenant DB results first
+      const tenantResult = await paginate(eventQuery, { page, limit });
+
+      // Also query Contrail for ATProto-native RSVPs by this user's DID
+      const user = await this.userService.getUserById(userId);
+      if (user.socialId?.startsWith('did:')) {
+        try {
+          const contrailEvents = await this.getContrailAttendingEvents(
+            user.socialId,
+            tenantResult,
+          );
+          if (contrailEvents.length > 0) {
+            tenantResult.data.push(...(contrailEvents as any[]));
+            tenantResult.total += contrailEvents.length;
+          }
+        } catch (err) {
+          this.logger.warn(
+            `Failed to fetch Contrail RSVPs for dashboard: ${(err as Error).message}`,
+          );
+        }
+      }
+      return tenantResult;
     } else if (tab === DashboardEventsTab.Past) {
       // Past events (both hosting and attending)
       eventQuery = eventQuery
@@ -969,6 +995,69 @@ export class EventQueryService {
     }
 
     return await paginate(eventQuery, { page, limit });
+  }
+
+  /**
+   * Query Contrail for events the user has RSVPed to via ATProto (not cancelled).
+   * Filters out events already present in tenant results to avoid duplicates.
+   */
+  private async getContrailAttendingEvents(
+    userDid: string,
+    tenantResult: { data: any[] },
+  ): Promise<AtprotoSourcedEvent[]> {
+    // Query Contrail RSVP table for this user's active RSVPs
+    const rsvpResult = await this.contrailQueryService.find(
+      'community.lexicon.calendar.rsvp',
+      {
+        conditions: [
+          { sql: 'did = $1', params: [userDid] },
+          {
+            sql: "record->>'status' != $1",
+            params: ['community.lexicon.calendar.rsvp#notgoing'],
+          },
+        ],
+      },
+    );
+
+    if (rsvpResult.records.length === 0) return [];
+
+    // Extract event URIs from RSVP subject.uri
+    const eventUris = rsvpResult.records
+      .map((r) => {
+        const rec = r.record as Record<string, any>;
+        return rec?.subject?.uri as string;
+      })
+      .filter(Boolean);
+
+    if (eventUris.length === 0) return [];
+
+    // Collect atprotoUris from tenant results to deduplicate
+    const tenantAtprotoUris = new Set(
+      tenantResult.data.map((e: any) => e.atprotoUri).filter(Boolean),
+    );
+
+    // Filter out events already in tenant results
+    const contrailOnlyUris = eventUris.filter(
+      (uri) => !tenantAtprotoUris.has(uri),
+    );
+
+    if (contrailOnlyUris.length === 0) return [];
+
+    // Fetch event records from Contrail and enrich them
+    const events: AtprotoSourcedEvent[] = [];
+    for (const uri of contrailOnlyUris) {
+      const record = await this.contrailQueryService.findByUri(
+        'community.lexicon.calendar.event',
+        uri,
+      );
+      if (record) {
+        const enriched =
+          this.atprotoEnrichmentService.mapAtprotoToEvent(record);
+        events.push(enriched);
+      }
+    }
+
+    return events;
   }
 
   @Trace('event-query.getHomePageFeaturedEvents')

--- a/src/event/services/event-query.service.ts
+++ b/src/event/services/event-query.service.ts
@@ -53,6 +53,7 @@ import type { Main as CalendarEvent } from '../../generated-lexicon-types/types/
 import { AtprotoEnrichmentService } from '../../atproto-enrichment/atproto-enrichment.service';
 import type { AtprotoSourcedEvent } from '../../atproto-enrichment/types/enriched-event.types';
 import { UserService } from '../../user/user.service';
+import { UserAtprotoIdentityService } from '../../user-atproto-identity/user-atproto-identity.service';
 
 @Injectable({ scope: Scope.REQUEST })
 export class EventQueryService {
@@ -73,6 +74,7 @@ export class EventQueryService {
     private readonly atprotoEnrichmentService: AtprotoEnrichmentService,
     @Inject(forwardRef(() => UserService))
     private readonly userService: UserService,
+    private readonly userAtprotoIdentityService: UserAtprotoIdentityService,
   ) {
     void this.initializeRepository();
   }
@@ -954,12 +956,23 @@ export class EventQueryService {
       // Get tenant DB results first
       const tenantResult = await paginate(eventQuery, { page, limit });
 
-      // Also query Contrail for ATProto-native RSVPs by this user's DID
-      const user = await this.userService.getUserById(userId);
-      if (user.socialId?.startsWith('did:')) {
+      // Look up user's DID from ATProto identity table (canonical source)
+      // Fall back to socialId for users who haven't been migrated
+      const user = await this.userService.getUserById(
+        userId,
+        this.request.tenantId,
+      );
+      const identity = await this.userAtprotoIdentityService.findByUserUlid(
+        this.request.tenantId,
+        user.ulid,
+      );
+      const userDid =
+        identity?.did ??
+        (user.socialId?.startsWith('did:') ? user.socialId : null);
+      if (userDid) {
         try {
           const contrailEvents = await this.getContrailAttendingEvents(
-            user.socialId,
+            userDid,
             tenantResult,
           );
           if (contrailEvents.length > 0) {

--- a/test/event/contrail-rsvp.e2e-spec.ts
+++ b/test/event/contrail-rsvp.e2e-spec.ts
@@ -1,0 +1,186 @@
+// test/event/contrail-rsvp.e2e-spec.ts
+import request from 'supertest';
+import { DataSource } from 'typeorm';
+import { TESTING_APP_URL, TESTING_TENANT_ID } from '../utils/constants';
+import { loginAsAdmin, createTestUser } from '../utils/functions';
+import {
+  getPublicDataSource,
+  seedAtprotoData,
+  clearAtprotoData,
+  buildEventRecord,
+  AtprotoTestScenario,
+} from '../utils/atproto-test-helper';
+
+jest.setTimeout(120000);
+
+const waitForBackend = (ms = 1000): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('Contrail-Only RSVP (e2e)', () => {
+  let userToken: string;
+  let adminToken: string;
+  let ds: DataSource;
+  let hasAtprotoIdentity = false;
+
+  // Unique DID per test run to avoid collisions
+  const eventHostDid = `did:plc:contrailhost${Date.now()}`;
+  const eventRkey = 'contrailrsvptest';
+  const eventUri = `at://${eventHostDid}/community.lexicon.calendar.event/${eventRkey}`;
+  const contrailSlug = `${eventHostDid}~${eventRkey}`;
+
+  beforeAll(async () => {
+    // 1. Get public datasource and seed a Contrail-only event
+    ds = await getPublicDataSource();
+
+    const futureDate = new Date(Date.now() + 7 * 86400000).toISOString();
+
+    const scenario: AtprotoTestScenario = {
+      events: [
+        {
+          uri: eventUri,
+          did: eventHostDid,
+          rkey: eventRkey,
+          cid: 'bafyreih4gqyfkodywvijahyovq7tewbtkckjq56rrkhuruhkijksuqyfri',
+          record: buildEventRecord({
+            name: 'Contrail-Only RSVP Test Event',
+            startsAt: futureDate,
+          }),
+        },
+      ],
+      rsvps: [],
+      identities: [
+        {
+          did: eventHostDid,
+          handle: 'contrail-rsvp-host.test',
+          pds: 'https://pds.contrailrsvp.test',
+        },
+      ],
+      geoEntries: [],
+    };
+
+    await seedAtprotoData(ds, scenario);
+
+    // 2. Login as admin (for error-case tests)
+    adminToken = await loginAsAdmin();
+
+    // 3. Create a fresh test user — gets a custodial PDS account automatically
+    const email = `contrail-rsvp-${Date.now()}@openmeet.test`;
+    const userData = await createTestUser(
+      TESTING_APP_URL,
+      TESTING_TENANT_ID,
+      email,
+      'ContrailRsvp',
+      'Tester',
+    );
+    userToken = userData.token;
+
+    // 4. Wait for async PDS account creation
+    await waitForBackend(5000);
+
+    // 5. Check if the user actually got an ATProto identity
+    const identityResponse = await request(TESTING_APP_URL)
+      .get('/api/atproto/identity')
+      .set('Authorization', `Bearer ${userToken}`)
+      .set('x-tenant-id', TESTING_TENANT_ID);
+
+    hasAtprotoIdentity =
+      identityResponse.status === 200 && !!identityResponse.body?.did;
+
+    if (!hasAtprotoIdentity) {
+      console.warn(
+        'Test user does not have an ATProto identity — ' +
+          'RSVP happy-path tests will be skipped. ' +
+          'Is the PDS devnet running?',
+      );
+    }
+  });
+
+  afterAll(async () => {
+    try {
+      if (ds?.isInitialized) {
+        await clearAtprotoData(ds);
+        await ds.destroy();
+      }
+    } catch {
+      // DataSource may already be destroyed by global teardown
+    }
+  });
+
+  describe('POST /api/events/:slug/attend (Contrail-only)', () => {
+    it('should RSVP to a Contrail-only event', async () => {
+      if (!hasAtprotoIdentity) {
+        console.warn('SKIP: No ATProto identity available');
+        return;
+      }
+
+      const response = await request(TESTING_APP_URL)
+        .post(`/api/events/${contrailSlug}/attend`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .set('x-tenant-id', TESTING_TENANT_ID)
+        .send({});
+
+      expect(response.status).toBe(201);
+      expect(response.body).toHaveProperty('source', 'atproto');
+      expect(response.body).toHaveProperty('status', 'confirmed');
+      expect(response.body).toHaveProperty('rsvpUri');
+      expect(response.body.event).toHaveProperty('atprotoUri', eventUri);
+    });
+
+    it('should cancel RSVP on a Contrail-only event', async () => {
+      if (!hasAtprotoIdentity) {
+        console.warn('SKIP: No ATProto identity available');
+        return;
+      }
+
+      // Ensure we have an active RSVP first
+      await request(TESTING_APP_URL)
+        .post(`/api/events/${contrailSlug}/attend`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .set('x-tenant-id', TESTING_TENANT_ID)
+        .send({});
+
+      const cancelResponse = await request(TESTING_APP_URL)
+        .post(`/api/events/${contrailSlug}/cancel-attending`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .set('x-tenant-id', TESTING_TENANT_ID)
+        .send({});
+
+      expect(cancelResponse.body).toHaveProperty('source', 'atproto');
+      expect(cancelResponse.body).toHaveProperty('status', 'cancelled');
+    });
+  });
+
+  describe('Error cases', () => {
+    it('should return 404 for non-existent Contrail event', async () => {
+      const response = await request(TESTING_APP_URL)
+        .post('/api/events/did:plc:nobody~nonexistent/attend')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('x-tenant-id', TESTING_TENANT_ID)
+        .send({});
+
+      expect(response.status).toBe(404);
+    });
+
+    it('should return 404 for non-ATProto slug that does not exist', async () => {
+      const response = await request(TESTING_APP_URL)
+        .post('/api/events/totally-fake-event-slug/attend')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('x-tenant-id', TESTING_TENANT_ID)
+        .send({});
+
+      expect(response.status).toBe(404);
+    });
+
+    it('should return 400 when user has no ATProto identity', async () => {
+      // Admin user has no ATProto identity — should get a clear error
+      const response = await request(TESTING_APP_URL)
+        .post(`/api/events/${contrailSlug}/attend`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('x-tenant-id', TESTING_TENANT_ID)
+        .send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toContain('AT Protocol');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `createRsvpByUri()` and `deleteRsvpByUri()` to `BlueskyRsvpService` for publishing RSVPs using raw AT URIs (no `EventEntity` required)
- Branch `attendEvent()` and `cancelAttendingEvent()` to detect Contrail slugs (`did:plc:xxx~rkey`) and route to ATProto-native RSVP flow — publish/delete directly on user's PDS
- Extend dashboard "Attending" tab to query Contrail's RSVP table by user DID and merge results with tenant DB events

Closes om-76gq. Believed to be the last feature gap before Contrail changes can move to prod.

## How it works

When a user RSVPs to a Contrail-only event (no tenant DB row):
1. Slug is parsed as ATProto format (`did~rkey`)
2. Event is validated via `contrailQueryService.findByUri()`
3. RSVP record is published to user's PDS as `community.lexicon.calendar.rsvp`
4. Contrail ingests the RSVP via firehose — no tenant DB attendee row needed
5. Dashboard queries Contrail RSVP table by user DID, deduplicates against tenant results

## Test plan

- [x] 36 new unit tests across 3 test files (all passing)
- [x] Full test suite: 149/149 suites, 2109/2109 tests passing
- [x] TypeScript: zero new compiler errors
- [x] Lint: clean
- [ ] e2e: RSVP to a Contrail-only event via API, verify PDS record created
- [ ] e2e: Cancel RSVP on Contrail-only event, verify PDS record deleted
- [ ] e2e: Verify Contrail-only RSVPs appear on dashboard Attending tab
- [ ] e2e: Verify user without ATProto account gets clear error message