### PR TITLE
feat(file): support custom S3 endpoint (S3-compatible providers)

### DIFF
--- a/env-example-relational
+++ b/env-example-relational
@@ -50,6 +50,12 @@ ACCESS_KEY_ID=None
 SECRET_ACCESS_KEY=None
 AWS_S3_REGION=None
 AWS_DEFAULT_S3_BUCKET=None
+# Optional: point the S3 client at an S3-compatible provider (e.g. DigitalOcean
+# Spaces: https://nyc3.digitaloceanspaces.com). Leave unset to use AWS S3.
+# AWS_S3_ENDPOINT=
+# Optional: path-style addressing (endpoint/bucket/key). Leave "false" for
+# providers that support virtual-hosted-style buckets without dots.
+# AWS_S3_FORCE_PATH_STYLE=false
 
 # MAIL_HOST is for API inside Docker (container-to-container)
 MAIL_HOST=maildev

--- a/src/file/config/file-config.type.ts
+++ b/src/file/config/file-config.type.ts
@@ -11,6 +11,8 @@ export type FileConfig = {
   secretAccessKey?: string;
   awsDefaultS3Bucket?: string;
   awsS3Region?: string;
+  awsS3Endpoint?: string;
+  awsS3ForcePathStyle?: boolean;
   cloudfrontDistributionDomain?: string;
   cloudfrontKeyPairId?: string;
   cloudfrontPrivateKey?: string;

--- a/src/file/config/file.config.ts
+++ b/src/file/config/file.config.ts
@@ -40,6 +40,26 @@ class EnvironmentVariablesValidator {
   @IsString()
   AWS_S3_REGION: string;
 
+  // Optional custom S3-compatible endpoint (e.g. DigitalOcean Spaces).
+  // When unset, the AWS SDK targets AWS S3 as before.
+  @ValidateIf((envValues) =>
+    [FileDriver.S3, FileDriver.S3_PRESIGNED, FileDriver.CLOUDFRONT].includes(
+      envValues.FILE_DRIVER,
+    ),
+  )
+  @IsString()
+  @IsOptional()
+  AWS_S3_ENDPOINT: string;
+
+  @ValidateIf((envValues) =>
+    [FileDriver.S3, FileDriver.S3_PRESIGNED, FileDriver.CLOUDFRONT].includes(
+      envValues.FILE_DRIVER,
+    ),
+  )
+  @IsString()
+  @IsOptional()
+  AWS_S3_FORCE_PATH_STYLE: string;
+
   @ValidateIf((envValues) => envValues.FILE_DRIVER === FileDriver.CLOUDFRONT)
   @IsString()
   CLOUDFRONT_DISTRIBUTION_DOMAIN: string;
@@ -66,6 +86,8 @@ export default registerAs<FileConfig>('file', () => {
     secretAccessKey: process.env.SECRET_ACCESS_KEY,
     awsDefaultS3Bucket: process.env.AWS_DEFAULT_S3_BUCKET,
     awsS3Region: process.env.AWS_S3_REGION,
+    awsS3Endpoint: process.env.AWS_S3_ENDPOINT,
+    awsS3ForcePathStyle: process.env.AWS_S3_FORCE_PATH_STYLE === 'true',
     cloudfrontDistributionDomain: process.env.CLOUDFRONT_DISTRIBUTION_DOMAIN,
     cloudfrontKeyPairId: process.env.CLOUDFRONT_KEY_PAIR_ID,
     cloudfrontPrivateKey: process.env.CLOUDFRONT_PRIVATE_KEY,

--- a/src/file/domain/file.ts
+++ b/src/file/domain/file.ts
@@ -4,10 +4,11 @@ import { Transform } from 'class-transformer';
 import fileConfig from '../config/file.config';
 import { FileConfig, FileDriver } from '../config/file-config.type';
 
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { AppConfig } from '../../config/app-config.type';
 import appConfig from '../../config/app.config';
+import { createFileS3Client } from '../s3-client.factory';
 
 export class FileType {
   @ApiProperty({
@@ -29,12 +30,12 @@ export class FileType {
           (fileConfig() as FileConfig).driver,
         )
       ) {
-        const s3 = new S3Client({
+        const s3 = createFileS3Client({
           region: (fileConfig() as FileConfig).awsS3Region ?? '',
-          credentials: {
-            accessKeyId: (fileConfig() as FileConfig).accessKeyId ?? '',
-            secretAccessKey: (fileConfig() as FileConfig).secretAccessKey ?? '',
-          },
+          accessKeyId: (fileConfig() as FileConfig).accessKeyId ?? '',
+          secretAccessKey: (fileConfig() as FileConfig).secretAccessKey ?? '',
+          endpoint: (fileConfig() as FileConfig).awsS3Endpoint,
+          forcePathStyle: (fileConfig() as FileConfig).awsS3ForcePathStyle,
         });
 
         const command = new GetObjectCommand({

--- a/src/file/infrastructure/persistence/relational/entities/file.entity.ts
+++ b/src/file/infrastructure/persistence/relational/entities/file.entity.ts
@@ -7,7 +7,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 import { Transform } from 'class-transformer';
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { ApiProperty } from '@nestjs/swagger';
 import { AppConfig } from '../../../../../config/app-config.type';
@@ -15,6 +15,7 @@ import appConfig from '../../../../../config/app.config';
 import { EntityRelationalHelper } from '../../../../../utils/relational-entity-helper';
 import { FileConfig, FileDriver } from '../../../../config/file-config.type';
 import fileConfig from '../../../../config/file.config';
+import { createFileS3Client } from '../../../../s3-client.factory';
 import { ulid } from 'ulid';
 
 @Entity({ name: 'files' })
@@ -69,12 +70,12 @@ export class FileEntity extends EntityRelationalHelper {
       } else if (
         [FileDriver.S3_PRESIGNED, FileDriver.S3].includes(config.driver)
       ) {
-        const s3 = new S3Client({
+        const s3 = createFileS3Client({
           region: config.awsS3Region ?? '',
-          credentials: {
-            accessKeyId: config.accessKeyId ?? '',
-            secretAccessKey: config.secretAccessKey ?? '',
-          },
+          accessKeyId: config.accessKeyId ?? '',
+          secretAccessKey: config.secretAccessKey ?? '',
+          endpoint: config.awsS3Endpoint,
+          forcePathStyle: config.awsS3ForcePathStyle,
         });
 
         const command = new GetObjectCommand({

--- a/src/file/infrastructure/uploader/s3-presigned/file.module.ts
+++ b/src/file/infrastructure/uploader/s3-presigned/file.module.ts
@@ -7,10 +7,10 @@ import { FilesS3PresignedController } from './file.controller';
 import { MulterModule } from '@nestjs/platform-express';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { randomStringGenerator } from '@nestjs/common/utils/random-string-generator.util';
-import { S3Client } from '@aws-sdk/client-s3';
 import multerS3 from 'multer-s3';
 
 import { FilesS3PresignedService } from './file.service';
+import { createFileS3Client } from '../../../s3-client.factory';
 import { RelationalFilePersistenceModule } from '../../persistence/relational/relational-persistence.module';
 import { AllConfigType } from '../../../../config/config.type';
 import { TenantConnectionService } from '../../../../tenant/tenant.service';
@@ -27,16 +27,18 @@ const infrastructurePersistenceModule = RelationalFilePersistenceModule;
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService<AllConfigType>) => {
-        const s3 = new S3Client({
+        const s3 = createFileS3Client({
           region: configService.get('file.awsS3Region', { infer: true }),
-          credentials: {
-            accessKeyId: configService.getOrThrow('file.accessKeyId', {
-              infer: true,
-            }),
-            secretAccessKey: configService.getOrThrow('file.secretAccessKey', {
-              infer: true,
-            }),
-          },
+          accessKeyId: configService.getOrThrow('file.accessKeyId', {
+            infer: true,
+          }),
+          secretAccessKey: configService.getOrThrow('file.secretAccessKey', {
+            infer: true,
+          }),
+          endpoint: configService.get('file.awsS3Endpoint', { infer: true }),
+          forcePathStyle: configService.get('file.awsS3ForcePathStyle', {
+            infer: true,
+          }),
         });
 
         return {

--- a/src/file/infrastructure/uploader/s3-presigned/file.service.ts
+++ b/src/file/infrastructure/uploader/s3-presigned/file.service.ts
@@ -11,6 +11,7 @@ import {
 import { FileUploadDto } from './dto/file.dto';
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { createFileS3Client } from '../../../s3-client.factory';
 import { randomStringGenerator } from '@nestjs/common/utils/random-string-generator.util';
 import { ConfigService } from '@nestjs/config';
 import { FileType } from '../../../domain/file';
@@ -31,17 +32,23 @@ export class FilesS3PresignedService {
     private readonly configService: ConfigService,
     private readonly tenantConnectionService: TenantConnectionService,
   ) {
-    this.s3 = new S3Client({
+    this.s3 = createFileS3Client({
       region: configService.get<string>('file.awsS3Region', { infer: true }),
-      credentials: {
-        accessKeyId: configService.getOrThrow<string>('file.accessKeyId', {
+      accessKeyId: configService.getOrThrow<string>('file.accessKeyId', {
+        infer: true,
+      }),
+      secretAccessKey: configService.getOrThrow<string>(
+        'file.secretAccessKey',
+        {
           infer: true,
-        }),
-        secretAccessKey: configService.getOrThrow<string>(
-          'file.secretAccessKey',
-          { infer: true },
-        ),
-      },
+        },
+      ),
+      endpoint: configService.get<string>('file.awsS3Endpoint', {
+        infer: true,
+      }),
+      forcePathStyle: configService.get<boolean>('file.awsS3ForcePathStyle', {
+        infer: true,
+      }),
     });
   }
 

--- a/src/file/infrastructure/uploader/s3/file.module.ts
+++ b/src/file/infrastructure/uploader/s3/file.module.ts
@@ -7,10 +7,10 @@ import { FilesS3Controller } from './file.controller';
 import { MulterModule } from '@nestjs/platform-express';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { randomStringGenerator } from '@nestjs/common/utils/random-string-generator.util';
-import { S3Client } from '@aws-sdk/client-s3';
 import multerS3 from 'multer-s3';
 
 import { FilesS3Service } from './file.service';
+import { createFileS3Client } from '../../../s3-client.factory';
 import { RelationalFilePersistenceModule } from '../../persistence/relational/relational-persistence.module';
 import { AllConfigType } from '../../../../config/config.type';
 
@@ -23,16 +23,18 @@ const infrastructurePersistenceModule = RelationalFilePersistenceModule;
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService<AllConfigType>) => {
-        const s3 = new S3Client({
+        const s3 = createFileS3Client({
           region: configService.get('file.awsS3Region', { infer: true }),
-          credentials: {
-            accessKeyId: configService.getOrThrow('file.accessKeyId', {
-              infer: true,
-            }),
-            secretAccessKey: configService.getOrThrow('file.secretAccessKey', {
-              infer: true,
-            }),
-          },
+          accessKeyId: configService.getOrThrow('file.accessKeyId', {
+            infer: true,
+          }),
+          secretAccessKey: configService.getOrThrow('file.secretAccessKey', {
+            infer: true,
+          }),
+          endpoint: configService.get('file.awsS3Endpoint', { infer: true }),
+          forcePathStyle: configService.get('file.awsS3ForcePathStyle', {
+            infer: true,
+          }),
         });
 
         return {

--- a/src/file/s3-client.factory.spec.ts
+++ b/src/file/s3-client.factory.spec.ts
@@ -1,0 +1,55 @@
+import { buildFileS3ClientConfig } from './s3-client.factory';
+
+describe('buildFileS3ClientConfig', () => {
+  const base = {
+    region: 'us-east-1',
+    accessKeyId: 'AKIA_TEST',
+    secretAccessKey: 'secret',
+  };
+
+  it('sets region and credentials', () => {
+    const config = buildFileS3ClientConfig(base);
+
+    expect(config.region).toBe('us-east-1');
+    expect(config.credentials).toEqual({
+      accessKeyId: 'AKIA_TEST',
+      secretAccessKey: 'secret',
+    });
+  });
+
+  it('omits endpoint/forcePathStyle when no endpoint is given (AWS S3 default)', () => {
+    const config = buildFileS3ClientConfig(base);
+
+    expect(config.endpoint).toBeUndefined();
+    expect(config.forcePathStyle).toBeUndefined();
+  });
+
+  it('applies a custom endpoint (e.g. DigitalOcean Spaces)', () => {
+    const config = buildFileS3ClientConfig({
+      ...base,
+      region: 'nyc3',
+      endpoint: 'https://nyc3.digitaloceanspaces.com',
+    });
+
+    expect(config.endpoint).toBe('https://nyc3.digitaloceanspaces.com');
+    // defaults to virtual-hosted style when not explicitly forced
+    expect(config.forcePathStyle).toBe(false);
+  });
+
+  it('honors forcePathStyle when an endpoint is set', () => {
+    const config = buildFileS3ClientConfig({
+      ...base,
+      endpoint: 'https://nyc3.digitaloceanspaces.com',
+      forcePathStyle: true,
+    });
+
+    expect(config.forcePathStyle).toBe(true);
+  });
+
+  it('ignores forcePathStyle when no endpoint is set', () => {
+    const config = buildFileS3ClientConfig({ ...base, forcePathStyle: true });
+
+    expect(config.endpoint).toBeUndefined();
+    expect(config.forcePathStyle).toBeUndefined();
+  });
+});

--- a/src/file/s3-client.factory.ts
+++ b/src/file/s3-client.factory.ts
@@ -1,0 +1,55 @@
+import { S3Client, S3ClientConfig } from '@aws-sdk/client-s3';
+
+/**
+ * Values needed to construct an S3Client for the file uploader/reader.
+ * Sourced from `file.*` config (see file.config.ts).
+ */
+export interface FileS3ClientParams {
+  region?: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  /**
+   * Custom S3-compatible endpoint (e.g. DigitalOcean Spaces
+   * `https://nyc3.digitaloceanspaces.com`). When unset, the AWS SDK's default
+   * AWS S3 endpoint is used, preserving prior behavior.
+   */
+  endpoint?: string;
+  /**
+   * Use path-style addressing (`endpoint/bucket/key`) instead of
+   * virtual-hosted-style (`bucket.endpoint/key`). Only meaningful when
+   * `endpoint` is set. Leave false for DO Spaces buckets without dots.
+   */
+  forcePathStyle?: boolean;
+}
+
+/**
+ * Build the S3ClientConfig for file storage. Adds a custom `endpoint` +
+ * `forcePathStyle` only when an endpoint is provided, so AWS S3 usage is
+ * unchanged when the new env vars are absent. Exported separately so the
+ * mapping can be unit-tested without constructing a real client.
+ */
+export function buildFileS3ClientConfig(
+  params: FileS3ClientParams,
+): S3ClientConfig {
+  const config: S3ClientConfig = {
+    region: params.region,
+    credentials: {
+      accessKeyId: params.accessKeyId,
+      secretAccessKey: params.secretAccessKey,
+    },
+  };
+
+  if (params.endpoint) {
+    config.endpoint = params.endpoint;
+    config.forcePathStyle = params.forcePathStyle ?? false;
+  }
+
+  return config;
+}
+
+/**
+ * Construct an S3Client for file storage from the given params.
+ */
+export function createFileS3Client(params: FileS3ClientParams): S3Client {
+  return new S3Client(buildFileS3ClientConfig(params));
+}


### PR DESCRIPTION
## What

Adds optional **`AWS_S3_ENDPOINT`** and **`AWS_S3_FORCE_PATH_STYLE`** env vars so the file uploader/reader can target an S3-compatible provider (e.g. **DigitalOcean Spaces**) instead of AWS S3. When both are unset, behavior is identical to today (AWS S3).

## Why

Ahead of moving app media off AWS S3/CloudFront onto DO Spaces, the API's file storage was hardwired to AWS: every `S3Client` was built with only `{ region, credentials }`, and there was no config field for a custom endpoint. This adds first-class support for a custom S3 endpoint without changing default AWS behavior.

## How

- New `src/file/s3-client.factory.ts` — `buildFileS3ClientConfig` / `createFileS3Client`. The custom `endpoint` + `forcePathStyle` are applied **only** when an endpoint is configured, so the AWS path is untouched.
- Routes all **five** `S3Client` construction sites through the factory:
  - presigned upload service (live write path — presigned PUT)
  - both MulterS3 module factories (`s3-presigned`, `s3`)
  - the two read-path presigned-GET transforms (`domain/file.ts`, `file.entity.ts`)
- Config plumbing in `file-config.type.ts` / `file.config.ts` (optional, validated only for S3-family drivers).
- Documents the vars in `env-example-relational`.

## Config example (DigitalOcean Spaces)

```
AWS_S3_REGION=nyc3
AWS_DEFAULT_S3_BUCKET=<space-name>
AWS_S3_ENDPOINT=https://nyc3.digitaloceanspaces.com
# AWS_S3_FORCE_PATH_STYLE=false   # default; virtual-hosted works for bucket names without dots
```

## Testing

- `src/file/s3-client.factory.spec.ts` — 5 unit tests covering the endpoint/forcePathStyle mapping (present, absent, path-style toggle), all passing.
- `nest build` clean; eslint clean on changed files.

## Backward compatibility

No behavior change when the new env vars are absent — existing AWS S3 / CloudFront deployments are unaffected.