### PR TITLE
fix(docker): drop ingest target so release stays default build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,12 +59,3 @@ EXPOSE 3000
 
 # CMD npm run migration:run:prod && npm run seed:run:prod && npm run start:prod
 CMD npm run start:prod
-
-
-# ---- Ingest ----
-# Same artifact as `release`, different default command. The contrail live-ingest
-# Deployment streams ATProto records from Jetstream into Postgres continuously;
-# no HTTP port. Process liveness is the sole health signal (kubelet restarts on
-# exit). See src/contrail/ingest.ts and the Phase D plan.
-FROM release AS ingest
-CMD ["npm", "run", "contrail:ingest"]


### PR DESCRIPTION
## Summary

Hotfix for dev API crashloop introduced by PR #582.

PR #582 appended `FROM release AS ingest` as the **last** stage of the Dockerfile. `.github/workflows/deploy-to-dev.yml` runs `docker build` with no `--target`, so Docker defaults to the last stage in the file — the API image at tag `b518567` is therefore the ingest variant with `CMD ["npm", "run", "contrail:ingest"]`.

The API Deployment doesn't override CMD, so the new pod runs the ingest entrypoint, never binds port 3000, readiness probe hits `connection refused`, kubelet restarts → crashloop.

```
> openmeet-api@1.5.0 contrail:ingest
> node dist/contrail/ingest.js
[ingest] starting; namespace=net.openmeet, schema=contrail, jetstreams=(default)
Loaded 1205 known DIDs from database
Starting persistent ingestion. Cursor: ...
```

Dev is degraded but not down — the prior 44h pod (`49c35a4`) keeps serving.

## Fix

Delete the `FROM release AS ingest` block. The `release` stage becomes the default again; `npm run start:prod` runs by default; readiness probe passes.

The ingest target was not load-bearing: Phase E's `contrail-ingest` Deployment overrides `command: ["npm", "run", "contrail:ingest"]` on the single-replica pod, so the same `release` image works for both roles.

## Why this slipped past CI

- `test` and `e2e-test` jobs build `relational.test.Dockerfile` / `relational.e2e.Dockerfile`, not the production `Dockerfile`.
- `build-and-deploy` job's `docker build .` "succeeds" — it just builds the wrong stage. No probe runs in CI to catch the no-HTTP-server image.

Follow-up issue worth filing: add a CI smoke that runs the built image with the same readiness probe as the Deployment.

## Test plan

- [x] `git diff` shows only the 9-line ingest block removed; release stage and its `CMD npm run start:prod` untouched.
- [ ] Post-merge: `build-and-deploy` produces a new ECR image; gitops bumps dev overlay; ArgoCD rolls API; new pod passes readiness within ~90s.
- [ ] `kubectl get pods -n dev -l app=api` shows 2/2 Ready, no restart loop.