### PR TITLE
fix: hotfix release — series limit, past-event RSVP, iCal tracking

### DIFF
--- a/src/attendance/attendance.service.ts
+++ b/src/attendance/attendance.service.ts
@@ -433,6 +433,12 @@ export class AttendanceService {
     const event = resolved.tenantEvent;
     if (!event) return; // Foreign events are always public, no auth needed
 
+    // Prevent RSVP to past events
+    const eventEnd = event.endDate || event.startDate;
+    if (eventEnd && new Date(eventEnd) < new Date()) {
+      throw new BadRequestException('Cannot RSVP to a past event');
+    }
+
     // Private event access control
     if (!resolved.isPublic) {
       if (event.user && event.user.id === userId) return; // Creator always allowed

--- a/src/event-series/services/event-series-occurrence.service.ts
+++ b/src/event-series/services/event-series-occurrence.service.ts
@@ -550,7 +550,7 @@ export class EventSeriesOccurrenceService {
       log('Finding existing events');
       let existingOccurrences: EventEntity[] = [];
       try {
-        const queryLimit = Math.min(effectiveCount * 2, 20); // Reasonable limit to prevent memory issues
+        const queryLimit = 500; // Must cover long-running series (e.g. weekly for 5+ years)
         const [events] =
           await this.eventManagementService.findEventsBySeriesSlug(
             seriesSlug,

--- a/src/event/services/event-management.service.spec.ts
+++ b/src/event/services/event-management.service.spec.ts
@@ -78,8 +78,8 @@ describe('EventManagementService', () => {
     ulid: '01HABCDEFGHJKMNPQRSTVWXY1',
     slug: 'test-event-1',
     name: 'Test Event 1',
-    startDate: new Date('2024-01-01T10:00:00Z'),
-    endDate: new Date('2024-01-01T11:00:00Z'),
+    startDate: new Date('2099-01-01T10:00:00Z'),
+    endDate: new Date('2099-01-01T11:00:00Z'),
   } as EventEntity;
 
   const fullMockEvent2: EventEntity = {
@@ -88,8 +88,8 @@ describe('EventManagementService', () => {
     ulid: '01HABCDEFGHJKMNPQRSTVWXY2',
     slug: 'test-event-2',
     name: 'Test Event 2',
-    startDate: new Date('2024-01-02T10:00:00Z'),
-    endDate: new Date('2024-01-02T11:00:00Z'),
+    startDate: new Date('2099-01-02T10:00:00Z'),
+    endDate: new Date('2099-01-02T11:00:00Z'),
   } as EventEntity;
 
   // Mock for findOne/create results
@@ -99,8 +99,8 @@ describe('EventManagementService', () => {
     ulid: '01HABCDEFGHJKMNPQRSTVWX99',
     slug: 'test-series-event-123',
     name: 'Test Series Event',
-    startDate: new Date('2023-10-01T12:00:00Z'),
-    endDate: new Date('2023-10-01T13:00:00Z'),
+    startDate: new Date('2099-10-01T12:00:00Z'),
+    endDate: new Date('2099-10-01T13:00:00Z'),
   } as EventEntity;
 
   beforeEach(async () => {

--- a/src/event/services/ical/ical.service.spec.ts
+++ b/src/event/services/ical/ical.service.spec.ts
@@ -166,15 +166,15 @@ describe('ICalendarService', () => {
       user: mockOrganizer as UserEntity,
     };
 
-    it('should generate ICS content with METHOD:REQUEST', () => {
+    it('should generate ICS content with METHOD:PUBLISH (informational only)', () => {
       const icsContent = service.generateCalendarInvite(
         mockEvent as EventEntity,
         mockAttendee as UserEntity,
         mockOrganizer as UserEntity,
       );
 
-      expect(icsContent).toContain('METHOD:REQUEST');
-      expect(icsContent).not.toContain('METHOD:PUBLISH');
+      expect(icsContent).toContain('METHOD:PUBLISH');
+      expect(icsContent).not.toContain('METHOD:REQUEST');
     });
 
     it('should include BEGIN:VCALENDAR and END:VCALENDAR', () => {
@@ -212,26 +212,25 @@ describe('ICalendarService', () => {
       expect(icsContent).toContain('organizer@example.com');
     });
 
-    it('should include attendee with PARTSTAT:ACCEPTED', () => {
+    it('should NOT include ATTENDEE properties (no RSVP tracking)', () => {
       const icsContent = service.generateCalendarInvite(
         mockEvent as EventEntity,
         mockAttendee as UserEntity,
         mockOrganizer as UserEntity,
       );
 
-      expect(icsContent).toMatch(/ATTENDEE.*John Doe/);
-      expect(icsContent).toContain('PARTSTAT=ACCEPTED');
-      expect(icsContent).toContain('attendee@example.com');
+      expect(icsContent).not.toContain('ATTENDEE');
+      expect(icsContent).not.toContain('PARTSTAT=ACCEPTED');
     });
 
-    it('should include RSVP:TRUE for attendee', () => {
+    it('should NOT include RSVP=TRUE (calendar is informational only)', () => {
       const icsContent = service.generateCalendarInvite(
         mockEvent as EventEntity,
         mockAttendee as UserEntity,
         mockOrganizer as UserEntity,
       );
 
-      expect(icsContent).toContain('RSVP=TRUE');
+      expect(icsContent).not.toContain('RSVP=TRUE');
     });
 
     it('should set STATUS to CONFIRMED', () => {
@@ -321,7 +320,7 @@ describe('ICalendarService', () => {
       expect(icsContent).toContain('organizer@example.com');
     });
 
-    it('should handle attendee without full name gracefully', () => {
+    it('should not include attendee even when attendee info is provided', () => {
       const attendeeWithoutName = {
         ...mockAttendee,
         firstName: '',
@@ -334,9 +333,8 @@ describe('ICalendarService', () => {
         mockOrganizer as UserEntity,
       );
 
-      // Should still include attendee
-      expect(icsContent).toContain('ATTENDEE');
-      expect(icsContent).toContain('attendee@example.com');
+      // PUBLISH method should never include ATTENDEE
+      expect(icsContent).not.toContain('ATTENDEE');
     });
 
     it('should handle all-day events correctly', () => {

--- a/src/event/services/ical/ical.service.ts
+++ b/src/event/services/ical/ical.service.ts
@@ -217,8 +217,10 @@ export class ICalendarService {
       });
     }
 
-    // Set method to REQUEST for calendar invites
-    calendar.method('REQUEST' as any);
+    // PUBLISH = informational "add to calendar" attachment
+    // REQUEST would trigger accept/decline in email clients, creating a
+    // shadow RSVP channel that bypasses OpenMeet (reported by CRMC)
+    calendar.method('PUBLISH' as any);
 
     // Create the event using existing method
     const calEvent = this.createCalendarEvent(event);
@@ -228,28 +230,8 @@ export class ICalendarService {
       calEvent.url(eventUrl);
     }
 
-    // Override organizer with provided organizer info
-    const organizerName =
-      `${organizer.firstName || ''} ${organizer.lastName || ''}`.trim() ||
-      organizer.email.split('@')[0];
-
-    calEvent.organizer({
-      name: organizerName,
-      email: organizer.email,
-    });
-
-    // Add the specific attendee with ACCEPTED status
-    const attendeeName =
-      `${attendee.firstName || ''} ${attendee.lastName || ''}`.trim() ||
-      attendee.email.split('@')[0];
-
-    calEvent.createAttendee({
-      name: attendeeName,
-      email: attendee.email,
-      rsvp: true,
-      status: 'ACCEPTED' as any,
-      role: 'REQ-PARTICIPANT' as any,
-    });
+    // No ATTENDEE or ORGANIZER override — PUBLISH method doesn't need them.
+    // Organizer is already set by createCalendarEvent() from event.user.
 
     // Add 24-hour reminder
     calEvent.createAlarm({

--- a/test/event-attendees/events-attendees.e2e-spec.ts
+++ b/test/event-attendees/events-attendees.e2e-spec.ts
@@ -42,8 +42,8 @@ describe('EventAttendeeController (e2e)', () => {
         name: 'Test Event',
         slug: `test-event-${Date.now()}`, // Make slug unique
         description: 'A test event',
-        startDate: '2024-12-31T00:00:00Z',
-        endDate: '2024-12-31T23:59:59Z',
+        startDate: '2099-12-31T00:00:00Z',
+        endDate: '2099-12-31T23:59:59Z',
         type: EventType.Hybrid,
         location: 'Test Location',
         locationOnline: 'https://test-online-location.com',

--- a/test/event/calendar-invite.e2e-spec.ts
+++ b/test/event/calendar-invite.e2e-spec.ts
@@ -212,9 +212,9 @@ describe('Calendar Invite E2E', () => {
         expect(icsContent).toContain('BEGIN:VEVENT');
         expect(icsContent).toContain('END:VEVENT');
 
-        // Verify METHOD:REQUEST (calendar invite, not just info)
-        expect(icsContent).toContain('METHOD:REQUEST');
-        console.log('✓ ICS has METHOD:REQUEST');
+        // Verify METHOD:PUBLISH (informational attachment, not auto-RSVP request)
+        expect(icsContent).toContain('METHOD:PUBLISH');
+        console.log('✓ ICS has METHOD:PUBLISH');
 
         // Verify event details are in ICS
         expect(icsContent).toContain(testEvent.name);
@@ -699,9 +699,9 @@ describe('Calendar Invite E2E', () => {
       );
       const icsContent = await icsResponse.text();
 
-      // Should have METHOD:REQUEST for calendar updates
-      expect(icsContent).toContain('METHOD:REQUEST');
-      console.log('✅ ICS uses METHOD:REQUEST for update');
+      // Should have METHOD:PUBLISH for calendar updates (informational attachment)
+      expect(icsContent).toContain('METHOD:PUBLISH');
+      console.log('✅ ICS uses METHOD:PUBLISH for update');
 
       // Should contain the same event UID (so it updates rather than creates new)
       expect(icsContent).toContain(`UID:${testEvent.ulid}`);


### PR DESCRIPTION
## Summary

Hotfix release branch with three user-reported fixes, cut from current prod baseline (`4d06997`) ahead of #574 and #576.

- **Series query limit** (om-gedq): Raised from 20 to 500. Weekly series running 5+ months had newest events truncated, showing as "missed" on the series page. Reported by Steve Munkelt (Kona Freethinkers).
- **Past-event RSVP guard** (om-0214): Block RSVP after event ends. 6 users RSVP'd to a past event because the series page couldn't find the materialized occurrence.
- **iCal METHOD:PUBLISH** (om-5f1m): Calendar invite attachments changed from REQUEST to PUBLISH, removing accept/decline buttons that created a shadow RSVP channel bypassing OpenMeet. Reported by Kurt (CRMC).

## Deploy plan

1. Build image from this branch
2. Deploy to dev, verify fixes
3. Deploy to prod
4. Merge this PR into main after #574/#576 are ready to ship

**Do not merge yet** — this branch should be deployed independently first.

## Test plan

- [ ] Verify Steve's "Weekly Discussion Topics" series shows all 22 events as materialized
- [ ] Verify RSVP to a past event returns 400 error
- [ ] Verify calendar invite email uses METHOD:PUBLISH (no accept/decline buttons)
- [ ] Verify RSVP to future events still works normally