### PR TITLE
feat(contrail): add /xrpc/net.openmeet.event + rsvp endpoints (additive)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ lerna-debug.log*
 k6-tests/results/*.json
 !k6-tests/results/.gitkeep
 
+# Claude Code worktree state (per-developer, never commit)
+.claude/
+
 # IDEs and editors
 /.idea
 .project

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@atmo-dev/contrail": "^0.6.0",
         "@atproto/api": "^0.13.31",
         "@atproto/crypto": "^0.4.5",
         "@atproto/identity": "^0.4.7",
@@ -445,6 +446,248 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@atcute/atproto": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@atcute/atproto/-/atproto-3.1.12.tgz",
+      "integrity": "sha512-SaHY0vV5+VfS2ViOcbYtxPmmh82vbxoK5ccHTGn5+ciHNY2arEVcBUFbIQKtsQP4PPZ+lNAVooH+Wh62flvCzg==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/lexicons": "^1.3.1"
+      },
+      "peerDependencies": {
+        "@atcute/lexicons": "^1.0.0"
+      }
+    },
+    "node_modules/@atcute/cbor": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@atcute/cbor/-/cbor-2.3.3.tgz",
+      "integrity": "sha512-zZ4nHOK837zTMWJtta35YD7pcukrTzDc8jkpIGlSgoDYzu3l4BX3WVgpPJtRn3K6h2v97uyiWfiVjSpM7JSFzQ==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/cid": "^2.4.1",
+        "@atcute/multibase": "^1.2.0",
+        "@atcute/uint8array": "^1.1.1"
+      },
+      "peerDependencies": {
+        "@atcute/cid": "^2.0.0"
+      }
+    },
+    "node_modules/@atcute/cid": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@atcute/cid/-/cid-2.4.1.tgz",
+      "integrity": "sha512-bwhna69RCv7yetXudtj+2qrMPYvhhIQqvJz6YUpUS98v7OdF3X2dnye9Nig2NDrklZcuyOsu7sQo7GOykJXRLQ==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/multibase": "^1.1.8",
+        "@atcute/uint8array": "^1.1.1"
+      }
+    },
+    "node_modules/@atcute/client": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@atcute/client/-/client-4.2.2.tgz",
+      "integrity": "sha512-z16BaGgdO6WIkDCxqeI+zhnh2KmW9jsjd312PJ6YYsoDBpPPqL+WkBmxQ7eO9C6CMFxXsZpYcM81RzZEETA4PQ==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/identity": "^1.1.5",
+        "@atcute/lexicons": "^1.3.1"
+      },
+      "peerDependencies": {
+        "@atcute/lexicons": "^1.0.0"
+      }
+    },
+    "node_modules/@atcute/crypto": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@atcute/crypto/-/crypto-2.4.1.tgz",
+      "integrity": "sha512-tJ3Pi/XYcAsABKtqSlSOTKfO5YiQ4XdqlTuPS8HiRZSezOPcXBFFzAFWpSIJPURbVPFQL3LLrrK0Ea24wl5qeQ==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/multibase": "^1.2.0",
+        "@atcute/uint8array": "^1.1.1",
+        "@noble/secp256k1": "^3.0.0"
+      }
+    },
+    "node_modules/@atcute/identity": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@atcute/identity/-/identity-1.1.5.tgz",
+      "integrity": "sha512-5i9nl1UVnBDPCumUwrLNl4BZpGvQ/XABEXbjhiw3PQwRUfpQA8FqByDGxXy2gWpFDrNvQ9yVuOoNsjzxJgjjVA==",
+      "license": "0BSD",
+      "peer": true,
+      "dependencies": {
+        "@atcute/lexicons": "^1.3.1",
+        "@badrap/valita": "^0.4.6"
+      },
+      "peerDependencies": {
+        "@atcute/lexicons": "^1.0.0"
+      }
+    },
+    "node_modules/@atcute/identity-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@atcute/identity-resolver/-/identity-resolver-1.2.3.tgz",
+      "integrity": "sha512-q891zLUMtgoD60y5Pv2YmTg4wIf4ipFuIhZlIuQTTB7qM9sGxmBbe2quzTRCTl3pnsLEmTz7l+3Dszgoutsp5w==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/lexicons": "^1.3.1",
+        "@atcute/util-fetch": "^1.0.5",
+        "@badrap/valita": "^0.4.6"
+      },
+      "peerDependencies": {
+        "@atcute/identity": "^1.0.0",
+        "@atcute/lexicons": "^1.0.0"
+      }
+    },
+    "node_modules/@atcute/jetstream": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@atcute/jetstream/-/jetstream-1.1.3.tgz",
+      "integrity": "sha512-IlivviByHDKEC+qsfBL2DSHx9MkJxH0vsoYKc0ouZ8HKwXzR/GSwyjZ8TKb2KyVzbVfh1UPifLW9E3lCoGqaOw==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/lexicons": "^1.3.1",
+        "@badrap/valita": "^0.4.6",
+        "@mary-ext/event-iterator": "^1.0.0",
+        "@mary-ext/simple-event-emitter": "^1.0.1",
+        "partysocket": "^1.1.18",
+        "type-fest": "^4.41.0"
+      },
+      "peerDependencies": {
+        "@atcute/lexicons": "^1.0.0"
+      }
+    },
+    "node_modules/@atcute/jetstream/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@atcute/lexicons": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@atcute/lexicons/-/lexicons-1.3.1.tgz",
+      "integrity": "sha512-2JVxDmHt+QwsUoPyVYWIN7ZLRLfLx4GeJxKFjA9ofStuby9hCMv7Q4GAPIXuJD8wPv8vrnhr1yRNQhiJX+bthw==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/uint8array": "^1.1.1",
+        "@atcute/util-text": "^1.3.1",
+        "@standard-schema/spec": "^1.1.0",
+        "esm-env": "^1.2.2"
+      }
+    },
+    "node_modules/@atcute/multibase": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@atcute/multibase/-/multibase-1.2.0.tgz",
+      "integrity": "sha512-ZK2GRra+qIYq9nNuQB52m2ul0hOmCQEtPobGfTSUxm7pF0OGEkWGkWHugFhNEDVzHzTwPxHp6VGotdZFue4lYQ==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/uint8array": "^1.1.1"
+      }
+    },
+    "node_modules/@atcute/uint8array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@atcute/uint8array/-/uint8array-1.1.2.tgz",
+      "integrity": "sha512-n+lutnbN9mKzSjSVdfsYfzJ40u2971H+iLSL46D6d7zcrA4delxusf/ftGFvj5oGW03OioaFgQOy3Lqa3JmTeA==",
+      "license": "0BSD"
+    },
+    "node_modules/@atcute/util-fetch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@atcute/util-fetch/-/util-fetch-1.0.5.tgz",
+      "integrity": "sha512-qjHj01BGxjSjIFdPiAjSARnodJIIyKxnCMMEcXMESo9TAyND6XZQqrie5fia+LlYWVXdpsTds8uFQwc9jdKTig==",
+      "license": "0BSD",
+      "dependencies": {
+        "@badrap/valita": "^0.4.6"
+      }
+    },
+    "node_modules/@atcute/util-text": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@atcute/util-text/-/util-text-1.3.1.tgz",
+      "integrity": "sha512-MRgJXkx67znuBXuoAYCJkBZyd3OApL7zZlNf5kXhuoCXcdiu1nblRDycYTADSkym4epBSQWxh26kmI9sewaq6A==",
+      "license": "0BSD",
+      "dependencies": {
+        "unicode-segmenter": "^0.14.5"
+      }
+    },
+    "node_modules/@atcute/xrpc-server": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@atcute/xrpc-server/-/xrpc-server-0.1.12.tgz",
+      "integrity": "sha512-70KIerQlljp5+s6t0u6YNN9klEboQUZa2hhoi/hmXIO1cIKEORettTMctnyjfcCJaSfAuj42dxPu51GTZBlm8w==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/cbor": "^2.3.2",
+        "@atcute/crypto": "^2.4.1",
+        "@atcute/identity": "^1.1.4",
+        "@atcute/identity-resolver": "^1.2.2",
+        "@atcute/lexicons": "^1.2.9",
+        "@atcute/multibase": "^1.2.0",
+        "@atcute/uint8array": "^1.1.1",
+        "@badrap/valita": "^0.4.6",
+        "nanoid": "^5.1.7"
+      }
+    },
+    "node_modules/@atcute/xrpc-server/node_modules/nanoid": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@atmo-dev/contrail": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@atmo-dev/contrail/-/contrail-0.6.0.tgz",
+      "integrity": "sha512-R5xlhQFT+nUkxCNKS41TwnVID2GZl2heh6Zz3Mw7+Zn0zrDLKkcbc4znNLw7q0VZk04Wx9xNxZQGlmfwUooJ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@atcute/atproto": "^3.1.10",
+        "@atcute/cbor": "^2.3.2",
+        "@atcute/cid": "^2.4.1",
+        "@atcute/client": "^4.2.1",
+        "@atcute/identity": "^1.1.4",
+        "@atcute/identity-resolver": "^1.2.2",
+        "@atcute/jetstream": "^1.0.2",
+        "@atcute/lexicons": "^1.2.9",
+        "@atcute/xrpc-server": "^0.1.12",
+        "cac": "^7.0.0",
+        "hono": "^4.12.8",
+        "jiti": "^2.4.0"
+      },
+      "bin": {
+        "contrail": "dist/cli.js"
+      },
+      "peerDependencies": {
+        "pg": "^8.0.0",
+        "wrangler": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "pg": {
+          "optional": true
+        },
+        "wrangler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@atmo-dev/contrail/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/@atproto-labs/did-resolver": {
@@ -2932,6 +3175,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@badrap/valita": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@badrap/valita/-/valita-0.4.6.tgz",
+      "integrity": "sha512-4kdqcjyxo/8RQ8ayjms47HCWZIF5981oE5nIenbfThKDxWXtEHKipAOWlflpPJzZx9y/JWYQkp18Awr7VuepFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -5111,6 +5363,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/@mary-ext/event-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mary-ext/event-iterator/-/event-iterator-1.0.0.tgz",
+      "integrity": "sha512-l6gCPsWJ8aRCe/s7/oCmero70kDHgIK5m4uJvYgwEYTqVxoBOIXbKr5tnkLqUHEg6mNduB4IWvms3h70Hp9ADQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      }
+    },
+    "node_modules/@mary-ext/event-iterator/node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mary-ext/simple-event-emitter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mary-ext/simple-event-emitter/-/simple-event-emitter-1.0.1.tgz",
+      "integrity": "sha512-9+VvZisxZ/gSg+JJH7hmXaA8Qj42Qjz3O58RSB+INYc8iLA0icATZxHB9vKbj59ojDGZjO3hCKzMXocx3L0H8w==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@matrix-org/matrix-sdk-crypto-wasm": {
       "version": "15.3.0",
       "resolved": "https://registry.npmjs.org/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-15.3.0.tgz",
@@ -6094,6 +6373,15 @@
       "engines": {
         "node": "^14.21.3 || >=16"
       },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-3.1.0.tgz",
+      "integrity": "sha512-+F7iS7tUMaNGXcc9X3PjmjvuQnXEuSjCRNzVVA2xAcKXgCaP0dHYz4SFyt4FKNHef7sOP//xihowcySSS7PK9g==",
+      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -8451,6 +8739,12 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.5.tgz",
       "integrity": "sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw=="
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@swc/cli": {
       "version": "0.5.2",
@@ -11134,6 +11428,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
+      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/cacheable-lookup": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
@@ -12981,6 +13284,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -13093,6 +13402,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/event-target-polyfill": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.4.tgz",
+      "integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==",
+      "license": "MIT"
     },
     "node_modules/eventemitter2": {
       "version": "6.4.9",
@@ -14304,6 +14619,15 @@
       "dependencies": {
         "no-case": "^2.2.0",
         "upper-case": "^1.1.3"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/html-comment-regex": {
@@ -17866,6 +18190,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/partysocket": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.19.tgz",
+      "integrity": "sha512-hPwsXSdUc8PKNCinET6TD3JQOxzQ2JaP0bUZQXBVl6UM8UuLn1odgf1LcJXHy4UHSQwWL/RU3AnyhEsGM+W+sg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-polyfill": "^0.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/pascal-case": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "migration:revert:tenant": "env-cmd ts-node -r tsconfig-paths/register ./src/database/revert-tenant-migration.ts",
     "migration:run:prod": "ts-node -r tsconfig-paths/register  ./src/database/run-multi-tenant-migrations.ts",
     "backfill:activity-feeds": "env-cmd ts-node -r tsconfig-paths/register ./src/database/backfill-activity-feeds.ts",
+    "contrail:sync": "ts-node -r tsconfig-paths/register ./src/contrail/sync.ts",
+    "contrail:smoke": "ts-node -r tsconfig-paths/register ./src/contrail/smoke-server.ts",
     "seed:run:prod": "ts-node -r tsconfig-paths/register ./src/database/seeds/relational/run-seed.ts --tenant-config=./config/tenants.json",
     "schema:drop": "npm run typeorm -- --dataSource=src/database/data-source.ts schema:drop",
     "schema:reset": "env-cmd ts-node -r tsconfig-paths/register ./src/database/run-schema-reset.ts",
@@ -62,6 +64,7 @@
     "perf:report": "node k6-tests/compare-results.js"
   },
   "dependencies": {
+    "@atmo-dev/contrail": "0.6.0",
     "@atproto/api": "^0.13.31",
     "@atproto/crypto": "^0.4.5",
     "@atproto/identity": "^0.4.7",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -29,6 +29,7 @@ import { MailerModule } from './mailer/mailer.module';
 import { TenantConnectionService } from './tenant/tenant.service';
 import { TenantModule } from './tenant/tenant.module';
 import { EventModule } from './event/event.module';
+import { ContrailXrpcModule } from './contrail/contrail-xrpc.module';
 import { APP_GUARD } from '@nestjs/core';
 import { TenantGuard } from './tenant/tenant.guard';
 import { ThrottlerModule } from '@nestjs/throttler';
@@ -150,6 +151,7 @@ const infrastructureDatabaseModule = TypeOrmModule.forRootAsync({
     HomeModule,
     TenantModule,
     EventModule,
+    ContrailXrpcModule,
     CategoryModule,
     GroupModule,
     ActivityFeedModule,

--- a/src/contrail/contrail-init-lock.spec.ts
+++ b/src/contrail/contrail-init-lock.spec.ts
@@ -1,0 +1,57 @@
+import pg from 'pg';
+import { withInitLock } from './contrail-init-lock';
+
+const TEST_DB_URL = process.env.CONTRAIL_TEST_DATABASE_URL;
+
+const describeIfDb = TEST_DB_URL ? describe : describe.skip;
+
+describeIfDb('withInitLock (requires CONTRAIL_TEST_DATABASE_URL)', () => {
+  let pool: pg.Pool;
+
+  beforeAll(() => {
+    pool = new pg.Pool({ connectionString: TEST_DB_URL });
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('should serialize concurrent critical sections', async () => {
+    const events: string[] = [];
+    const work = async (id: string) => {
+      await withInitLock(pool, 'om-test-init-lock', async () => {
+        events.push(`${id}-enter`);
+        await new Promise((r) => setTimeout(r, 50));
+        events.push(`${id}-exit`);
+      });
+    };
+
+    await Promise.all([work('A'), work('B')]);
+
+    expect(events).toHaveLength(4);
+    const aEnter = events.indexOf('A-enter');
+    const aExit = events.indexOf('A-exit');
+    const bEnter = events.indexOf('B-enter');
+    const bExit = events.indexOf('B-exit');
+
+    const aBeforeB = aEnter < aExit && aExit < bEnter && bEnter < bExit;
+    const bBeforeA = bEnter < bExit && bExit < aEnter && aEnter < aExit;
+
+    expect(aBeforeB || bBeforeA).toBe(true);
+  });
+
+  it('should release the lock on critical-section throw', async () => {
+    await expect(
+      withInitLock(pool, 'om-test-init-lock-throw', () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    let ran = false;
+    await withInitLock(pool, 'om-test-init-lock-throw', () => {
+      ran = true;
+      return Promise.resolve();
+    });
+    expect(ran).toBe(true);
+  });
+});

--- a/src/contrail/contrail-init-lock.ts
+++ b/src/contrail/contrail-init-lock.ts
@@ -1,0 +1,21 @@
+import pg from 'pg';
+
+export async function withInitLock<T>(
+  pool: pg.Pool,
+  key: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await client.query('SELECT pg_advisory_lock(hashtext($1)::bigint)', [key]);
+    try {
+      return await fn();
+    } finally {
+      await client.query('SELECT pg_advisory_unlock(hashtext($1)::bigint)', [
+        key,
+      ]);
+    }
+  } finally {
+    client.release();
+  }
+}

--- a/src/contrail/contrail-loader.ts
+++ b/src/contrail/contrail-loader.ts
@@ -1,0 +1,26 @@
+// @atmo-dev/contrail ships as ESM-only. OM API compiles with `module: commonjs`,
+// which would transform `await import(...)` into `require(...)` — broken for ESM.
+// The `Function`-constructor indirection keeps the dynamic import opaque to the
+// TS compiler, so Node's runtime executes the real ESM import.
+const esmImport = new Function('specifier', 'return import(specifier)') as <
+  T = unknown,
+>(
+  specifier: string,
+) => Promise<T>;
+
+export async function loadContrail(): Promise<{
+  pkg: typeof import('@atmo-dev/contrail');
+  server: typeof import('@atmo-dev/contrail/server');
+  postgres: typeof import('@atmo-dev/contrail/postgres');
+}> {
+  const [pkg, server, postgres] = await Promise.all([
+    esmImport<typeof import('@atmo-dev/contrail')>('@atmo-dev/contrail'),
+    esmImport<typeof import('@atmo-dev/contrail/server')>(
+      '@atmo-dev/contrail/server',
+    ),
+    esmImport<typeof import('@atmo-dev/contrail/postgres')>(
+      '@atmo-dev/contrail/postgres',
+    ),
+  ]);
+  return { pkg, server, postgres };
+}

--- a/src/contrail/contrail-xrpc.module.ts
+++ b/src/contrail/contrail-xrpc.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { ContrailProvider } from './contrail.provider';
+
+@Module({
+  providers: [ContrailProvider],
+  exports: [ContrailProvider],
+})
+export class ContrailXrpcModule {}

--- a/src/contrail/contrail.config.ts
+++ b/src/contrail/contrail.config.ts
@@ -1,0 +1,44 @@
+import type { ContrailConfig } from '@atmo-dev/contrail';
+
+export const contrailConfig: ContrailConfig = {
+  namespace: 'net.openmeet',
+  collections: {
+    event: {
+      collection: 'community.lexicon.calendar.event',
+      queryable: {
+        mode: {},
+        name: {},
+        status: {},
+        startsAt: { type: 'range' },
+        endsAt: { type: 'range' },
+        createdAt: { type: 'range' },
+      },
+      searchable: ['name', 'description'],
+      relations: {
+        rsvps: {
+          collection: 'rsvp',
+          groupBy: 'status',
+          count: true,
+          groups: {
+            interested: 'community.lexicon.calendar.rsvp#interested',
+            going: 'community.lexicon.calendar.rsvp#going',
+            notgoing: 'community.lexicon.calendar.rsvp#notgoing',
+          },
+        },
+      },
+    },
+    rsvp: {
+      collection: 'community.lexicon.calendar.rsvp',
+      queryable: {
+        status: {},
+        'subject.uri': {},
+      },
+      references: {
+        event: {
+          collection: 'event',
+          field: 'subject.uri',
+        },
+      },
+    },
+  },
+};

--- a/src/contrail/contrail.d.ts
+++ b/src/contrail/contrail.d.ts
@@ -1,0 +1,85 @@
+declare module '@atmo-dev/contrail' {
+  export interface QueryableField {
+    type?: 'range';
+  }
+
+  export interface RelationConfig {
+    collection: string;
+    field?: string;
+    match?: 'uri' | 'did';
+    groupBy?: string;
+    count?: boolean;
+    countDistinct?: string;
+    groups?: Record<string, string>;
+  }
+
+  export interface ReferenceConfig {
+    collection: string;
+    field: string;
+  }
+
+  export interface CollectionConfig {
+    collection: string;
+    discover?: boolean;
+    queryable?: Record<string, QueryableField>;
+    relations?: Record<string, RelationConfig>;
+    references?: Record<string, ReferenceConfig>;
+    searchable?: string[] | false;
+    methods?: ('listRecords' | 'getRecord')[];
+    timeField?: string | false;
+  }
+
+  export interface Logger {
+    log(...args: unknown[]): void;
+    warn(...args: unknown[]): void;
+    error(...args: unknown[]): void;
+  }
+
+  export interface ContrailConfig {
+    namespace: string;
+    collections: Record<string, CollectionConfig>;
+    relays?: string[];
+    jetstreams?: string[];
+    logger?: Logger;
+    notify?: boolean | string;
+  }
+
+  export type Database = unknown;
+
+  export interface ContrailOptions extends ContrailConfig {
+    db?: Database;
+    spacesDb?: Database;
+  }
+
+  export interface BackfillProgress {
+    records: number;
+    usersComplete: number;
+    usersTotal: number;
+    usersFailed: number;
+  }
+
+  export interface BackfillAllOptions {
+    concurrency?: number;
+    onProgress?: (p: BackfillProgress) => void;
+  }
+
+  export class Contrail {
+    constructor(options: ContrailOptions);
+    init(db?: Database, spacesDb?: Database): Promise<void>;
+    discover(db?: Database): Promise<string[]>;
+    backfill(options?: BackfillAllOptions, db?: Database): Promise<number>;
+  }
+}
+
+declare module '@atmo-dev/contrail/server' {
+  import type { Contrail } from '@atmo-dev/contrail';
+  export function createHandler(
+    contrail: Contrail,
+  ): (request: Request) => Promise<Response>;
+}
+
+declare module '@atmo-dev/contrail/postgres' {
+  import type { Pool } from 'pg';
+  import type { Database } from '@atmo-dev/contrail';
+  export function createPostgresDatabase(pool: Pool): Database;
+}

--- a/src/contrail/contrail.provider.ts
+++ b/src/contrail/contrail.provider.ts
@@ -1,0 +1,80 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import pg from 'pg';
+import type { Contrail } from '@atmo-dev/contrail';
+import { contrailConfig } from './contrail.config';
+import { withInitLock } from './contrail-init-lock';
+import { loadContrail } from './contrail-loader';
+
+const INIT_LOCK_KEY = 'net.openmeet.contrail.init';
+const DEFAULT_SCHEMA = 'contrail';
+
+@Injectable()
+export class ContrailProvider implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(ContrailProvider.name);
+  private pool?: pg.Pool;
+  private contrail?: Contrail;
+  private handler?: (request: Request) => Promise<Response>;
+
+  async onModuleInit(): Promise<void> {
+    const databaseUrl = process.env.CONTRAIL_DATABASE_URL;
+    if (!databaseUrl) {
+      this.logger.warn(
+        'CONTRAIL_DATABASE_URL not set; ContrailProvider will not initialize. ' +
+          '/xrpc/net.openmeet.* requests will return 503.',
+      );
+      return;
+    }
+
+    const schema = process.env.CONTRAIL_SCHEMA ?? DEFAULT_SCHEMA;
+
+    // node-postgres supports `options` at runtime to pass libpq startup
+    // parameters; @types/pg doesn't expose it yet (cast through PoolConfig).
+    this.pool = new pg.Pool({
+      connectionString: databaseUrl,
+      options: `-c search_path=${schema},public`,
+    } as pg.PoolConfig);
+
+    const { pkg, server, postgres } = await loadContrail();
+    const db = postgres.createPostgresDatabase(this.pool);
+    this.contrail = new pkg.Contrail({ ...contrailConfig, db });
+
+    await withInitLock(this.pool, INIT_LOCK_KEY, async () => {
+      await this.pool!.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`);
+      await this.contrail!.init();
+    });
+
+    this.handler = server.createHandler(this.contrail);
+
+    const redactedUrl = databaseUrl.replace(/:[^:@/]+@/, ':***@');
+    this.logger.log(
+      `Contrail initialized; namespace=${contrailConfig.namespace}, schema=${schema}, db=${redactedUrl}`,
+    );
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.pool?.end();
+  }
+
+  isReady(): boolean {
+    return this.handler !== undefined;
+  }
+
+  async handle(request: Request): Promise<Response> {
+    if (!this.handler) {
+      return new Response(
+        JSON.stringify({
+          error: 'NotInitialized',
+          message:
+            'ContrailProvider is not initialized (CONTRAIL_DATABASE_URL unset)',
+        }),
+        { status: 503, headers: { 'content-type': 'application/json' } },
+      );
+    }
+    return this.handler(request);
+  }
+}

--- a/src/contrail/smoke-server.ts
+++ b/src/contrail/smoke-server.ts
@@ -1,0 +1,80 @@
+/**
+ * Standalone smoke server for the Contrail XRPC layer.
+ *
+ * Boots a minimal NestJS app with just `ContrailXrpcModule` and the same
+ * /xrpc/net.openmeet middleware mount used in main.ts. No tenants, no
+ * TypeORM, no auth — just the new XRPC surface, so you can curl it.
+ *
+ * Usage:
+ *   CONTRAIL_DATABASE_URL=postgres://... \
+ *   CONTRAIL_SCHEMA=contrail \
+ *   PORT=3010 \
+ *   ts-node -r tsconfig-paths/register src/contrail/smoke-server.ts
+ *
+ * Curl examples:
+ *   curl 'http://localhost:3010/xrpc/net.openmeet.event.listRecords?limit=3'
+ *   curl 'http://localhost:3010/xrpc/net.openmeet.event.listRecords?sort=rsvpsCount&limit=3'
+ *   curl 'http://localhost:3010/xrpc/net.openmeet.rsvp.listRecords?limit=3'
+ *
+ * Phase 1 dev aid only. Not deployed.
+ */
+import 'reflect-metadata';
+import { Module } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import type {
+  NextFunction,
+  Request as ExpressRequest,
+  Response as ExpressResponse,
+} from 'express';
+import { ContrailXrpcModule } from './contrail-xrpc.module';
+import { ContrailProvider } from './contrail.provider';
+
+@Module({ imports: [ContrailXrpcModule] })
+class SmokeAppModule {}
+
+async function bootstrap(): Promise<void> {
+  const app = await NestFactory.create(SmokeAppModule, {
+    logger: ['log', 'error', 'warn'],
+  });
+  const provider = app.get(ContrailProvider);
+
+  app.use(
+    '/xrpc',
+    async (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
+      if (!req.url.startsWith('/net.openmeet.')) return next();
+      try {
+        const fullPath = `/xrpc${req.url}`;
+        const url = new URL(
+          fullPath,
+          `http://${req.headers.host ?? 'localhost'}`,
+        );
+        const headers: Record<string, string> = {};
+        for (const [k, v] of Object.entries(req.headers)) {
+          if (typeof v === 'string') headers[k] = v;
+          else if (Array.isArray(v)) headers[k] = v.join(', ');
+        }
+        const fetchRequest = new globalThis.Request(url.toString(), {
+          method: req.method,
+          headers,
+        });
+        const fetchResponse = await provider.handle(fetchRequest);
+        res.status(fetchResponse.status);
+        fetchResponse.headers.forEach((value, key) =>
+          res.setHeader(key, value),
+        );
+        res.send(await fetchResponse.text());
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  const port = parseInt(process.env.PORT ?? '3010', 10);
+  await app.listen(port);
+  console.log(`Contrail smoke listening on http://localhost:${port}`);
+}
+
+bootstrap().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/contrail/sync.ts
+++ b/src/contrail/sync.ts
@@ -1,0 +1,91 @@
+/**
+ * One-shot Contrail sync: discover known DIDs from public relays and backfill
+ * their records into the Contrail Postgres index.
+ *
+ * Designed to run as a standalone process (npm script or K8s Job). MUST NOT
+ * run inside an API pod — Jetstream ingest belongs in a dedicated process if
+ * we ever stand it up (Phase 2 decision; not in this script).
+ *
+ * Usage:
+ *   CONTRAIL_DATABASE_URL=postgres://... \
+ *   CONTRAIL_SCHEMA=contrail \
+ *   npm run contrail:sync
+ */
+import pg from 'pg';
+import { contrailConfig } from './contrail.config';
+import { withInitLock } from './contrail-init-lock';
+import { loadContrail } from './contrail-loader';
+
+const INIT_LOCK_KEY = 'net.openmeet.contrail.init';
+const DEFAULT_SCHEMA = 'contrail';
+
+function elapsed(start: number): string {
+  const ms = Date.now() - start;
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const mins = Math.floor(ms / 60_000);
+  const secs = ((ms % 60_000) / 1000).toFixed(0);
+  return `${mins}m ${secs}s`;
+}
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env.CONTRAIL_DATABASE_URL;
+  if (!databaseUrl) {
+    console.error('CONTRAIL_DATABASE_URL is required');
+    process.exit(1);
+  }
+  const schema = process.env.CONTRAIL_SCHEMA ?? DEFAULT_SCHEMA;
+
+  const pool = new pg.Pool({
+    connectionString: databaseUrl,
+    options: `-c search_path=${schema},public`,
+  } as pg.PoolConfig);
+
+  try {
+    const { pkg, postgres } = await loadContrail();
+    const db = postgres.createPostgresDatabase(pool);
+    const contrail = new pkg.Contrail({ ...contrailConfig, db });
+    const syncStart = Date.now();
+
+    console.log(`=== Contrail sync (schema=${schema}) ===\n`);
+
+    await withInitLock(pool, INIT_LOCK_KEY, async () => {
+      await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`);
+      await contrail.init();
+    });
+
+    console.log('--- Discovery ---');
+    const discoveryStart = Date.now();
+    const discovered = await contrail.discover();
+    console.log(
+      `  Done: ${discovered.length} users in ${elapsed(discoveryStart)}\n`,
+    );
+
+    console.log('--- Backfill ---');
+    const backfillStart = Date.now();
+    const total = await contrail.backfill({
+      concurrency: 10,
+      onProgress: ({ records, usersComplete, usersTotal, usersFailed }) => {
+        const secs = (Date.now() - backfillStart) / 1000;
+        const rate = secs > 0 ? Math.round(records / secs) : 0;
+        const failStr = usersFailed > 0 ? ` | ${usersFailed} failed` : '';
+        process.stdout.write(
+          `\r  ${records} records | ${usersComplete}/${usersTotal} users | ${rate}/s | ${elapsed(backfillStart)}${failStr}   `,
+        );
+      },
+    });
+    process.stdout.write('\n');
+    console.log(`  Done: ${total} records in ${elapsed(backfillStart)}\n`);
+
+    console.log(`=== Finished in ${elapsed(syncStart)} ===`);
+    console.log(`  Discovered: ${discovered.length} users`);
+    console.log(`  Backfilled: ${total} records`);
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import { AggregateByTenantContextIdStrategy } from './strategy/tenant.strategy';
 import { TenantGuard } from './tenant/tenant.guard';
 import { getBuildInfo } from './utils/version';
 import cookieParser from 'cookie-parser';
+import { ContrailProvider } from './contrail/contrail.provider';
 
 // Add direct console.log for startup debugging - these will show even before logger is configured
 const startupLog = (message: string) => {
@@ -84,6 +85,49 @@ async function bootstrap() {
       ],
       methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
     });
+    // Contrail XRPC mount: /xrpc/net.openmeet.* served by ContrailProvider.
+    // Registered as raw Express middleware so it bypasses Nest's global prefix
+    // and TenantGuard (the new XRPC layer is single-tenant by design).
+    const contrailProvider = app.get(ContrailProvider);
+    app.use(
+      '/xrpc',
+      async (
+        req: import('express').Request,
+        res: import('express').Response,
+        next: import('express').NextFunction,
+      ) => {
+        // Scope: only intercept net.openmeet.* methods. Mounting at /xrpc
+        // (not /xrpc/net.openmeet) is required because Express's prefix
+        // matcher needs a path-boundary after the mount path; the dot in
+        // `net.openmeet.event.listRecords` is not a boundary.
+        if (!req.url.startsWith('/net.openmeet.')) return next();
+        try {
+          const fullPath = `/xrpc${req.url}`;
+          const url = new URL(
+            fullPath,
+            `http://${req.headers.host ?? 'localhost'}`,
+          );
+          const headers: Record<string, string> = {};
+          for (const [k, v] of Object.entries(req.headers)) {
+            if (typeof v === 'string') headers[k] = v;
+            else if (Array.isArray(v)) headers[k] = v.join(', ');
+          }
+          const fetchRequest = new globalThis.Request(url.toString(), {
+            method: req.method,
+            headers,
+          });
+          const fetchResponse = await contrailProvider.handle(fetchRequest);
+          res.status(fetchResponse.status);
+          fetchResponse.headers.forEach((value, key) =>
+            res.setHeader(key, value),
+          );
+          res.send(await fetchResponse.text());
+        } catch (err) {
+          next(err);
+        }
+      },
+    );
+
     startupLog('NestJS application created successfully');
 
     // Choose logger based on environment

--- a/test/contrail/contrail-xrpc.e2e-spec.ts
+++ b/test/contrail/contrail-xrpc.e2e-spec.ts
@@ -11,8 +11,16 @@ import { TESTING_APP_URL } from '../utils/constants';
  *
  * These hit raw Express middleware (no Nest controller / TenantGuard /
  * api prefix). The mount in main.ts is single-tenant by design.
+ *
+ * The suite is gated on CONTRAIL_DATABASE_URL: in CI / local envs where the
+ * Contrail PG isn't wired, the provider returns 503 by design (graceful
+ * degradation), so the assertions would all fail. Skip cleanly in that case.
  */
-describe('Contrail XRPC mount (e2e)', () => {
+const describeIfContrail = process.env.CONTRAIL_DATABASE_URL
+  ? describe
+  : describe.skip;
+
+describeIfContrail('Contrail XRPC mount (e2e)', () => {
   const app = TESTING_APP_URL;
 
   it('should respond on event.listRecords', async () => {

--- a/test/contrail/contrail-xrpc.e2e-spec.ts
+++ b/test/contrail/contrail-xrpc.e2e-spec.ts
@@ -1,0 +1,54 @@
+import request from 'supertest';
+import { TESTING_APP_URL } from '../utils/constants';
+
+/**
+ * Curl-level proof that OM API's /xrpc/net.openmeet.* mount works.
+ *
+ * Prereqs:
+ *   - OM API running (e.g. `npm run start:dev`)
+ *   - CONTRAIL_DATABASE_URL pointing at a Postgres populated with Contrail
+ *     records (use `npm run contrail:sync` first, or the smoke-gate PG)
+ *
+ * These hit raw Express middleware (no Nest controller / TenantGuard /
+ * api prefix). The mount in main.ts is single-tenant by design.
+ */
+describe('Contrail XRPC mount (e2e)', () => {
+  const app = TESTING_APP_URL;
+
+  it('should respond on event.listRecords', async () => {
+    const res = await request(app)
+      .get('/xrpc/net.openmeet.event.listRecords')
+      .query({ limit: 3 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('records');
+    expect(Array.isArray(res.body.records)).toBe(true);
+  });
+
+  it('should sort by rsvpsCount on event.listRecords', async () => {
+    const res = await request(app)
+      .get('/xrpc/net.openmeet.event.listRecords')
+      .query({ sort: 'rsvpsCount', limit: 3 });
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.records)).toBe(true);
+  });
+
+  it('should support full-text search on event.listRecords', async () => {
+    const res = await request(app)
+      .get('/xrpc/net.openmeet.event.listRecords')
+      .query({ search: 'meetup', limit: 3 });
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.records)).toBe(true);
+  });
+
+  it('should respond on rsvp.listRecords', async () => {
+    const res = await request(app)
+      .get('/xrpc/net.openmeet.rsvp.listRecords')
+      .query({ limit: 3 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('records');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new XRPC surface backed by Contrail's index of public ATProto calendar events and RSVPs. The endpoints (`listRecords`, `getRecord`) are served by a `ContrailProvider` that wraps `@atmo-dev/contrail@0.6.0` against a dedicated Postgres schema.

- Endpoints live at `/xrpc/net.openmeet.event.*` and `/xrpc/net.openmeet.rsvp.*`.
- Populated by a one-shot sync (`npm run contrail:sync`); a live-ingest deployment can be added later.
- Single-tenant by design — the new surface bypasses `TenantGuard` and the `/api` prefix by mounting as raw Express middleware.

**What this PR does not change**: `event-query.service.ts`, the events table, the publishing pipeline, `bsky-firehose-consumer`, `bsky-event-processor`. None of OM's existing read or write paths are touched.

## Three implementation notes worth attention

1. **Advisory lock around `contrail.init()`** (`contrail.provider.ts`, `contrail-init-lock.ts`). Without it, concurrent boots across replicas race on `ALTER TABLE ADD COLUMN` inside Contrail's init and emit "column already exists" errors. The unit test in `contrail-init-lock.spec.ts` exercises the serialization invariant against a real Postgres.

2. **Mount at `/xrpc` with internal NSID filter, not `/xrpc/net.openmeet`** (`main.ts`). Express's prefix matcher needs a path boundary (`/` or end) after the mount path; the dot in `net.openmeet.event.listRecords` is not one. So we mount at `/xrpc` and gate inside the handler with `req.url.startsWith('/net.openmeet.')`.

3. **Function-constructor wrapper for the dynamic ESM import** (`contrail-loader.ts`). `@atmo-dev/contrail` is ESM-only. OM API compiles to CommonJS, where TypeScript rewrites `await import(...)` to `require(...)` — broken for ESM. The Function-constructor indirection keeps the import opaque to the TS compiler so Node executes the real ESM import at runtime. A local `contrail.d.ts` shim declares the types so we don't need a project-wide `moduleResolution` change.

## Verification

- `npm test -- --testPathPattern=contrail-init-lock` passes (2 tests) when run with `CONTRAIL_TEST_DATABASE_URL` pointing at a Postgres.
- `nest build` clean.
- Curl-level proof against a local Contrail Postgres (smoke server in `src/contrail/smoke-server.ts`): `listRecords` (sorted by rsvpsCount), `listRecords?search=meetup`, `getRecord?...hydrateRsvps=3`, and `rsvp.listRecords?subjectUri=...` all return well-formed responses with real records.

## Companion changes

- **openmeet-infrastructure** `main` already updated: `k8s/components/api/base/job-contrail-sync.yaml` is a suspended CronJob that runs `npm run contrail:sync` inside the API image. Triggered manually: `kubectl create job --from=cronjob/contrail-sync contrail-sync-$(date +%s)`.

## Known follow-ups (out of scope for this PR)

- The project's `tsc --noEmit` baseline has 461 pre-existing errors in `*.spec.ts` files (unrelated to this PR; surfaced because the local hook runs project-wide). `nest build` passes because `tsconfig.build.json` excludes specs. Cleanup is its own ticket.
- Phase 2: live ingest as a separate Deployment (`replicas: 1`) for continuous indexing; deferred cutover decisions on read paths and retiring `bsky-firehose-consumer`.

## Test plan

- [ ] `npm test -- --testPathPattern=contrail-init-lock` passes
- [ ] `nest build` clean
- [ ] Curl `/xrpc/net.openmeet.event.listRecords?limit=3` against a Postgres populated via `npm run contrail:sync` returns records
- [ ] Curl `/xrpc/net.openmeet.event.getRecord?uri=...&hydrateRsvps=3` returns event with RSVPs grouped by status
- [ ] OM API boots without `CONTRAIL_DATABASE_URL` set (Provider logs a warning, endpoints return 503)