### PR TITLE
fix(contrail): run sync from compiled dist, not ts-node src

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "migration:revert:tenant": "env-cmd ts-node -r tsconfig-paths/register ./src/database/revert-tenant-migration.ts",
     "migration:run:prod": "ts-node -r tsconfig-paths/register  ./src/database/run-multi-tenant-migrations.ts",
     "backfill:activity-feeds": "env-cmd ts-node -r tsconfig-paths/register ./src/database/backfill-activity-feeds.ts",
-    "contrail:sync": "ts-node -r tsconfig-paths/register ./src/contrail/sync.ts",
+    "contrail:sync": "node dist/contrail/sync.js",
     "contrail:smoke": "ts-node -r tsconfig-paths/register ./src/contrail/smoke-server.ts",
     "seed:run:prod": "ts-node -r tsconfig-paths/register ./src/database/seeds/relational/run-seed.ts --tenant-config=./config/tenants.json",
     "schema:drop": "npm run typeorm -- --dataSource=src/database/data-source.ts schema:drop",


### PR DESCRIPTION
## Summary
- The production Docker image only ships `dist/`; `src/` is removed in the release stage (except `src/mail/mail-templates`).
- The `contrail-sync` CronJob (suspended; manually triggered today during Phase 1 dev validation) calls `npm run contrail:sync`, which was `ts-node ./src/contrail/sync.ts` — fails immediately with `Cannot find module './sync.ts'`.
- Switch the npm script to `node dist/contrail/sync.js`. `sync.ts` uses only relative imports, so `tsconfig-paths` isn't needed.
- `contrail:smoke` stays on `ts-node` (developer-local tool, not run in-cluster).

## Why this wasn't caught in #580
- #580's local smoke gate ran the script from a developer machine where both `src/` and `ts-node` exist, so the bug was invisible.
- `migration:run:prod` and `seed:run:prod` share the same shape but are run from developer hosts (see `CLAUDE.md`), so they aren't exercised in-cluster.
- `contrail-sync` is the first script of this shape that actually runs as a Kubernetes Job.

## Test plan
- [ ] CI green on this branch.
- [ ] After merge + image rebuild, manually trigger the suspended `contrail-sync` CronJob in dev:
      `kubectl create job --from=cronjob/contrail-sync contrail-sync-manual -n dev`
- [ ] Logs show `=== Contrail sync (schema=contrail) ===` followed by Discovery + Backfill output.
- [ ] After completion, `curl 'https://api-dev.openmeet.net/xrpc/net.openmeet.event.listRecords?sort=rsvpsCount&limit=3'` returns real records (was empty before).