### PR TITLE
feat(atproto): store event images as PDS blobs referenced via the record media field

### DIFF
--- a/env-example-relational
+++ b/env-example-relational
@@ -56,6 +56,11 @@ AWS_DEFAULT_S3_BUCKET=None
 # Optional: path-style addressing (endpoint/bucket/key). Leave "false" for
 # providers that support virtual-hosted-style buckets without dots.
 # AWS_S3_FORCE_PATH_STYLE=false
+# Optional: comma-separated hostnames trusted as OpenMeet media origins when a
+# legacy full-URL image reference is mapped back to an object key (e.g. a
+# retired CloudFront distribution kept alive for images in old records). The
+# object is still read from our own bucket -- these hosts are never fetched.
+# MEDIA_ALLOWED_LEGACY_ORIGINS=abcd1234.cloudfront.net
 
 # MAIL_HOST is for API inside Docker (container-to-container)
 MAIL_HOST=maildev

--- a/env-example-relational
+++ b/env-example-relational
@@ -56,6 +56,11 @@ AWS_DEFAULT_S3_BUCKET=None
 # Optional: path-style addressing (endpoint/bucket/key). Leave "false" for
 # providers that support virtual-hosted-style buckets without dots.
 # AWS_S3_FORCE_PATH_STYLE=false
+# Optional: public base URL (a CDN) fronting the PDS com.atproto.sync.getBlob
+# endpoint, baked into federated event records for images stored as PDS blobs
+# on OpenMeet's own PDS (e.g. https://media.openmeet.net). Leave unset to bake
+# the owner's own PDS host instead. See src/bluesky/event-image-blob.service.ts.
+# BLOB_PUBLIC_BASE_URL=
 
 # MAIL_HOST is for API inside Docker (container-to-container)
 MAIL_HOST=maildev

--- a/env-example-relational
+++ b/env-example-relational
@@ -56,11 +56,6 @@ AWS_DEFAULT_S3_BUCKET=None
 # Optional: path-style addressing (endpoint/bucket/key). Leave "false" for
 # providers that support virtual-hosted-style buckets without dots.
 # AWS_S3_FORCE_PATH_STYLE=false
-# Optional: public base URL (a CDN) fronting the PDS com.atproto.sync.getBlob
-# endpoint, baked into federated event records for images stored as PDS blobs
-# on OpenMeet's own PDS (e.g. https://media.openmeet.net). Leave unset to bake
-# the owner's own PDS host instead. See src/bluesky/event-image-blob.service.ts.
-# BLOB_PUBLIC_BASE_URL=
 
 # MAIL_HOST is for API inside Docker (container-to-container)
 MAIL_HOST=maildev

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
         "rrule": "^2.8.1",
         "rxjs": "7.8.1",
         "safe-stable-stringify": "^2.5.0",
+        "sharp": "^0.33.5",
         "slugify": "^1.6.6",
         "source-map-support": "0.5.21",
         "swagger-ui-express": "5.0.1",
@@ -317,6 +318,24 @@
         }
       }
     },
+    "node_modules/@angular-devkit/schematics-cli/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@angular-devkit/schematics-cli/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -344,6 +363,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -415,6 +435,24 @@
         }
       }
     },
+    "node_modules/@angular-devkit/schematics/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@angular-devkit/schematics/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -442,6 +480,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -515,7 +554,6 @@
       "resolved": "https://registry.npmjs.org/@atcute/identity/-/identity-1.1.5.tgz",
       "integrity": "sha512-5i9nl1UVnBDPCumUwrLNl4BZpGvQ/XABEXbjhiw3PQwRUfpQA8FqByDGxXy2gWpFDrNvQ9yVuOoNsjzxJgjjVA==",
       "license": "0BSD",
-      "peer": true,
       "dependencies": {
         "@atcute/lexicons": "^1.3.1",
         "@badrap/valita": "^0.4.6"
@@ -1443,6 +1481,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.370.0.tgz",
       "integrity": "sha512-/W4arzC/+yVW/cvEXbuwvG0uly4yFSZnnIA+gkqgAm+0HVfacwcPpNf4BjyxjnvIdh03l7w2DriF6MlKUfiQ3A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.370.0",
         "tslib": "^2.5.0"
@@ -1456,6 +1495,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.370.0.tgz",
       "integrity": "sha512-8PGMKklSkRKjunFhzM2y5Jm0H2TBu7YRNISdYzXLUHKSP9zlMEYagseKVdmox0zKHf1LXVNuSlUV2b6SRrieCQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
@@ -1469,6 +1509,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
       "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2772,7 +2813,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
       "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -3759,6 +3799,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
@@ -4349,7 +4399,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.5.tgz",
       "integrity": "sha512-d3iiHxdpg5+ZcJ6jnDSOT8Z0O0VMVGy34jAnYLUX8yd36b1qn8f1TwOA/Lc7TsOh03IkPJ38eGI5qD2EjNkoEA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -4363,7 +4412,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
       "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -4426,6 +4474,367 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -5504,7 +5913,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-4.0.1.tgz",
       "integrity": "sha512-68pFJgu+/AZbWkGu65Z3r55bTsCPlgyKaV4BSG8yUAD72q1PPuyVRgUwFv6BxdnibTUHlyxm06FmYWNC+bjN7A==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "axios": "^1.3.1",
@@ -5658,7 +6066,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -5783,7 +6190,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.16.tgz",
       "integrity": "sha512-JSIeW+USuMJkkcNbiOdcPkVCeI3TSnXstIVEPpp3HiaKnPRuSbUUKm9TY9o/XpIcPHWUOQItAtC5BiAwFdVITQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -5883,7 +6289,6 @@
       "integrity": "sha512-tXWXyCiqWthelJjrE0KLFjf0O98VEt+WPVx5CrqCf+059kIxJ8y1Vw7Cy7N4fwQafWNrmFL2AfN87DDMbVAY0w==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -5986,7 +6391,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.16.tgz",
       "integrity": "sha512-IOegr5+ZfUiMKgk+garsSU4MOkPRhm46e6w8Bp1GcO4vCdl9Piz6FlWAzKVfa/U3Hn/DdzSVJOW3TWcQQFdBDw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -6146,6 +6550,24 @@
         }
       }
     },
+    "node_modules/@nestjs/schematics/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nestjs/schematics/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -6173,6 +6595,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -6405,7 +6828,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-11.0.0.tgz",
       "integrity": "sha512-SOeUQl70Lb2OfhGkvnh4KXWlsd+zA08RuuQgT7kKbzivngxzSo1Oc7Usu5VxCxACQC9wc2l9esOHILSJeK7rJA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0",
@@ -6419,7 +6841,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.16.tgz",
       "integrity": "sha512-kfLhCFsq6139JVFCQpbFB6LOEjZzdpE7JzXsZtRbVjqmsgTKVSIh8gKRgzpcq27rbLNqHhhZavboOltOfSxZow==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -6536,7 +6957,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -7975,7 +8395,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.0.tgz",
       "integrity": "sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -8846,7 +9265,6 @@
       "integrity": "sha512-ul2qIqjM5bfe9zWLqFDmHZCf9HXXSZZAlZLe4czn+lH4PewO+OWZnQcYCscnJKlbx6MuWjzXVR7gkspjNEJwJA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@xhmikosr/bin-wrapper": "^13.0.5",
@@ -8919,7 +9337,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.12"
@@ -9179,7 +9596,6 @@
       "resolved": "https://registry.npmjs.org/@touch4it/ical-timezones/-/ical-timezones-1.9.0.tgz",
       "integrity": "sha512-UAiZMrFlgMdOIaJDPsKu5S7OecyMLr3GGALJTYkRgHmsHAA/8Ixm1qD09ELP2X7U1lqgrctEgvKj9GzMbczC+g==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">= 14.0.0"
       }
@@ -9334,7 +9750,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.0.tgz",
       "integrity": "sha512-35EhHNOXgxnUgh4XCJsGhE7zdlDhYDN/aMG6UbkByCFFNgQ7b3U+uVoqBpicFydR8JEfgdjCF7SJ7MiJfzuiTA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -9368,7 +9783,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
       "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -9547,7 +9961,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.5.tgz",
       "integrity": "sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -9780,7 +10193,6 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -10723,7 +11135,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10786,7 +11197,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -11031,7 +11441,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
       "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -11412,7 +11821,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -11870,15 +12278,13 @@
     "node_modules/class-transformer": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
-      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "peer": true
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -11969,6 +12375,19 @@
       "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
       "dev": true
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -11986,6 +12405,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/colord": {
       "version": "2.9.3",
@@ -12219,7 +12648,6 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
       "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
@@ -12343,6 +12771,7 @@
       "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.0.30",
         "source-map-js": "^1.0.1"
@@ -12380,7 +12809,6 @@
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.2.tgz",
       "integrity": "sha512-HYOPBsNvoiFeR1eghKD5C3ASm64v9YVyJB4Ivnl2gqKoQYvjjN/G0rztvKQq8OxocUtC6sjqY8jwYngIB4AByA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssnano-preset-default": "^7.0.10",
         "lilconfig": "^3.1.3"
@@ -12520,7 +12948,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -12539,8 +12966,7 @@
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
       "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -12686,6 +13112,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -13188,7 +13623,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -13248,7 +13682,6 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -13578,7 +14011,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -15186,7 +15618,6 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.5.0.tgz",
       "integrity": "sha512-7CutT89g23FfSa8MDoIFs2GYYa0PaNiW/OrT+nRyjRXHDZd17HmIgy+reOQ/yhh72NznNjGuS8kbCAcA4Ro4mw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ioredis/commands": "^1.1.1",
         "cluster-key-slot": "^1.1.0",
@@ -15593,7 +16024,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -16967,7 +17397,8 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "license": "CC0-1.0",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -17619,7 +18050,6 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -17629,7 +18059,6 @@
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
       "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "moment": "^2.29.4"
       },
@@ -18317,7 +18746,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
-      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -18482,7 +18910,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.12.0.tgz",
       "integrity": "sha512-A+LHUSnwnxrnL/tZ+OLfqR1SxLN3c/pgDztZ47Rpbsd4jUytsTtwQo/TLPRzPJMp/1pbhYVhH9cuSZLAajNfjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.6.4",
         "pg-pool": "^3.6.2",
@@ -18681,7 +19108,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -19344,7 +19770,6 @@
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -19398,7 +19823,6 @@
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
       "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.4.0",
         "tdigest": "^0.1.1"
@@ -19599,7 +20023,6 @@
       "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.0.tgz",
       "integrity": "sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==",
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "./packages/*"
       ],
@@ -19648,8 +20071,7 @@
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
-      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "peer": true
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -19900,7 +20322,6 @@
       "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
       "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -19914,7 +20335,6 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -20188,6 +20608,45 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -20290,6 +20749,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
@@ -20796,6 +21270,7 @@
       "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^7.2.0",
         "css-select": "^5.1.0",
@@ -20822,6 +21297,7 @@
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -20928,7 +21404,6 @@
       "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "devOptional": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -20993,7 +21468,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -21139,7 +21613,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -21263,7 +21736,6 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
       "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "tldts": "^6.1.32"
       },
@@ -21364,7 +21836,6 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -21508,7 +21979,6 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.27.tgz",
       "integrity": "sha512-pNV1bn+1n8qEe8tUNsNdD8ejuPcMAg47u2lUGnbsajiNUr3p2Js1XLKQjBMH0yMRMDfdX8T+fIRejFmIwy9x4A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^3.17.0",
@@ -21710,7 +22180,6 @@
       "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21795,7 +22264,6 @@
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
       "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.18.1"
       }
@@ -22088,7 +22556,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -22157,7 +22624,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "rrule": "^2.8.1",
     "rxjs": "7.8.1",
     "safe-stable-stringify": "^2.5.0",
+    "sharp": "^0.33.5",
     "slugify": "^1.6.6",
     "source-map-support": "0.5.21",
     "swagger-ui-express": "5.0.1",

--- a/src/bluesky/bluesky.module.ts
+++ b/src/bluesky/bluesky.module.ts
@@ -7,6 +7,7 @@ import { BlueskyIdentityService } from './bluesky-identity.service';
 import { BlueskyRsvpService } from './bluesky-rsvp.service';
 import { AtprotoHandleCacheService } from './atproto-handle-cache.service';
 import { AtprotoLexiconService } from './atproto-lexicon.service';
+import { EventImageBlobService } from './event-image-blob.service';
 import { UserModule } from '../user/user.module';
 import { ElastiCacheModule } from '../elasticache/elasticache.module';
 import { EventModule } from '../event/event.module';
@@ -35,6 +36,7 @@ import { UserAtprotoIdentityModule } from '../user-atproto-identity/user-atproto
     BlueskyRsvpService,
     AtprotoHandleCacheService,
     AtprotoLexiconService,
+    EventImageBlobService,
   ],
   exports: [
     BlueskyService,
@@ -43,6 +45,7 @@ import { UserAtprotoIdentityModule } from '../user-atproto-identity/user-atproto
     BlueskyRsvpService,
     AtprotoHandleCacheService,
     AtprotoLexiconService,
+    EventImageBlobService,
   ],
 })
 export class BlueskyModule {}

--- a/src/bluesky/bluesky.service.spec.ts
+++ b/src/bluesky/bluesky.service.spec.ts
@@ -142,30 +142,24 @@ const mockAtprotoLexiconService = {
 };
 
 const mockEventImageBlobService = {
-  uploadEventImage: jest.fn().mockResolvedValue({
-    blob: {
-      ref: { toString: () => 'bafkreiblob' },
+  uploadEventImage: jest.fn().mockImplementation((_agent, ref) =>
+    Promise.resolve({
+      blob: {
+        ref: { toString: () => 'bafkreiblob' },
+        mimeType: 'image/webp',
+        size: 1234,
+      },
+      cid: 'bafkreiblob',
       mimeType: 'image/webp',
       size: 1234,
-    },
-    cid: 'bafkreiblob',
-    mimeType: 'image/webp',
-    size: 1234,
-    width: 800,
-    height: 600,
-  }),
-  uploadExternalImage: jest.fn().mockResolvedValue({
-    blob: {
-      ref: { toString: () => 'bafexternal' },
-      mimeType: 'image/webp',
-      size: 2000,
-    },
-    cid: 'bafexternal',
-    mimeType: 'image/webp',
-    size: 2000,
-    width: 1024,
-    height: 768,
-  }),
+      width: 800,
+      height: 600,
+      // The service records the resolved object key. For a raw-key input that
+      // is the input itself; the URL->key origin resolution is unit-tested in
+      // event-image-blob.service.spec.ts.
+      sourceKey: typeof ref === 'string' ? ref : undefined,
+    }),
+  ),
 };
 
 // Mock Agent implementation to return in tests
@@ -1493,6 +1487,24 @@ describe('BlueskyService', () => {
     });
 
     it('should re-host a legacy full-URL image as a blob rather than baking the URL', async () => {
+      // A legacy full-URL now flows through the single uploadEventImage entry
+      // point, which maps a recognized OpenMeet origin back to an object key and
+      // reads it from our own bucket (never fetching the URL -- SSRF-guarded and
+      // unit-tested in event-image-blob.service.spec.ts). The resolved key comes
+      // back as sourceKey.
+      mockEventImageBlobService.uploadEventImage.mockResolvedValueOnce({
+        blob: {
+          ref: { toString: () => 'bafrehosted' },
+          mimeType: 'image/webp',
+          size: 2000,
+        },
+        cid: 'bafrehosted',
+        mimeType: 'image/webp',
+        size: 2000,
+        width: 1024,
+        height: 768,
+        sourceKey: 'events/old.jpg',
+      });
       const event = {
         name: 'Test Event Legacy URL Image',
         description: 'Test Description',
@@ -1502,7 +1514,7 @@ describe('BlueskyService', () => {
         status: EventStatus.Published,
         createdAt: new Date('2023-11-01T00:00:00Z'),
         slug: 'test-event-legacy-url',
-        image: { path: 'https://legacy.cdn.example.com/old.jpg' },
+        image: { path: 'https://cdn.openmeet.net/events/old.jpg' },
       } as EventEntity;
 
       await service.createEventRecord(
@@ -1512,14 +1524,11 @@ describe('BlueskyService', () => {
         'test-tenant',
       );
 
-      // Full URLs go through the external re-host path, not the S3-key path.
-      expect(
-        mockEventImageBlobService.uploadExternalImage,
-      ).toHaveBeenCalledWith(
+      // One entry point for both keys and legacy URLs; no separate external path.
+      expect(mockEventImageBlobService.uploadEventImage).toHaveBeenCalledWith(
         expect.anything(),
-        'https://legacy.cdn.example.com/old.jpg',
+        'https://cdn.openmeet.net/events/old.jpg',
       );
-      expect(mockEventImageBlobService.uploadEventImage).not.toHaveBeenCalled();
 
       const putRecordCall =
         mockAgentImplementation.com.atproto.repo.putRecord.mock.calls[0][0];
@@ -1534,11 +1543,11 @@ describe('BlueskyService', () => {
       const thumbnail = (record.media as any[]).find(
         (m) => m.role === 'thumbnail',
       );
-      expect(thumbnail.content.ref.toString()).toBe('bafexternal');
+      expect(thumbnail.content.ref.toString()).toBe('bafrehosted');
       expect(thumbnail.aspect_ratio).toEqual({ width: 1024, height: 768 });
       expect(thumbnail.alt).toBe('Test Event Legacy URL Image');
-      // External re-host has no S3 source key.
-      expect(record.openMeetMeta).toBeUndefined();
+      // The resolved object key (not the URL) is recorded for dedup.
+      expect(record.openMeetMeta.imageSourceKey).toBe('events/old.jpg');
     });
 
     it('should publish without an image when the blob upload fails', async () => {
@@ -1568,6 +1577,59 @@ describe('BlueskyService', () => {
       ).toHaveBeenCalled();
       expect(result.record).not.toHaveProperty('media');
       expect(result.record.openMeetMeta).toBeUndefined();
+    });
+
+    it('should preserve an existing thumbnail and source key when a republish upload fails (transient)', async () => {
+      // Regression: a transient upload failure on republish must NOT unpin a
+      // previously published image. The event still has a local image (so this
+      // is a temporary dependency failure, not an image removal), and the record
+      // already carries our thumbnail + its source key -- both must survive.
+      mockEventImageBlobService.uploadEventImage.mockResolvedValueOnce(null);
+      const header = {
+        role: 'header',
+        content: { $type: 'blob', ref: { $link: 'bafheader' } },
+      };
+      const existingThumbnail = {
+        role: 'thumbnail',
+        content: { $type: 'blob', ref: { $link: 'bafgoodthumb' } },
+        aspect_ratio: { width: 800, height: 600 },
+        alt: 'Previously published',
+      };
+      const event = {
+        name: 'Test Event Transient Upload Failure',
+        description: 'Test Description',
+        startDate: new Date('2023-12-01T12:00:00Z'),
+        endDate: new Date('2023-12-01T14:00:00Z'),
+        type: EventType.InPerson,
+        status: EventStatus.Published,
+        createdAt: new Date('2023-11-01T00:00:00Z'),
+        slug: 'test-event-transient-fail',
+        image: { path: 'lsdfaopkljdfs/still-here.jpg' },
+        atprotoRecord: {
+          media: [header, existingThumbnail],
+          openMeetMeta: { imageSourceKey: 'lsdfaopkljdfs/still-here.jpg' },
+        },
+      } as unknown as EventEntity;
+
+      const result = await service.createEventRecord(
+        event,
+        'test-did',
+        'test.handle',
+        'test-tenant',
+        mockAgentImplementation as any,
+      );
+
+      const media = result.record.media as any[];
+      // The previously published thumbnail is kept verbatim (blob still pinned).
+      const thumbnails = media.filter((m) => m.role === 'thumbnail');
+      expect(thumbnails).toHaveLength(1);
+      expect(thumbnails[0]).toEqual(existingThumbnail);
+      // Foreign entries preserved too.
+      expect(media.find((m) => m.role === 'header')).toEqual(header);
+      // The source key that matches the preserved thumbnail survives.
+      expect((result.record.openMeetMeta as any).imageSourceKey).toBe(
+        'lsdfaopkljdfs/still-here.jpg',
+      );
     });
 
     // Bug 2: locationOnline should be normalized to include protocol

--- a/src/bluesky/bluesky.service.spec.ts
+++ b/src/bluesky/bluesky.service.spec.ts
@@ -14,6 +14,7 @@ import { BlueskyIdService } from './bluesky-id.service';
 import { BlueskyIdentityService } from './bluesky-identity.service';
 import { UserAtprotoIdentityService } from '../user-atproto-identity/user-atproto-identity.service';
 import { AtprotoLexiconService } from './atproto-lexicon.service';
+import { EventImageBlobService } from './event-image-blob.service';
 
 // Mock modules first before creating mock implementations
 jest.mock('@atproto/api', () => ({
@@ -94,6 +95,7 @@ const mockBlueskyIdentityService = {
   resolveProfile: jest.fn().mockResolvedValue({
     did: 'did:plc:test-resolved',
     handle: 'test.user',
+    pdsUrl: 'https://pds.opnmt.me',
     displayName: 'Test User',
     avatar: 'https://example.com/avatar.jpg',
     followersCount: 100,
@@ -137,6 +139,21 @@ const mockRequest = {
 
 const mockAtprotoLexiconService = {
   validate: jest.fn().mockReturnValue({ success: true, value: {} }),
+};
+
+const mockEventImageBlobService = {
+  uploadEventImage: jest.fn().mockResolvedValue({
+    blob: { ref: { toString: () => 'bafkreiblob' }, mimeType: 'image/jpeg', size: 1234 },
+    cid: 'bafkreiblob',
+    mimeType: 'image/jpeg',
+    size: 1234,
+  }),
+  buildGetBlobUrl: jest.fn(
+    (_pdsUrl: string, did: string, cid: string) =>
+      `https://media.openmeet.net/xrpc/com.atproto.sync.getBlob?did=${encodeURIComponent(
+        did,
+      )}&cid=${encodeURIComponent(cid)}`,
+  ),
 };
 
 // Mock Agent implementation to return in tests
@@ -217,6 +234,10 @@ describe('BlueskyService', () => {
         {
           provide: AtprotoLexiconService,
           useValue: mockAtprotoLexiconService,
+        },
+        {
+          provide: EventImageBlobService,
+          useValue: mockEventImageBlobService,
         },
       ],
     }).compile();
@@ -1322,8 +1343,8 @@ describe('BlueskyService', () => {
       expect(result.rkey).toBe(sourceDataRkey);
     });
 
-    // Bug 1: Image URI should be a full URL, not raw DB path
-    it('should transform image path to a full URL using instanceToPlain', async () => {
+    // Image is uploaded as a PDS blob and referenced by a stable getBlob URL
+    it('should upload the image as a blob and bake a getBlob URL into the record', async () => {
       // Arrange - event with a raw DB path (tenantId/filename.jpg)
       const event = {
         name: 'Test Event with Image',
@@ -1346,18 +1367,32 @@ describe('BlueskyService', () => {
       // Act
       await service.createEventRecord(event, did, handle, tenantId);
 
-      // Assert - the image URI should NOT be the raw DB path
+      // The image should have been uploaded as a blob from its raw DB key
+      expect(mockEventImageBlobService.uploadEventImage).toHaveBeenCalledWith(
+        expect.anything(),
+        'lsdfaopkljdfs/f1fd62ebcddf53472a2ab.jpg',
+      );
+
       const putRecordCall =
         mockAgentImplementation.com.atproto.repo.putRecord.mock.calls[0][0];
       const imageUri = putRecordCall.record.uris.find(
         (u: any) => u.name === 'Event Image',
       );
       expect(imageUri).toBeDefined();
-      // The raw path should have been transformed - it should NOT be the bare DB value
+      // The raw path should NOT be baked in, and neither should a non-portable
+      // api.openmeet.net / CloudFront / S3 URL -- it must be a stable getBlob URL.
       expect(imageUri.uri).not.toBe('lsdfaopkljdfs/f1fd62ebcddf53472a2ab.jpg');
-      // It should be a full CloudFront URL
+      expect(imageUri.uri).not.toContain('api.openmeet.net');
+      expect(imageUri.uri).not.toContain('cloudfront');
       expect(imageUri.uri).toBe(
-        'https://cdn.example.com/lsdfaopkljdfs/f1fd62ebcddf53472a2ab.jpg',
+        'https://media.openmeet.net/xrpc/com.atproto.sync.getBlob?did=test-did&cid=bafkreiblob',
+      );
+
+      // The blob must be pinned in the record so the PDS does not GC it
+      expect(putRecordCall.record.openMeetMedia).toBeDefined();
+      expect(putRecordCall.record.openMeetMedia.image).toBeDefined();
+      expect(putRecordCall.record.openMeetMedia.sourceKey).toBe(
+        'lsdfaopkljdfs/f1fd62ebcddf53472a2ab.jpg',
       );
     });
 

--- a/src/bluesky/bluesky.service.spec.ts
+++ b/src/bluesky/bluesky.service.spec.ts
@@ -1404,6 +1404,9 @@ describe('BlueskyService', () => {
       expect(thumbnail.content).toBeDefined();
       expect(thumbnail.content.ref.toString()).toBe('bafkreiblob');
       expect(thumbnail.aspect_ratio).toEqual({ width: 800, height: 600 });
+      // Accessibility default: the event name stands in for alt text until a
+      // dedicated alt-text field exists.
+      expect(thumbnail.alt).toBe('Test Event with Image');
 
       // The old bespoke openMeetMedia field is gone.
       expect(record.openMeetMedia).toBeUndefined();
@@ -1452,6 +1455,7 @@ describe('BlueskyService', () => {
       const thumbnails = media.filter((m) => m.role === 'thumbnail');
       expect(thumbnails).toHaveLength(1);
       expect(thumbnails[0].content.ref.toString()).toBe('bafkreiblob');
+      expect(thumbnails[0].alt).toBe('Test Event with Foreign Media');
     });
 
     it('should drop the thumbnail but keep foreign media when the event has no image', async () => {
@@ -1532,6 +1536,7 @@ describe('BlueskyService', () => {
       );
       expect(thumbnail.content.ref.toString()).toBe('bafexternal');
       expect(thumbnail.aspect_ratio).toEqual({ width: 1024, height: 768 });
+      expect(thumbnail.alt).toBe('Test Event Legacy URL Image');
       // External re-host has no S3 source key.
       expect(record.openMeetMeta).toBeUndefined();
     });

--- a/src/bluesky/bluesky.service.spec.ts
+++ b/src/bluesky/bluesky.service.spec.ts
@@ -143,17 +143,29 @@ const mockAtprotoLexiconService = {
 
 const mockEventImageBlobService = {
   uploadEventImage: jest.fn().mockResolvedValue({
-    blob: { ref: { toString: () => 'bafkreiblob' }, mimeType: 'image/jpeg', size: 1234 },
+    blob: {
+      ref: { toString: () => 'bafkreiblob' },
+      mimeType: 'image/webp',
+      size: 1234,
+    },
     cid: 'bafkreiblob',
-    mimeType: 'image/jpeg',
+    mimeType: 'image/webp',
     size: 1234,
+    width: 800,
+    height: 600,
   }),
-  buildGetBlobUrl: jest.fn(
-    (_pdsUrl: string, did: string, cid: string) =>
-      `https://media.openmeet.net/xrpc/com.atproto.sync.getBlob?did=${encodeURIComponent(
-        did,
-      )}&cid=${encodeURIComponent(cid)}`,
-  ),
+  uploadExternalImage: jest.fn().mockResolvedValue({
+    blob: {
+      ref: { toString: () => 'bafexternal' },
+      mimeType: 'image/webp',
+      size: 2000,
+    },
+    cid: 'bafexternal',
+    mimeType: 'image/webp',
+    size: 2000,
+    width: 1024,
+    height: 768,
+  }),
 };
 
 // Mock Agent implementation to return in tests
@@ -1343,8 +1355,8 @@ describe('BlueskyService', () => {
       expect(result.rkey).toBe(sourceDataRkey);
     });
 
-    // Image is uploaded as a PDS blob and referenced by a stable getBlob URL
-    it('should upload the image as a blob and bake a getBlob URL into the record', async () => {
+    // Image is uploaded as a PDS blob and referenced via the media[] convention
+    it('should reference the image blob via a media[] thumbnail entry with aspect_ratio', async () => {
       // Arrange - event with a raw DB path (tenantId/filename.jpg)
       const event = {
         name: 'Test Event with Image',
@@ -1375,25 +1387,182 @@ describe('BlueskyService', () => {
 
       const putRecordCall =
         mockAgentImplementation.com.atproto.repo.putRecord.mock.calls[0][0];
-      const imageUri = putRecordCall.record.uris.find(
+      const record = putRecordCall.record;
+
+      // No URL is baked into the record at all -- no "Event Image" uri entry.
+      const imageUri = (record.uris as any[]).find(
         (u: any) => u.name === 'Event Image',
       );
-      expect(imageUri).toBeDefined();
-      // The raw path should NOT be baked in, and neither should a non-portable
-      // api.openmeet.net / CloudFront / S3 URL -- it must be a stable getBlob URL.
-      expect(imageUri.uri).not.toBe('lsdfaopkljdfs/f1fd62ebcddf53472a2ab.jpg');
-      expect(imageUri.uri).not.toContain('api.openmeet.net');
-      expect(imageUri.uri).not.toContain('cloudfront');
-      expect(imageUri.uri).toBe(
-        'https://media.openmeet.net/xrpc/com.atproto.sync.getBlob?did=test-did&cid=bafkreiblob',
-      );
+      expect(imageUri).toBeUndefined();
 
-      // The blob must be pinned in the record so the PDS does not GC it
-      expect(putRecordCall.record.openMeetMedia).toBeDefined();
-      expect(putRecordCall.record.openMeetMedia.image).toBeDefined();
-      expect(putRecordCall.record.openMeetMedia.sourceKey).toBe(
+      // The blob is referenced via the ecosystem media[] convention.
+      expect(Array.isArray(record.media)).toBe(true);
+      const thumbnail = (record.media as any[]).find(
+        (m) => m.role === 'thumbnail',
+      );
+      expect(thumbnail).toBeDefined();
+      expect(thumbnail.content).toBeDefined();
+      expect(thumbnail.content.ref.toString()).toBe('bafkreiblob');
+      expect(thumbnail.aspect_ratio).toEqual({ width: 800, height: 600 });
+
+      // The old bespoke openMeetMedia field is gone.
+      expect(record.openMeetMedia).toBeUndefined();
+
+      // The S3 source key is stored in openMeetMeta (not the media entry).
+      expect(record.openMeetMeta.imageSourceKey).toBe(
         'lsdfaopkljdfs/f1fd62ebcddf53472a2ab.jpg',
       );
+    });
+
+    it('should preserve foreign media entries and replace only the thumbnail on republish', async () => {
+      const header = {
+        role: 'header',
+        content: { $type: 'blob', ref: { $link: 'bafheader' } },
+      };
+      const oldThumbnail = {
+        role: 'thumbnail',
+        content: { $type: 'blob', ref: { $link: 'bafoldthumb' } },
+        aspect_ratio: { width: 1, height: 1 },
+      };
+      const event = {
+        name: 'Test Event with Foreign Media',
+        description: 'Test Description',
+        startDate: new Date('2023-12-01T12:00:00Z'),
+        endDate: new Date('2023-12-01T14:00:00Z'),
+        type: EventType.InPerson,
+        status: EventStatus.Published,
+        createdAt: new Date('2023-11-01T00:00:00Z'),
+        slug: 'test-event-foreign-media',
+        image: { path: 'lsdfaopkljdfs/new-image.jpg' },
+        atprotoRecord: { media: [header, oldThumbnail] },
+      } as unknown as EventEntity;
+
+      const result = await service.createEventRecord(
+        event,
+        'test-did',
+        'test.handle',
+        'test-tenant',
+        mockAgentImplementation as any,
+      );
+
+      const media = result.record.media as any[];
+      // Foreign header entry survives.
+      expect(media.find((m) => m.role === 'header')).toEqual(header);
+      // Exactly one thumbnail, and it's the freshly uploaded blob (not the old one).
+      const thumbnails = media.filter((m) => m.role === 'thumbnail');
+      expect(thumbnails).toHaveLength(1);
+      expect(thumbnails[0].content.ref.toString()).toBe('bafkreiblob');
+    });
+
+    it('should drop the thumbnail but keep foreign media when the event has no image', async () => {
+      const header = {
+        role: 'header',
+        content: { $type: 'blob', ref: { $link: 'bafheader' } },
+      };
+      const oldThumbnail = {
+        role: 'thumbnail',
+        content: { $type: 'blob', ref: { $link: 'bafoldthumb' } },
+      };
+      const event = {
+        name: 'Test Event No Image',
+        description: 'Test Description',
+        startDate: new Date('2023-12-01T12:00:00Z'),
+        endDate: new Date('2023-12-01T14:00:00Z'),
+        type: EventType.InPerson,
+        status: EventStatus.Published,
+        createdAt: new Date('2023-11-01T00:00:00Z'),
+        slug: 'test-event-no-image',
+        atprotoRecord: { media: [header, oldThumbnail] },
+      } as unknown as EventEntity;
+
+      const result = await service.createEventRecord(
+        event,
+        'test-did',
+        'test.handle',
+        'test-tenant',
+        mockAgentImplementation as any,
+      );
+
+      const media = result.record.media as any[];
+      expect(media).toEqual([header]);
+      expect(mockEventImageBlobService.uploadEventImage).not.toHaveBeenCalled();
+    });
+
+    it('should re-host a legacy full-URL image as a blob rather than baking the URL', async () => {
+      const event = {
+        name: 'Test Event Legacy URL Image',
+        description: 'Test Description',
+        startDate: new Date('2023-12-01T12:00:00Z'),
+        endDate: new Date('2023-12-01T14:00:00Z'),
+        type: EventType.InPerson,
+        status: EventStatus.Published,
+        createdAt: new Date('2023-11-01T00:00:00Z'),
+        slug: 'test-event-legacy-url',
+        image: { path: 'https://legacy.cdn.example.com/old.jpg' },
+      } as EventEntity;
+
+      await service.createEventRecord(
+        event,
+        'test-did',
+        'test.handle',
+        'test-tenant',
+      );
+
+      // Full URLs go through the external re-host path, not the S3-key path.
+      expect(
+        mockEventImageBlobService.uploadExternalImage,
+      ).toHaveBeenCalledWith(
+        expect.anything(),
+        'https://legacy.cdn.example.com/old.jpg',
+      );
+      expect(mockEventImageBlobService.uploadEventImage).not.toHaveBeenCalled();
+
+      const putRecordCall =
+        mockAgentImplementation.com.atproto.repo.putRecord.mock.calls[0][0];
+      const record = putRecordCall.record;
+
+      // The URL is not baked anywhere.
+      const imageUri = (record.uris as any[]).find(
+        (u: any) => u.name === 'Event Image',
+      );
+      expect(imageUri).toBeUndefined();
+
+      const thumbnail = (record.media as any[]).find(
+        (m) => m.role === 'thumbnail',
+      );
+      expect(thumbnail.content.ref.toString()).toBe('bafexternal');
+      expect(thumbnail.aspect_ratio).toEqual({ width: 1024, height: 768 });
+      // External re-host has no S3 source key.
+      expect(record.openMeetMeta).toBeUndefined();
+    });
+
+    it('should publish without an image when the blob upload fails', async () => {
+      mockEventImageBlobService.uploadEventImage.mockResolvedValueOnce(null);
+      const event = {
+        name: 'Test Event Image Upload Fails',
+        description: 'Test Description',
+        startDate: new Date('2023-12-01T12:00:00Z'),
+        endDate: new Date('2023-12-01T14:00:00Z'),
+        type: EventType.InPerson,
+        status: EventStatus.Published,
+        createdAt: new Date('2023-11-01T00:00:00Z'),
+        slug: 'test-event-image-fail',
+        image: { path: 'lsdfaopkljdfs/broken.jpg' },
+      } as EventEntity;
+
+      const result = await service.createEventRecord(
+        event,
+        'test-did',
+        'test.handle',
+        'test-tenant',
+      );
+
+      // Still published, just without an image reference.
+      expect(
+        mockAgentImplementation.com.atproto.repo.putRecord,
+      ).toHaveBeenCalled();
+      expect(result.record).not.toHaveProperty('media');
+      expect(result.record.openMeetMeta).toBeUndefined();
     });
 
     // Bug 2: locationOnline should be normalized to include protocol

--- a/src/bluesky/bluesky.service.ts
+++ b/src/bluesky/bluesky.service.ts
@@ -6,6 +6,7 @@ import { UserEntity } from '../user/infrastructure/persistence/relational/entiti
 import { Agent } from '@atproto/api';
 import { NodeOAuthClient } from '@atproto/oauth-client-node';
 import { TID } from '@atproto/common-web';
+import { BlobRef } from '@atproto/lexicon';
 import { instanceToPlain } from 'class-transformer';
 import { initializeOAuthClient } from '../utils/bluesky';
 import { ElastiCacheService } from '../elasticache/elasticache.service';
@@ -16,6 +17,7 @@ import {
   BLUESKY_COLLECTIONS,
 } from './BlueskyTypes';
 import { AtprotoLexiconService } from './atproto-lexicon.service';
+import { EventImageBlobService } from './event-image-blob.service';
 import { mergeArrayField } from './atproto-record-merge.utils';
 import { EventManagementService } from '../event/services/event-management.service';
 import { EventQueryService } from '../event/services/event-query.service';
@@ -68,6 +70,7 @@ export class BlueskyService {
     private readonly blueskyIdentityService: BlueskyIdentityService,
     private readonly userAtprotoIdentityService: UserAtprotoIdentityService,
     private readonly atprotoLexiconService: AtprotoLexiconService,
+    private readonly eventImageBlobService: EventImageBlobService,
   ) {}
 
   private async getOAuthClient(tenantId: string): Promise<NodeOAuthClient> {
@@ -79,34 +82,23 @@ export class BlueskyService {
   }
 
   /**
-   * Build a full URL for an image path.
-   * If the path is already a full URL, return it as-is.
-   * Otherwise, construct from CloudFront or backend domain config.
+   * Resolve the PDS host for a DID so the getBlob URL points at the repo that
+   * actually holds the blob. Falls back to OpenMeet's own PDS (custodial users).
    */
-  private buildImageUrl(path: string): string {
-    // Already a full URL
-    if (/^https?:\/\//i.test(path)) {
-      return path;
+  private async resolveUserPdsUrl(did: string): Promise<string> {
+    try {
+      const profile = await this.blueskyIdentityService.resolveProfile(did);
+      if (profile?.pdsUrl) {
+        return profile.pdsUrl;
+      }
+    } catch (err) {
+      this.logger.warn(
+        `Could not resolve PDS URL for ${did}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
     }
-
-    const cloudfrontDomain = this.configService.get<string>(
-      'file.cloudfrontDistributionDomain',
-      { infer: true },
-    );
-    if (cloudfrontDomain) {
-      return `https://${cloudfrontDomain}/${path}`;
-    }
-
-    const backendDomain =
-      this.configService.get<string>('app.backendDomain', { infer: true }) ||
-      this.configService.get<string>('BACKEND_DOMAIN', { infer: true });
-    if (backendDomain) {
-      const separator = path.startsWith('/') ? '' : '/';
-      return `${backendDomain}${separator}${path}`;
-    }
-
-    // Last resort: prepend https://
-    return `https://${path}`;
+    return this.configService.get<string>('pds.url', { infer: true }) || '';
   }
 
   async resumeSession(tenantId: string, did: string): Promise<Agent> {
@@ -414,19 +406,58 @@ export class BlueskyService {
         );
       }
 
-      // Prepare uris array with image if it exists
+      // Prepare uris array with image if it exists.
+      //
+      // The event image is uploaded to the owner's PDS as a content-addressed
+      // blob and referenced by a stable, federated getBlob URL. This keeps the
+      // media in the same portable substrate as the (immutable) record instead
+      // of a non-portable OpenMeet/S3/CloudFront URL. The blob ref is also pinned
+      // into the record (openMeetMedia, below) so the PDS does not garbage-
+      // collect it -- the community lexicon has no blob field, so a URL alone
+      // would leave the blob unreferenced and it would eventually be deleted.
       const uris: BlueskyEventUri[] = [];
+      let eventImageBlob: BlobRef | undefined;
+      let eventImageSourceKey: string | undefined;
       if (event.image?.path) {
-        // Build the full image URL from the raw DB path.
-        // instanceToPlain may not fire @Transform on plain objects, so we
-        // construct the URL using config -- the same approach as embed.service.ts.
-        const imageUrl = this.buildImageUrl(event.image.path);
-        uris.push({
-          $type: 'community.lexicon.calendar.event#uri',
-          uri: imageUrl,
-          name: 'Event Image',
-          source: sourceId,
-        });
+        const imagePath = event.image.path;
+        if (/^https?:\/\//i.test(imagePath)) {
+          // Already a full URL (legacy/corrupted state): pass through, no blob.
+          uris.push({
+            $type: 'community.lexicon.calendar.event#uri',
+            uri: imagePath,
+            name: 'Event Image',
+            source: sourceId,
+          });
+        } else {
+          // TODO(dedup): re-uploads on every publish. Safe (a fresh, valid
+          // BlobRef always re-pins the blob) but wasteful; a future optimization
+          // can reuse the prior blob when the source key is unchanged.
+          const uploaded = await this.eventImageBlobService.uploadEventImage(
+            agent,
+            imagePath,
+          );
+          if (uploaded) {
+            const userPdsUrl = await this.resolveUserPdsUrl(did);
+            const imageUrl = this.eventImageBlobService.buildGetBlobUrl(
+              userPdsUrl,
+              did,
+              uploaded.cid,
+            );
+            eventImageBlob = uploaded.blob;
+            eventImageSourceKey = imagePath;
+            uris.push({
+              $type: 'community.lexicon.calendar.event#uri',
+              uri: imageUrl,
+              name: 'Event Image',
+              source: sourceId,
+            });
+          } else {
+            this.logger.warn(
+              'Failed to upload event image blob; publishing event without image',
+              { eventId: event.id, imagePath },
+            );
+          }
+        }
       } else if (event.image) {
         // Log a warning if we have an image but no path
         this.logger.warn('Event has image but no path', {
@@ -511,6 +542,18 @@ export class BlueskyService {
         };
       } else {
         delete recordData.openMeetMeta;
+      }
+
+      // Pin the event image blob. The community lexicon has no blob field, so we
+      // reference the blob via an OpenMeet-namespaced field to keep the PDS from
+      // garbage-collecting it; the getBlob URL in `uris` is what appviews render.
+      if (eventImageBlob) {
+        recordData.openMeetMedia = {
+          image: eventImageBlob,
+          sourceKey: eventImageSourceKey,
+        };
+      } else {
+        delete recordData.openMeetMedia;
       }
 
       // Validate record against AT Protocol lexicon schema

--- a/src/bluesky/bluesky.service.ts
+++ b/src/bluesky/bluesky.service.ts
@@ -17,7 +17,10 @@ import {
   BLUESKY_COLLECTIONS,
 } from './BlueskyTypes';
 import { AtprotoLexiconService } from './atproto-lexicon.service';
-import { EventImageBlobService } from './event-image-blob.service';
+import {
+  EventImageBlobService,
+  UploadedEventImage,
+} from './event-image-blob.service';
 import { mergeArrayField } from './atproto-record-merge.utils';
 import { EventManagementService } from '../event/services/event-management.service';
 import { EventQueryService } from '../event/services/event-query.service';
@@ -79,26 +82,6 @@ export class BlueskyService {
       this.configService,
       this.elasticacheService,
     );
-  }
-
-  /**
-   * Resolve the PDS host for a DID so the getBlob URL points at the repo that
-   * actually holds the blob. Falls back to OpenMeet's own PDS (custodial users).
-   */
-  private async resolveUserPdsUrl(did: string): Promise<string> {
-    try {
-      const profile = await this.blueskyIdentityService.resolveProfile(did);
-      if (profile?.pdsUrl) {
-        return profile.pdsUrl;
-      }
-    } catch (err) {
-      this.logger.warn(
-        `Could not resolve PDS URL for ${did}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
-    return this.configService.get<string>('pds.url', { infer: true }) || '';
   }
 
   async resumeSession(tenantId: string, did: string): Promise<Agent> {
@@ -406,57 +389,52 @@ export class BlueskyService {
         );
       }
 
-      // Prepare uris array with image if it exists.
-      //
-      // The event image is uploaded to the owner's PDS as a content-addressed
-      // blob and referenced by a stable, federated getBlob URL. This keeps the
-      // media in the same portable substrate as the (immutable) record instead
-      // of a non-portable OpenMeet/S3/CloudFront URL. The blob ref is also pinned
-      // into the record (openMeetMedia, below) so the PDS does not garbage-
-      // collect it -- the community lexicon has no blob field, so a URL alone
-      // would leave the blob unreferenced and it would eventually be deleted.
+      // Upload the event image to the owner's PDS as a content-addressed blob
+      // and reference it from the record via the ecosystem media[] convention
+      // (below). The bytes live in the same portable substrate as the immutable
+      // record; the blob ref pins them against PDS garbage collection. No URL is
+      // baked into the record -- consumers build a getBlob/CDN URL at render time
+      // from the blob ref and the owner's DID.
       const uris: BlueskyEventUri[] = [];
       let eventImageBlob: BlobRef | undefined;
+      let eventImageAspectRatio: { width: number; height: number } | undefined;
       let eventImageSourceKey: string | undefined;
       if (event.image?.path) {
         const imagePath = event.image.path;
+        let uploaded: UploadedEventImage | null;
         if (/^https?:\/\//i.test(imagePath)) {
-          // Already a full URL (legacy/corrupted state): pass through, no blob.
-          uris.push({
-            $type: 'community.lexicon.calendar.event#uri',
-            uri: imagePath,
-            name: 'Event Image',
-            source: sourceId,
-          });
+          // Legacy/corrupted rows store a full URL. Re-host it as a PDS blob
+          // rather than baking a non-portable URL into the record (mirrors
+          // atmo's handling of external images).
+          uploaded = await this.eventImageBlobService.uploadExternalImage(
+            agent,
+            imagePath,
+          );
         } else {
           // TODO(dedup): re-uploads on every publish. Safe (a fresh, valid
           // BlobRef always re-pins the blob) but wasteful; a future optimization
           // can reuse the prior blob when the source key is unchanged.
-          const uploaded = await this.eventImageBlobService.uploadEventImage(
+          uploaded = await this.eventImageBlobService.uploadEventImage(
             agent,
             imagePath,
           );
           if (uploaded) {
-            const userPdsUrl = await this.resolveUserPdsUrl(did);
-            const imageUrl = this.eventImageBlobService.buildGetBlobUrl(
-              userPdsUrl,
-              did,
-              uploaded.cid,
-            );
-            eventImageBlob = uploaded.blob;
             eventImageSourceKey = imagePath;
-            uris.push({
-              $type: 'community.lexicon.calendar.event#uri',
-              uri: imageUrl,
-              name: 'Event Image',
-              source: sourceId,
-            });
-          } else {
-            this.logger.warn(
-              'Failed to upload event image blob; publishing event without image',
-              { eventId: event.id, imagePath },
-            );
           }
+        }
+        if (uploaded) {
+          eventImageBlob = uploaded.blob;
+          if (uploaded.width != null && uploaded.height != null) {
+            eventImageAspectRatio = {
+              width: uploaded.width,
+              height: uploaded.height,
+            };
+          }
+        } else {
+          this.logger.warn(
+            'Failed to upload event image blob; publishing event without image',
+            { eventId: event.id, imagePath },
+          );
         }
       } else if (event.image) {
         // Log a warning if we have an image but no path
@@ -534,26 +512,46 @@ export class BlueskyService {
         uris: mergeArrayField(base.uris as any[], uris, sourceId),
       });
 
-      // Add openmeet-specific metadata in record, or clean up if event left series
-      if (event.series) {
-        recordData.openMeetMeta = {
-          seriesSlug: event.series.slug,
-          isRecurring: true,
+      // Reference the event image via the ecosystem media[] convention: an
+      // array of { role, content: <blob>, aspect_ratio } entries. Preserve any
+      // foreign entries another app may have written (e.g. a `header`) and
+      // replace/append only the `thumbnail` entry we own -- same pattern as
+      // atmo's save.ts. When the event has no image, drop the thumbnail entry
+      // (we are the only writer of it) but leave foreign entries intact.
+      const existingMedia = Array.isArray(base.media)
+        ? (base.media as Record<string, unknown>[])
+        : [];
+      const foreignMedia = existingMedia.filter((m) => m?.role !== 'thumbnail');
+      if (eventImageBlob) {
+        const thumbnail: Record<string, unknown> = {
+          role: 'thumbnail',
+          content: eventImageBlob,
         };
+        if (eventImageAspectRatio) {
+          thumbnail.aspect_ratio = eventImageAspectRatio;
+        }
+        recordData.media = [...foreignMedia, thumbnail];
+      } else if (foreignMedia.length > 0) {
+        recordData.media = foreignMedia;
       } else {
-        delete recordData.openMeetMeta;
+        delete recordData.media;
       }
 
-      // Pin the event image blob. The community lexicon has no blob field, so we
-      // reference the blob via an OpenMeet-namespaced field to keep the PDS from
-      // garbage-collecting it; the getBlob URL in `uris` is what appviews render.
-      if (eventImageBlob) {
-        recordData.openMeetMedia = {
-          image: eventImageBlob,
-          sourceKey: eventImageSourceKey,
-        };
+      // OpenMeet-namespaced metadata: series info plus the S3 source key of the
+      // uploaded image (kept out of the media entry, used for future re-upload
+      // dedup). Reconstructed fresh each publish; removed if empty.
+      const openMeetMeta: Record<string, unknown> = {};
+      if (event.series) {
+        openMeetMeta.seriesSlug = event.series.slug;
+        openMeetMeta.isRecurring = true;
+      }
+      if (eventImageSourceKey) {
+        openMeetMeta.imageSourceKey = eventImageSourceKey;
+      }
+      if (Object.keys(openMeetMeta).length > 0) {
+        recordData.openMeetMeta = openMeetMeta;
       } else {
-        delete recordData.openMeetMedia;
+        delete recordData.openMeetMeta;
       }
 
       // Validate record against AT Protocol lexicon schema

--- a/src/bluesky/bluesky.service.ts
+++ b/src/bluesky/bluesky.service.ts
@@ -17,10 +17,7 @@ import {
   BLUESKY_COLLECTIONS,
 } from './BlueskyTypes';
 import { AtprotoLexiconService } from './atproto-lexicon.service';
-import {
-  EventImageBlobService,
-  UploadedEventImage,
-} from './event-image-blob.service';
+import { EventImageBlobService } from './event-image-blob.service';
 import { mergeArrayField } from './atproto-record-merge.utils';
 import { EventManagementService } from '../event/services/event-management.service';
 import { EventQueryService } from '../event/services/event-query.service';
@@ -399,31 +396,25 @@ export class BlueskyService {
       let eventImageBlob: BlobRef | undefined;
       let eventImageAspectRatio: { width: number; height: number } | undefined;
       let eventImageSourceKey: string | undefined;
+      // Distinguishes "the event has no image" from "the event has an image but
+      // this publish could not upload it". The latter must NOT drop a
+      // previously published thumbnail (see the media[] block below).
+      let imageUploadFailed = false;
       if (event.image?.path) {
         const imagePath = event.image.path;
-        let uploaded: UploadedEventImage | null;
-        if (/^https?:\/\//i.test(imagePath)) {
-          // Legacy/corrupted rows store a full URL. Re-host it as a PDS blob
-          // rather than baking a non-portable URL into the record (mirrors
-          // atmo's handling of external images).
-          uploaded = await this.eventImageBlobService.uploadExternalImage(
-            agent,
-            imagePath,
-          );
-        } else {
-          // TODO(dedup): re-uploads on every publish. Safe (a fresh, valid
-          // BlobRef always re-pins the blob) but wasteful; a future optimization
-          // can reuse the prior blob when the source key is unchanged.
-          uploaded = await this.eventImageBlobService.uploadEventImage(
-            agent,
-            imagePath,
-          );
-          if (uploaded) {
-            eventImageSourceKey = imagePath;
-          }
-        }
+        // uploadEventImage handles a raw object key and also a legacy full-URL
+        // that points at a recognized OpenMeet origin (which it maps back to a
+        // key); it never fetches an unrecognized/arbitrary URL.
+        // TODO(dedup): re-uploads on every publish. Safe (a fresh, valid BlobRef
+        // always re-pins the blob) but wasteful; a future optimization can reuse
+        // the prior blob when the source key is unchanged.
+        const uploaded = await this.eventImageBlobService.uploadEventImage(
+          agent,
+          imagePath,
+        );
         if (uploaded) {
           eventImageBlob = uploaded.blob;
+          eventImageSourceKey = uploaded.sourceKey;
           if (uploaded.width != null && uploaded.height != null) {
             eventImageAspectRatio = {
               width: uploaded.width,
@@ -431,8 +422,12 @@ export class BlueskyService {
             };
           }
         } else {
+          // Transient failure (S3, image processing, or uploadBlob), or an
+          // unrecognized image origin. Preserve any image already on the record
+          // rather than mutating it away on a temporary problem.
+          imageUploadFailed = true;
           this.logger.warn(
-            'Failed to upload event image blob; publishing event without image',
+            'Failed to upload event image blob; preserving any previously published image',
             { eventId: event.id, imagePath },
           );
         }
@@ -516,15 +511,24 @@ export class BlueskyService {
       // array of { role, content: <blob>, aspect_ratio } entries. Preserve any
       // foreign entries another app may have written (e.g. a `header`) and
       // replace/append only the `thumbnail` entry we own -- same pattern as
-      // atmo's save.ts. When the event has no image, drop the thumbnail entry
-      // (we are the only writer of it) but leave foreign entries intact.
+      // atmo's save.ts.
+      //
+      // Three distinct cases, so a transient upload failure never destroys a
+      // previously published image:
+      //   (a) upload succeeded          -> replace our thumbnail with the new blob
+      //   (b) image present, upload FAILED -> keep the existing thumbnail as-is
+      //   (c) event has no image        -> drop our thumbnail (we are its only
+      //                                     writer), leaving foreign entries intact
       const existingMedia = Array.isArray(base.media)
         ? (base.media as Record<string, unknown>[])
         : [];
+      const existingThumbnail = existingMedia.find(
+        (m) => m?.role === 'thumbnail',
+      );
       const foreignMedia = existingMedia.filter((m) => m?.role !== 'thumbnail');
       if (eventImageBlob) {
-        // alt is optional in the ecosystem media shape; default it to the event
-        // name as an accessibility fallback (screen readers get something
+        // (a) alt is optional in the ecosystem media shape; default it to the
+        // event name as an accessibility fallback (screen readers get something
         // meaningful) until the product grows a dedicated alt-text field.
         const thumbnail: Record<string, unknown> = {
           role: 'thumbnail',
@@ -535,7 +539,11 @@ export class BlueskyService {
           thumbnail.aspect_ratio = eventImageAspectRatio;
         }
         recordData.media = [...foreignMedia, thumbnail];
+      } else if (imageUploadFailed && existingThumbnail) {
+        // (b) do not unpin a good blob over a temporary upload failure.
+        recordData.media = [...foreignMedia, existingThumbnail];
       } else if (foreignMedia.length > 0) {
+        // (c) no image (or a failure with nothing prior to preserve).
         recordData.media = foreignMedia;
       } else {
         delete recordData.media;
@@ -551,6 +559,15 @@ export class BlueskyService {
       }
       if (eventImageSourceKey) {
         openMeetMeta.imageSourceKey = eventImageSourceKey;
+      } else if (imageUploadFailed) {
+        // Preserve the prior source key alongside the preserved thumbnail
+        // (case b above) so the two stay consistent after a transient failure.
+        const priorSourceKey = (
+          base.openMeetMeta as Record<string, unknown> | undefined
+        )?.imageSourceKey;
+        if (typeof priorSourceKey === 'string') {
+          openMeetMeta.imageSourceKey = priorSourceKey;
+        }
       }
       if (Object.keys(openMeetMeta).length > 0) {
         recordData.openMeetMeta = openMeetMeta;

--- a/src/bluesky/bluesky.service.ts
+++ b/src/bluesky/bluesky.service.ts
@@ -523,9 +523,13 @@ export class BlueskyService {
         : [];
       const foreignMedia = existingMedia.filter((m) => m?.role !== 'thumbnail');
       if (eventImageBlob) {
+        // alt is optional in the ecosystem media shape; default it to the event
+        // name as an accessibility fallback (screen readers get something
+        // meaningful) until the product grows a dedicated alt-text field.
         const thumbnail: Record<string, unknown> = {
           role: 'thumbnail',
           content: eventImageBlob,
+          alt: event.name,
         };
         if (eventImageAspectRatio) {
           thumbnail.aspect_ratio = eventImageAspectRatio;

--- a/src/bluesky/event-image-blob.service.spec.ts
+++ b/src/bluesky/event-image-blob.service.spec.ts
@@ -364,6 +364,25 @@ describe('EventImageBlobService', () => {
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
+    it('should map a configured legacy origin (retired CloudFront) back to a key', async () => {
+      mockedFileConfig.mockReturnValue({
+        ...baseFileConfig,
+        mediaAllowedLegacyOrigins: ['ds1xtylbemsat.cloudfront.net'],
+      } as any);
+      const png = await smallImage(10, 10, 'png');
+      const send = mockS3Returning({ bytes: png, contentType: 'image/png' });
+      const { agent } = mockAgent();
+
+      const result = await service.uploadEventImage(
+        agent,
+        'https://ds1xtylbemsat.cloudfront.net/events/legacy.png',
+      );
+
+      expect(result!.sourceKey).toBe('events/legacy.png');
+      expect(send.mock.calls[0][0].input.Key).toBe('events/legacy.png');
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
     it('should refuse an unrecognized external URL without fetching or reading S3 (SSRF guard)', async () => {
       const send = mockS3Returning({ bytes: await smallImage(10, 10) });
       const { agent, uploadBlob } = mockAgent();

--- a/src/bluesky/event-image-blob.service.spec.ts
+++ b/src/bluesky/event-image-blob.service.spec.ts
@@ -1,0 +1,157 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { EventImageBlobService } from './event-image-blob.service';
+import { createFileS3Client } from '../file/s3-client.factory';
+import fileConfig from '../file/config/file.config';
+
+jest.mock('../file/s3-client.factory');
+jest.mock('../file/config/file.config');
+
+const mockedCreateS3 = createFileS3Client as jest.MockedFunction<
+  typeof createFileS3Client
+>;
+const mockedFileConfig = fileConfig as jest.MockedFunction<typeof fileConfig>;
+
+describe('EventImageBlobService', () => {
+  let service: EventImageBlobService;
+
+  const baseFileConfig = {
+    driver: 's3-presigned',
+    accessKeyId: 'key',
+    secretAccessKey: 'secret',
+    awsDefaultS3Bucket: 'openmeet-media',
+    awsS3Region: 'us-east-1',
+    awsS3Endpoint: 'https://nyc3.digitaloceanspaces.com',
+    awsS3ForcePathStyle: false,
+    blobPublicBaseUrl: 'https://media.openmeet.net',
+    maxFileSize: 5242880,
+  };
+
+  const mockConfigService = {
+    get: jest.fn((key: string) =>
+      key === 'pds.url' ? 'https://pds.opnmt.me' : undefined,
+    ),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockedFileConfig.mockReturnValue(baseFileConfig as any);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EventImageBlobService,
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get<EventImageBlobService>(EventImageBlobService);
+  });
+
+  describe('buildGetBlobUrl', () => {
+    it('uses the CDN base URL when the owner is on OpenMeet PDS', () => {
+      const url = service.buildGetBlobUrl(
+        'https://pds.opnmt.me',
+        'did:plc:abc',
+        'bafcid',
+      );
+      expect(url).toBe(
+        'https://media.openmeet.net/xrpc/com.atproto.sync.getBlob?did=did%3Aplc%3Aabc&cid=bafcid',
+      );
+    });
+
+    it('uses the owner PDS host for external PDS users (CDN only fronts OpenMeet PDS)', () => {
+      const url = service.buildGetBlobUrl(
+        'https://mushroom.us-west.host.bsky.network',
+        'did:plc:ext',
+        'bafext',
+      );
+      expect(url).toBe(
+        'https://mushroom.us-west.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did%3Aplc%3Aext&cid=bafext',
+      );
+    });
+
+    it('falls back to the owner PDS host when no CDN base is configured', () => {
+      mockedFileConfig.mockReturnValue({
+        ...baseFileConfig,
+        blobPublicBaseUrl: undefined,
+      } as any);
+      const url = service.buildGetBlobUrl(
+        'https://pds.opnmt.me',
+        'did:plc:abc',
+        'bafcid',
+      );
+      expect(url).toBe(
+        'https://pds.opnmt.me/xrpc/com.atproto.sync.getBlob?did=did%3Aplc%3Aabc&cid=bafcid',
+      );
+    });
+  });
+
+  describe('uploadEventImage', () => {
+    function mockS3Returning(body: {
+      bytes: Uint8Array;
+      contentType?: string;
+    }) {
+      const send = jest.fn().mockResolvedValue({
+        Body: {
+          transformToByteArray: jest.fn().mockResolvedValue(body.bytes),
+        },
+        ContentType: body.contentType,
+      });
+      mockedCreateS3.mockReturnValue({ send } as any);
+      return send;
+    }
+
+    it('uploads a small image byte-for-byte and returns the blob + cid', async () => {
+      mockS3Returning({
+        bytes: new Uint8Array([1, 2, 3, 4]),
+        contentType: 'image/jpeg',
+      });
+      const uploadBlob = jest.fn().mockResolvedValue({
+        data: {
+          blob: {
+            ref: { toString: () => 'bafuploadedcid' },
+            mimeType: 'image/jpeg',
+            size: 4,
+          },
+        },
+      });
+      const agent = { uploadBlob } as any;
+
+      const result = await service.uploadEventImage(agent, 'tenant/pic.jpg');
+
+      expect(result).not.toBeNull();
+      expect(result!.cid).toBe('bafuploadedcid');
+      expect(result!.mimeType).toBe('image/jpeg');
+      // small image => not resized, uploaded as-is
+      expect(uploadBlob).toHaveBeenCalledTimes(1);
+      const [bytesArg, opts] = uploadBlob.mock.calls[0];
+      expect(Buffer.isBuffer(bytesArg)).toBe(true);
+      expect(bytesArg).toHaveLength(4);
+      expect(opts).toEqual({ encoding: 'image/jpeg' });
+    });
+
+    it('returns null (does not throw) when the object cannot be fetched', async () => {
+      const send = jest.fn().mockRejectedValue(new Error('NoSuchKey'));
+      mockedCreateS3.mockReturnValue({ send } as any);
+      const agent = { uploadBlob: jest.fn() } as any;
+
+      const result = await service.uploadEventImage(agent, 'tenant/missing.jpg');
+
+      expect(result).toBeNull();
+      expect(agent.uploadBlob).not.toHaveBeenCalled();
+    });
+
+    it('infers mime type from the key when the object has no ContentType', async () => {
+      mockS3Returning({ bytes: new Uint8Array([1, 2, 3]) });
+      const uploadBlob = jest.fn().mockResolvedValue({
+        data: {
+          blob: { ref: { toString: () => 'bafpng' }, mimeType: 'image/png', size: 3 },
+        },
+      });
+
+      await service.uploadEventImage({ uploadBlob } as any, 'tenant/logo.png');
+
+      expect(uploadBlob.mock.calls[0][1]).toEqual({ encoding: 'image/png' });
+    });
+  });
+});

--- a/src/bluesky/event-image-blob.service.spec.ts
+++ b/src/bluesky/event-image-blob.service.spec.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from 'crypto';
+import { promises as fsPromises } from 'fs';
 import { Test, TestingModule } from '@nestjs/testing';
 import sharp from 'sharp';
 import { EventImageBlobService } from './event-image-blob.service';
@@ -12,6 +13,8 @@ const mockedCreateS3 = createFileS3Client as jest.MockedFunction<
   typeof createFileS3Client
 >;
 const mockedFileConfig = fileConfig as jest.MockedFunction<typeof fileConfig>;
+
+const MAX_BLOB_BYTES = 900 * 1024;
 
 /** A small, valid image well under the 900KB passthrough threshold. */
 async function smallImage(
@@ -35,13 +38,29 @@ async function smallImage(
 }
 
 /**
- * A random-noise image that does not compress below the 900KB threshold and
+ * A random-noise RGB image that does not compress below the 900KB threshold and
  * whose longest edge exceeds 2048, so normalizeForBlob takes the resize+WebP
  * path. Noise is (nearly) incompressible, so the encoded PNG stays large.
  */
 async function oversizedImage(width: number, height: number): Promise<Buffer> {
   const raw = randomBytes(width * height * 3);
   return sharp(raw, { raw: { width, height, channels: 3 } })
+    .png()
+    .toBuffer();
+}
+
+/**
+ * A high-entropy RGBA image: WebP encodes the alpha channel LOSSLESSLY, so
+ * noise transparency keeps the encode oversized at any lossy quality until the
+ * fallback ladder flattens the alpha away. Reproduces the over-ceiling bug the
+ * bounded ladder fixes.
+ */
+async function oversizedAlphaImage(
+  width: number,
+  height: number,
+): Promise<Buffer> {
+  const raw = randomBytes(width * height * 4);
+  return sharp(raw, { raw: { width, height, channels: 4 } })
     .png()
     .toBuffer();
 }
@@ -69,6 +88,10 @@ describe('EventImageBlobService', () => {
     }).compile();
 
     service = module.get<EventImageBlobService>(EventImageBlobService);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   function mockAgent(cid = 'bafuploadedcid') {
@@ -132,7 +155,7 @@ describe('EventImageBlobService', () => {
 
     it('should resize and re-encode oversized images to WebP, capturing final dimensions', async () => {
       const big = await oversizedImage(2100, 500);
-      expect(big.length).toBeGreaterThan(900 * 1024);
+      expect(big.length).toBeGreaterThan(MAX_BLOB_BYTES);
       mockS3Returning({ bytes: big, contentType: 'image/png' });
       const { agent, uploadBlob } = mockAgent('bafwebp');
 
@@ -144,9 +167,32 @@ describe('EventImageBlobService', () => {
       expect(result!.width).toBe(2048);
       expect(result!.height).toBeLessThanOrEqual(2048);
       expect(result!.height).toBeLessThan(500);
+      expect(result!.size).toBeLessThanOrEqual(MAX_BLOB_BYTES);
       const [, opts] = uploadBlob.mock.calls[0];
       expect(opts).toEqual({ encoding: 'image/webp' });
-    }, 20000);
+    }, 30000);
+
+    it('should never upload an over-ceiling blob for high-entropy RGBA input (ladder or skip)', async () => {
+      // WebP stores alpha losslessly, so noise transparency can defeat the
+      // lossy quality loop entirely; the bounded fallback ladder must either
+      // produce something under the ceiling (flattening the alpha) or give up
+      // with null -- never return oversized bytes.
+      const rgba = await oversizedAlphaImage(1500, 1500);
+      expect(rgba.length).toBeGreaterThan(MAX_BLOB_BYTES);
+      mockS3Returning({ bytes: rgba, contentType: 'image/png' });
+      const { agent, uploadBlob } = mockAgent('bafalpha');
+
+      const result = await service.uploadEventImage(agent, 'tenant/alpha.png');
+
+      if (result === null) {
+        expect(uploadBlob).not.toHaveBeenCalled();
+      } else {
+        expect(result.size).toBeLessThanOrEqual(MAX_BLOB_BYTES);
+        expect(result.mimeType).toBe('image/webp');
+        const [bytesArg] = uploadBlob.mock.calls[0];
+        expect(bytesArg.length).toBeLessThanOrEqual(MAX_BLOB_BYTES);
+      }
+    }, 60000);
 
     it('should return null (not throw) when the object cannot be fetched', async () => {
       const send = jest.fn().mockRejectedValue(new Error('NoSuchKey'));
@@ -171,15 +217,51 @@ describe('EventImageBlobService', () => {
 
       expect(uploadBlob.mock.calls[0][1]).toEqual({ encoding: 'image/png' });
     });
+
+    it('should read the object from local disk when the local file driver is active', async () => {
+      mockedFileConfig.mockReturnValue({
+        ...baseFileConfig,
+        driver: 'local',
+      } as any);
+      const png = await smallImage(12, 8, 'png');
+      const readFileSpy = jest
+        .spyOn(fsPromises, 'readFile')
+        .mockResolvedValue(png as any);
+      const { agent, uploadBlob } = mockAgent('baflocal');
+
+      const result = await service.uploadEventImage(
+        agent,
+        '/api/v1/files/abc123.png',
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.width).toBe(12);
+      expect(result!.height).toBe(8);
+      // Reads ./files/<basename> -- where the local driver stores uploads.
+      expect(readFileSpy).toHaveBeenCalledWith('files/abc123.png');
+      expect(uploadBlob).toHaveBeenCalledTimes(1);
+      expect(uploadBlob.mock.calls[0][1]).toEqual({ encoding: 'image/png' });
+      // No S3 client involved on this path.
+      expect(mockedCreateS3).not.toHaveBeenCalled();
+    });
   });
 
   describe('uploadExternalImage', () => {
+    function toStream(chunks: Uint8Array[]): AsyncIterable<Uint8Array> {
+      return (async function* () {
+        for (const chunk of chunks) {
+          yield await Promise.resolve(chunk);
+        }
+      })();
+    }
+
     function mockFetch(response: {
       ok?: boolean;
       status?: number;
       contentType?: string | null;
       contentLength?: string | null;
       body?: Buffer;
+      stream?: AsyncIterable<Uint8Array>;
     }) {
       const headers = new Map<string, string | null>();
       headers.set('content-type', response.contentType ?? null);
@@ -188,12 +270,9 @@ describe('EventImageBlobService', () => {
         ok: response.ok ?? true,
         status: response.status ?? 200,
         headers: { get: (h: string) => headers.get(h.toLowerCase()) ?? null },
-        arrayBuffer: () =>
-          Promise.resolve(
-            response.body
-              ? new Uint8Array(response.body).buffer
-              : new ArrayBuffer(0),
-          ),
+        body:
+          response.stream ??
+          toStream(response.body ? [new Uint8Array(response.body)] : []),
       });
       global.fetch = fetchMock as any;
       return fetchMock;
@@ -260,6 +339,37 @@ describe('EventImageBlobService', () => {
 
       expect(result).toBeNull();
       expect(uploadBlob).not.toHaveBeenCalled();
+    });
+
+    it('should abort mid-stream when a lying Content-Length hides an over-cap body', async () => {
+      // The server declares a small size, then streams far more than the 10MB
+      // cap. The download must stop as soon as the running total crosses the
+      // cap instead of buffering everything first.
+      const chunk = new Uint8Array(1024 * 1024); // 1MB per chunk
+      let yielded = 0;
+      const lyingStream: AsyncIterable<Uint8Array> = (async function* () {
+        for (let i = 0; i < 50; i++) {
+          yielded++;
+          yield await Promise.resolve(chunk);
+        }
+      })();
+      mockFetch({
+        contentType: 'image/png',
+        contentLength: '1000', // lie
+        stream: lyingStream,
+      });
+      const { agent, uploadBlob } = mockAgent();
+
+      const result = await service.uploadExternalImage(
+        agent,
+        'https://legacy.example.com/liar.png',
+      );
+
+      expect(result).toBeNull();
+      expect(uploadBlob).not.toHaveBeenCalled();
+      // Bailed right after crossing the 10MB cap (11 chunks), long before
+      // draining all 50MB.
+      expect(yielded).toBeLessThanOrEqual(11);
     });
 
     it('should return null (not throw) when the fetch fails', async () => {

--- a/src/bluesky/event-image-blob.service.spec.ts
+++ b/src/bluesky/event-image-blob.service.spec.ts
@@ -1,5 +1,6 @@
+import { randomBytes } from 'crypto';
 import { Test, TestingModule } from '@nestjs/testing';
-import { ConfigService } from '@nestjs/config';
+import sharp from 'sharp';
 import { EventImageBlobService } from './event-image-blob.service';
 import { createFileS3Client } from '../file/s3-client.factory';
 import fileConfig from '../file/config/file.config';
@@ -12,6 +13,39 @@ const mockedCreateS3 = createFileS3Client as jest.MockedFunction<
 >;
 const mockedFileConfig = fileConfig as jest.MockedFunction<typeof fileConfig>;
 
+/** A small, valid image well under the 900KB passthrough threshold. */
+async function smallImage(
+  width: number,
+  height: number,
+  format: 'png' | 'webp' | 'jpeg' = 'png',
+): Promise<Buffer> {
+  const img = sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: { r: 12, g: 34, b: 56 },
+    },
+  });
+  return format === 'png'
+    ? img.png().toBuffer()
+    : format === 'webp'
+      ? img.webp().toBuffer()
+      : img.jpeg().toBuffer();
+}
+
+/**
+ * A random-noise image that does not compress below the 900KB threshold and
+ * whose longest edge exceeds 2048, so normalizeForBlob takes the resize+WebP
+ * path. Noise is (nearly) incompressible, so the encoded PNG stays large.
+ */
+async function oversizedImage(width: number, height: number): Promise<Buffer> {
+  const raw = randomBytes(width * height * 3);
+  return sharp(raw, { raw: { width, height, channels: 3 } })
+    .png()
+    .toBuffer();
+}
+
 describe('EventImageBlobService', () => {
   let service: EventImageBlobService;
 
@@ -23,14 +57,7 @@ describe('EventImageBlobService', () => {
     awsS3Region: 'us-east-1',
     awsS3Endpoint: 'https://nyc3.digitaloceanspaces.com',
     awsS3ForcePathStyle: false,
-    blobPublicBaseUrl: 'https://media.openmeet.net',
     maxFileSize: 5242880,
-  };
-
-  const mockConfigService = {
-    get: jest.fn((key: string) =>
-      key === 'pds.url' ? 'https://pds.opnmt.me' : undefined,
-    ),
   };
 
   beforeEach(async () => {
@@ -38,53 +65,18 @@ describe('EventImageBlobService', () => {
     mockedFileConfig.mockReturnValue(baseFileConfig as any);
 
     const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        EventImageBlobService,
-        { provide: ConfigService, useValue: mockConfigService },
-      ],
+      providers: [EventImageBlobService],
     }).compile();
 
     service = module.get<EventImageBlobService>(EventImageBlobService);
   });
 
-  describe('buildGetBlobUrl', () => {
-    it('uses the CDN base URL when the owner is on OpenMeet PDS', () => {
-      const url = service.buildGetBlobUrl(
-        'https://pds.opnmt.me',
-        'did:plc:abc',
-        'bafcid',
-      );
-      expect(url).toBe(
-        'https://media.openmeet.net/xrpc/com.atproto.sync.getBlob?did=did%3Aplc%3Aabc&cid=bafcid',
-      );
+  function mockAgent(cid = 'bafuploadedcid') {
+    const uploadBlob = jest.fn().mockResolvedValue({
+      data: { blob: { ref: { toString: () => cid } } },
     });
-
-    it('uses the owner PDS host for external PDS users (CDN only fronts OpenMeet PDS)', () => {
-      const url = service.buildGetBlobUrl(
-        'https://mushroom.us-west.host.bsky.network',
-        'did:plc:ext',
-        'bafext',
-      );
-      expect(url).toBe(
-        'https://mushroom.us-west.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did%3Aplc%3Aext&cid=bafext',
-      );
-    });
-
-    it('falls back to the owner PDS host when no CDN base is configured', () => {
-      mockedFileConfig.mockReturnValue({
-        ...baseFileConfig,
-        blobPublicBaseUrl: undefined,
-      } as any);
-      const url = service.buildGetBlobUrl(
-        'https://pds.opnmt.me',
-        'did:plc:abc',
-        'bafcid',
-      );
-      expect(url).toBe(
-        'https://pds.opnmt.me/xrpc/com.atproto.sync.getBlob?did=did%3Aplc%3Aabc&cid=bafcid',
-      );
-    });
-  });
+    return { agent: { uploadBlob } as any, uploadBlob };
+  }
 
   describe('uploadEventImage', () => {
     function mockS3Returning(body: {
@@ -101,57 +93,188 @@ describe('EventImageBlobService', () => {
       return send;
     }
 
-    it('uploads a small image byte-for-byte and returns the blob + cid', async () => {
-      mockS3Returning({
-        bytes: new Uint8Array([1, 2, 3, 4]),
-        contentType: 'image/jpeg',
-      });
-      const uploadBlob = jest.fn().mockResolvedValue({
-        data: {
-          blob: {
-            ref: { toString: () => 'bafuploadedcid' },
-            mimeType: 'image/jpeg',
-            size: 4,
-          },
-        },
-      });
-      const agent = { uploadBlob } as any;
+    it('should upload a small image byte-for-byte and capture its dimensions', async () => {
+      const png = await smallImage(10, 20, 'png');
+      mockS3Returning({ bytes: png, contentType: 'image/png' });
+      const { agent, uploadBlob } = mockAgent('bafsmall');
 
-      const result = await service.uploadEventImage(agent, 'tenant/pic.jpg');
+      const result = await service.uploadEventImage(agent, 'tenant/pic.png');
 
       expect(result).not.toBeNull();
-      expect(result!.cid).toBe('bafuploadedcid');
-      expect(result!.mimeType).toBe('image/jpeg');
-      // small image => not resized, uploaded as-is
+      expect(result!.cid).toBe('bafsmall');
+      // small image => uploaded unchanged, mime preserved
+      expect(result!.mimeType).toBe('image/png');
+      expect(result!.width).toBe(10);
+      expect(result!.height).toBe(20);
       expect(uploadBlob).toHaveBeenCalledTimes(1);
       const [bytesArg, opts] = uploadBlob.mock.calls[0];
       expect(Buffer.isBuffer(bytesArg)).toBe(true);
-      expect(bytesArg).toHaveLength(4);
-      expect(opts).toEqual({ encoding: 'image/jpeg' });
+      expect(Buffer.compare(bytesArg, png)).toBe(0); // byte-for-byte
+      expect(opts).toEqual({ encoding: 'image/png' });
     });
 
-    it('returns null (does not throw) when the object cannot be fetched', async () => {
+    it('should omit dimensions when the passthrough image cannot be probed', async () => {
+      // Not a decodable image, but under the threshold => uploaded as-is.
+      mockS3Returning({
+        bytes: new Uint8Array([1, 2, 3, 4]),
+        contentType: 'image/gif',
+      });
+      const { agent, uploadBlob } = mockAgent('bafodd');
+
+      const result = await service.uploadEventImage(agent, 'tenant/odd.gif');
+
+      expect(result).not.toBeNull();
+      expect(result!.mimeType).toBe('image/gif');
+      expect(result!.width).toBeUndefined();
+      expect(result!.height).toBeUndefined();
+      expect(uploadBlob).toHaveBeenCalledTimes(1);
+    });
+
+    it('should resize and re-encode oversized images to WebP, capturing final dimensions', async () => {
+      const big = await oversizedImage(2100, 500);
+      expect(big.length).toBeGreaterThan(900 * 1024);
+      mockS3Returning({ bytes: big, contentType: 'image/png' });
+      const { agent, uploadBlob } = mockAgent('bafwebp');
+
+      const result = await service.uploadEventImage(agent, 'tenant/big.png');
+
+      expect(result).not.toBeNull();
+      expect(result!.mimeType).toBe('image/webp');
+      // longest edge clamped to 2048 (2100 -> 2048), height scaled down
+      expect(result!.width).toBe(2048);
+      expect(result!.height).toBeLessThanOrEqual(2048);
+      expect(result!.height).toBeLessThan(500);
+      const [, opts] = uploadBlob.mock.calls[0];
+      expect(opts).toEqual({ encoding: 'image/webp' });
+    }, 20000);
+
+    it('should return null (not throw) when the object cannot be fetched', async () => {
       const send = jest.fn().mockRejectedValue(new Error('NoSuchKey'));
       mockedCreateS3.mockReturnValue({ send } as any);
       const agent = { uploadBlob: jest.fn() } as any;
 
-      const result = await service.uploadEventImage(agent, 'tenant/missing.jpg');
+      const result = await service.uploadEventImage(
+        agent,
+        'tenant/missing.jpg',
+      );
 
       expect(result).toBeNull();
       expect(agent.uploadBlob).not.toHaveBeenCalled();
     });
 
-    it('infers mime type from the key when the object has no ContentType', async () => {
-      mockS3Returning({ bytes: new Uint8Array([1, 2, 3]) });
-      const uploadBlob = jest.fn().mockResolvedValue({
-        data: {
-          blob: { ref: { toString: () => 'bafpng' }, mimeType: 'image/png', size: 3 },
-        },
-      });
+    it('should infer mime type from the key when the object has no ContentType', async () => {
+      const png = await smallImage(5, 5, 'png');
+      mockS3Returning({ bytes: png });
+      const { agent, uploadBlob } = mockAgent('bafpng');
 
-      await service.uploadEventImage({ uploadBlob } as any, 'tenant/logo.png');
+      await service.uploadEventImage(agent, 'tenant/logo.png');
 
       expect(uploadBlob.mock.calls[0][1]).toEqual({ encoding: 'image/png' });
+    });
+  });
+
+  describe('uploadExternalImage', () => {
+    function mockFetch(response: {
+      ok?: boolean;
+      status?: number;
+      contentType?: string | null;
+      contentLength?: string | null;
+      body?: Buffer;
+    }) {
+      const headers = new Map<string, string | null>();
+      headers.set('content-type', response.contentType ?? null);
+      headers.set('content-length', response.contentLength ?? null);
+      const fetchMock = jest.fn().mockResolvedValue({
+        ok: response.ok ?? true,
+        status: response.status ?? 200,
+        headers: { get: (h: string) => headers.get(h.toLowerCase()) ?? null },
+        arrayBuffer: () =>
+          Promise.resolve(
+            response.body
+              ? new Uint8Array(response.body).buffer
+              : new ArrayBuffer(0),
+          ),
+      });
+      global.fetch = fetchMock as any;
+      return fetchMock;
+    }
+
+    afterEach(() => {
+      delete (global as any).fetch;
+    });
+
+    it('should re-host a fetched external image as a PDS blob', async () => {
+      const png = await smallImage(30, 40, 'png');
+      const fetchMock = mockFetch({
+        contentType: 'image/png',
+        contentLength: String(png.length),
+        body: png,
+      });
+      const { agent, uploadBlob } = mockAgent('bafext');
+
+      const result = await service.uploadExternalImage(
+        agent,
+        'https://legacy.example.com/pic.png',
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.cid).toBe('bafext');
+      expect(result!.width).toBe(30);
+      expect(result!.height).toBe(40);
+      expect(uploadBlob).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://legacy.example.com/pic.png',
+        expect.objectContaining({ signal: expect.anything() }),
+      );
+    });
+
+    it('should return null when the response is not an image', async () => {
+      mockFetch({
+        contentType: 'text/html',
+        body: Buffer.from('<html></html>'),
+      });
+      const { agent, uploadBlob } = mockAgent();
+
+      const result = await service.uploadExternalImage(
+        agent,
+        'https://legacy.example.com/notimage',
+      );
+
+      expect(result).toBeNull();
+      expect(uploadBlob).not.toHaveBeenCalled();
+    });
+
+    it('should return null when the declared size exceeds the cap', async () => {
+      const png = await smallImage(10, 10, 'png');
+      mockFetch({
+        contentType: 'image/png',
+        contentLength: String(20 * 1024 * 1024),
+        body: png,
+      });
+      const { agent, uploadBlob } = mockAgent();
+
+      const result = await service.uploadExternalImage(
+        agent,
+        'https://legacy.example.com/huge.png',
+      );
+
+      expect(result).toBeNull();
+      expect(uploadBlob).not.toHaveBeenCalled();
+    });
+
+    it('should return null (not throw) when the fetch fails', async () => {
+      global.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error('network down')) as any;
+      const { agent, uploadBlob } = mockAgent();
+
+      const result = await service.uploadExternalImage(
+        agent,
+        'https://legacy.example.com/pic.png',
+      );
+
+      expect(result).toBeNull();
+      expect(uploadBlob).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/bluesky/event-image-blob.service.spec.ts
+++ b/src/bluesky/event-image-blob.service.spec.ts
@@ -154,8 +154,11 @@ describe('EventImageBlobService', () => {
       expect(opts).toEqual({ encoding: 'image/png' });
     });
 
-    it('should omit dimensions when the passthrough image cannot be probed', async () => {
-      // Not a decodable image, but under the threshold => uploaded as-is.
+    it('should reject a non-image object under the size threshold (no upload)', async () => {
+      // The presigned flow trusts the client-supplied content-type/filename, so
+      // an object can be arbitrary bytes. Even under the passthrough threshold it
+      // must be validated as a real image and skipped otherwise -- never
+      // published as an undecodable image blob.
       mockS3Returning({
         bytes: new Uint8Array([1, 2, 3, 4]),
         contentType: 'image/gif',
@@ -164,11 +167,8 @@ describe('EventImageBlobService', () => {
 
       const result = await service.uploadEventImage(agent, 'tenant/odd.gif');
 
-      expect(result).not.toBeNull();
-      expect(result!.mimeType).toBe('image/gif');
-      expect(result!.width).toBeUndefined();
-      expect(result!.height).toBeUndefined();
-      expect(uploadBlob).toHaveBeenCalledTimes(1);
+      expect(result).toBeNull();
+      expect(uploadBlob).not.toHaveBeenCalled();
     });
 
     it('should resize and re-encode oversized images to WebP, capturing final dimensions', async () => {
@@ -224,13 +224,27 @@ describe('EventImageBlobService', () => {
       expect(agent.uploadBlob).not.toHaveBeenCalled();
     });
 
-    it('should infer mime type from the key when the object has no ContentType', async () => {
+    it('should derive the uploaded mime from the detected format when the object has no ContentType', async () => {
       const png = await smallImage(5, 5, 'png');
       mockS3Returning({ bytes: png });
       const { agent, uploadBlob } = mockAgent('bafpng');
 
       await service.uploadEventImage(agent, 'tenant/logo.png');
 
+      expect(uploadBlob.mock.calls[0][1]).toEqual({ encoding: 'image/png' });
+    });
+
+    it('should correct a mismatched content-type from the detected image format', async () => {
+      // Valid PNG bytes stored with a bogus content-type are published as the
+      // detected format (image/png), never the untrusted stored type.
+      const png = await smallImage(6, 6, 'png');
+      mockS3Returning({ bytes: png, contentType: 'text/html' });
+      const { agent, uploadBlob } = mockAgent('bafmismatch');
+
+      const result = await service.uploadEventImage(agent, 'tenant/evil.png');
+
+      expect(result).not.toBeNull();
+      expect(result!.mimeType).toBe('image/png');
       expect(uploadBlob.mock.calls[0][1]).toEqual({ encoding: 'image/png' });
     });
 

--- a/src/bluesky/event-image-blob.service.spec.ts
+++ b/src/bluesky/event-image-blob.service.spec.ts
@@ -367,7 +367,7 @@ describe('EventImageBlobService', () => {
     it('should map a configured legacy origin (retired CloudFront) back to a key', async () => {
       mockedFileConfig.mockReturnValue({
         ...baseFileConfig,
-        mediaAllowedLegacyOrigins: ['ds1xtylbemsat.cloudfront.net'],
+        mediaAllowedLegacyOrigins: ['d111legacy222.cloudfront.net'],
       } as any);
       const png = await smallImage(10, 10, 'png');
       const send = mockS3Returning({ bytes: png, contentType: 'image/png' });
@@ -375,7 +375,7 @@ describe('EventImageBlobService', () => {
 
       const result = await service.uploadEventImage(
         agent,
-        'https://ds1xtylbemsat.cloudfront.net/events/legacy.png',
+        'https://d111legacy222.cloudfront.net/events/legacy.png',
       );
 
       expect(result!.sourceKey).toBe('events/legacy.png');

--- a/src/bluesky/event-image-blob.service.spec.ts
+++ b/src/bluesky/event-image-blob.service.spec.ts
@@ -53,16 +53,28 @@ async function oversizedImage(width: number, height: number): Promise<Buffer> {
 }
 
 /**
- * A high-entropy RGBA image: WebP encodes the alpha channel LOSSLESSLY, so
- * noise transparency keeps the encode oversized at any lossy quality until the
- * fallback ladder flattens the alpha away. Reproduces the over-ceiling bug the
- * bounded ladder fixes.
+ * A DETERMINISTIC high-entropy RGBA image (xorshift32 fill, fixed seed). WebP
+ * encodes the alpha channel LOSSLESSLY, so noise transparency keeps the encode
+ * oversized at any lossy quality until the fallback ladder flattens the alpha
+ * away. Deterministic bytes mean the ladder's outcome is fixed run-to-run, so
+ * the test can assert a single expected result instead of "success or null".
  */
-async function oversizedAlphaImage(
+async function deterministicAlphaNoise(
   width: number,
   height: number,
+  seed = 0x9e3779b9,
 ): Promise<Buffer> {
-  const raw = randomBytes(width * height * 4);
+  const raw = Buffer.alloc(width * height * 4);
+  let state = seed >>> 0;
+  for (let i = 0; i < raw.length; i++) {
+    // xorshift32: cheap, high-entropy, fully deterministic.
+    state ^= state << 13;
+    state >>>= 0;
+    state ^= state >> 17;
+    state ^= state << 5;
+    state >>>= 0;
+    raw[i] = state & 0xff;
+  }
   return sharp(raw, { raw: { width, height, channels: 4 } })
     .png()
     .toBuffer();
@@ -178,26 +190,24 @@ describe('EventImageBlobService', () => {
       expect(opts).toEqual({ encoding: 'image/webp' });
     }, 30000);
 
-    it('should never upload an over-ceiling blob for high-entropy RGBA input (ladder or skip)', async () => {
-      // WebP stores alpha losslessly, so noise transparency can defeat the
-      // lossy quality loop entirely; the bounded fallback ladder must either
-      // produce something under the ceiling (flattening the alpha) or give up
-      // with null -- never return oversized bytes.
-      const rgba = await oversizedAlphaImage(1500, 1500);
+    it('should flatten alpha via the fallback ladder to fit high-entropy RGBA under the ceiling', async () => {
+      // WebP stores alpha losslessly, so noise transparency defeats the lossy
+      // quality loop; the bounded fallback ladder must flatten the alpha away
+      // and land under the ceiling. The input is deterministic, so the ladder
+      // resolves to one fixed outcome: a WebP blob under the ceiling (never a
+      // skip, never oversized bytes).
+      const rgba = await deterministicAlphaNoise(1500, 1500);
       expect(rgba.length).toBeGreaterThan(MAX_BLOB_BYTES);
       mockS3Returning({ bytes: rgba, contentType: 'image/png' });
       const { agent, uploadBlob } = mockAgent('bafalpha');
 
       const result = await service.uploadEventImage(agent, 'tenant/alpha.png');
 
-      if (result === null) {
-        expect(uploadBlob).not.toHaveBeenCalled();
-      } else {
-        expect(result.size).toBeLessThanOrEqual(MAX_BLOB_BYTES);
-        expect(result.mimeType).toBe('image/webp');
-        const [bytesArg] = uploadBlob.mock.calls[0];
-        expect(bytesArg.length).toBeLessThanOrEqual(MAX_BLOB_BYTES);
-      }
+      expect(result).not.toBeNull();
+      expect(result!.mimeType).toBe('image/webp');
+      expect(result!.size).toBeLessThanOrEqual(MAX_BLOB_BYTES);
+      const [bytesArg] = uploadBlob.mock.calls[0];
+      expect(bytesArg.length).toBeLessThanOrEqual(MAX_BLOB_BYTES);
     }, 60000);
 
     it('should return null (not throw) when the object cannot be fetched', async () => {

--- a/src/bluesky/event-image-blob.service.spec.ts
+++ b/src/bluesky/event-image-blob.service.spec.ts
@@ -5,14 +5,17 @@ import sharp from 'sharp';
 import { EventImageBlobService } from './event-image-blob.service';
 import { createFileS3Client } from '../file/s3-client.factory';
 import fileConfig from '../file/config/file.config';
+import appConfig from '../config/app.config';
 
 jest.mock('../file/s3-client.factory');
 jest.mock('../file/config/file.config');
+jest.mock('../config/app.config');
 
 const mockedCreateS3 = createFileS3Client as jest.MockedFunction<
   typeof createFileS3Client
 >;
 const mockedFileConfig = fileConfig as jest.MockedFunction<typeof fileConfig>;
+const mockedAppConfig = appConfig as jest.MockedFunction<typeof appConfig>;
 
 const MAX_BLOB_BYTES = 900 * 1024;
 
@@ -82,6 +85,9 @@ describe('EventImageBlobService', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     mockedFileConfig.mockReturnValue(baseFileConfig as any);
+    mockedAppConfig.mockReturnValue({
+      backendDomain: 'https://api.openmeet.net',
+    } as any);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [EventImageBlobService],
@@ -246,144 +252,137 @@ describe('EventImageBlobService', () => {
     });
   });
 
-  describe('uploadExternalImage', () => {
-    function toStream(chunks: Uint8Array[]): AsyncIterable<Uint8Array> {
-      return (async function* () {
-        for (const chunk of chunks) {
-          yield await Promise.resolve(chunk);
-        }
-      })();
-    }
+  describe('legacy full-URL image references (origin recognition, no SSRF)', () => {
+    // An OpenMeet-origin URL is mapped back to an object key and read from our
+    // own bucket via the S3 path; the backend never fetch()es the URL. An
+    // unrecognized/arbitrary URL is refused outright -- no fetch, no S3 read --
+    // so a stored URL cannot be used to reach loopback/private/metadata hosts.
 
-    function mockFetch(response: {
-      ok?: boolean;
-      status?: number;
-      contentType?: string | null;
-      contentLength?: string | null;
-      body?: Buffer;
-      stream?: AsyncIterable<Uint8Array>;
+    function mockS3Returning(body: {
+      bytes: Uint8Array;
+      contentType?: string;
     }) {
-      const headers = new Map<string, string | null>();
-      headers.set('content-type', response.contentType ?? null);
-      headers.set('content-length', response.contentLength ?? null);
-      const fetchMock = jest.fn().mockResolvedValue({
-        ok: response.ok ?? true,
-        status: response.status ?? 200,
-        headers: { get: (h: string) => headers.get(h.toLowerCase()) ?? null },
-        body:
-          response.stream ??
-          toStream(response.body ? [new Uint8Array(response.body)] : []),
+      const send = jest.fn().mockResolvedValue({
+        Body: {
+          transformToByteArray: jest.fn().mockResolvedValue(body.bytes),
+        },
+        ContentType: body.contentType,
       });
-      global.fetch = fetchMock as any;
-      return fetchMock;
+      mockedCreateS3.mockReturnValue({ send } as any);
+      return send;
     }
 
+    let fetchSpy: jest.Mock;
+    beforeEach(() => {
+      // Fail loudly if the service ever fetches an external URL.
+      fetchSpy = jest.fn();
+      global.fetch = fetchSpy as any;
+    });
     afterEach(() => {
       delete (global as any).fetch;
     });
 
-    it('should re-host a fetched external image as a PDS blob', async () => {
+    it('should map a virtual-hosted Spaces URL back to a key and read it from our bucket, never fetching', async () => {
       const png = await smallImage(30, 40, 'png');
-      const fetchMock = mockFetch({
-        contentType: 'image/png',
-        contentLength: String(png.length),
-        body: png,
-      });
-      const { agent, uploadBlob } = mockAgent('bafext');
+      const send = mockS3Returning({ bytes: png, contentType: 'image/png' });
+      const { agent, uploadBlob } = mockAgent('bafspaces');
 
-      const result = await service.uploadExternalImage(
+      const result = await service.uploadEventImage(
         agent,
-        'https://legacy.example.com/pic.png',
+        'https://openmeet-media.nyc3.digitaloceanspaces.com/events/pic.png',
       );
 
       expect(result).not.toBeNull();
-      expect(result!.cid).toBe('bafext');
-      expect(result!.width).toBe(30);
-      expect(result!.height).toBe(40);
+      expect(result!.cid).toBe('bafspaces');
+      expect(result!.sourceKey).toBe('events/pic.png');
       expect(uploadBlob).toHaveBeenCalledTimes(1);
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://legacy.example.com/pic.png',
-        expect.objectContaining({ signal: expect.anything() }),
-      );
-    });
-
-    it('should return null when the response is not an image', async () => {
-      mockFetch({
-        contentType: 'text/html',
-        body: Buffer.from('<html></html>'),
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(send).toHaveBeenCalledTimes(1);
+      expect(send.mock.calls[0][0].input).toMatchObject({
+        Bucket: 'openmeet-media',
+        Key: 'events/pic.png',
       });
-      const { agent, uploadBlob } = mockAgent();
-
-      const result = await service.uploadExternalImage(
-        agent,
-        'https://legacy.example.com/notimage',
-      );
-
-      expect(result).toBeNull();
-      expect(uploadBlob).not.toHaveBeenCalled();
     });
 
-    it('should return null when the declared size exceeds the cap', async () => {
+    it('should strip the bucket segment from a path-style Spaces URL', async () => {
       const png = await smallImage(10, 10, 'png');
-      mockFetch({
-        contentType: 'image/png',
-        contentLength: String(20 * 1024 * 1024),
-        body: png,
-      });
-      const { agent, uploadBlob } = mockAgent();
+      const send = mockS3Returning({ bytes: png, contentType: 'image/png' });
+      const { agent } = mockAgent();
 
-      const result = await service.uploadExternalImage(
+      const result = await service.uploadEventImage(
         agent,
-        'https://legacy.example.com/huge.png',
+        'https://nyc3.digitaloceanspaces.com/openmeet-media/events/pic.png',
       );
 
-      expect(result).toBeNull();
-      expect(uploadBlob).not.toHaveBeenCalled();
+      expect(result).not.toBeNull();
+      expect(result!.sourceKey).toBe('events/pic.png');
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(send.mock.calls[0][0].input.Key).toBe('events/pic.png');
     });
 
-    it('should abort mid-stream when a lying Content-Length hides an over-cap body', async () => {
-      // The server declares a small size, then streams far more than the 10MB
-      // cap. The download must stop as soon as the running total crosses the
-      // cap instead of buffering everything first.
-      const chunk = new Uint8Array(1024 * 1024); // 1MB per chunk
-      let yielded = 0;
-      const lyingStream: AsyncIterable<Uint8Array> = (async function* () {
-        for (let i = 0; i < 50; i++) {
-          yielded++;
-          yield await Promise.resolve(chunk);
-        }
-      })();
-      mockFetch({
-        contentType: 'image/png',
-        contentLength: '1000', // lie
-        stream: lyingStream,
-      });
-      const { agent, uploadBlob } = mockAgent();
+    it('should ignore presigned query params when deriving the key', async () => {
+      const png = await smallImage(10, 10, 'png');
+      const send = mockS3Returning({ bytes: png, contentType: 'image/png' });
+      const { agent } = mockAgent();
 
-      const result = await service.uploadExternalImage(
+      const result = await service.uploadEventImage(
         agent,
-        'https://legacy.example.com/liar.png',
+        'https://openmeet-media.nyc3.digitaloceanspaces.com/events/pic.png?X-Amz-Signature=abc&X-Amz-Expires=3600',
       );
 
-      expect(result).toBeNull();
-      expect(uploadBlob).not.toHaveBeenCalled();
-      // Bailed right after crossing the 10MB cap (11 chunks), long before
-      // draining all 50MB.
-      expect(yielded).toBeLessThanOrEqual(11);
+      expect(result!.sourceKey).toBe('events/pic.png');
+      expect(send.mock.calls[0][0].input.Key).toBe('events/pic.png');
+      expect(fetchSpy).not.toHaveBeenCalled();
     });
 
-    it('should return null (not throw) when the fetch fails', async () => {
-      global.fetch = jest
-        .fn()
-        .mockRejectedValue(new Error('network down')) as any;
+    it('should map a configured CloudFront-origin URL back to a key', async () => {
+      mockedFileConfig.mockReturnValue({
+        ...baseFileConfig,
+        cloudfrontDistributionDomain: 'cdn.openmeet.net',
+      } as any);
+      const png = await smallImage(10, 10, 'png');
+      const send = mockS3Returning({ bytes: png, contentType: 'image/png' });
+      const { agent } = mockAgent();
+
+      const result = await service.uploadEventImage(
+        agent,
+        'https://cdn.openmeet.net/events/pic.png',
+      );
+
+      expect(result!.sourceKey).toBe('events/pic.png');
+      expect(send.mock.calls[0][0].input.Key).toBe('events/pic.png');
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('should refuse an unrecognized external URL without fetching or reading S3 (SSRF guard)', async () => {
+      const send = mockS3Returning({ bytes: await smallImage(10, 10) });
       const { agent, uploadBlob } = mockAgent();
 
-      const result = await service.uploadExternalImage(
+      const result = await service.uploadEventImage(
         agent,
         'https://legacy.example.com/pic.png',
       );
 
       expect(result).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(send).not.toHaveBeenCalled();
+      expect(uploadBlob).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      'http://127.0.0.1/x.png',
+      'http://169.254.169.254/latest/meta-data/iam/security-credentials/',
+      'http://localhost:9000/openmeet-media/events/pic.png',
+      'http://[::1]/x.png',
+    ])('should refuse loopback/private/metadata target %s', async (url) => {
+      const send = mockS3Returning({ bytes: await smallImage(10, 10) });
+      const { agent, uploadBlob } = mockAgent();
+
+      const result = await service.uploadEventImage(agent, url);
+
+      expect(result).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(send).not.toHaveBeenCalled();
       expect(uploadBlob).not.toHaveBeenCalled();
     });
   });

--- a/src/bluesky/event-image-blob.service.ts
+++ b/src/bluesky/event-image-blob.service.ts
@@ -1,9 +1,11 @@
+import { promises as fsPromises } from 'fs';
+import { basename, join } from 'path';
 import { Injectable, Logger } from '@nestjs/common';
 import { Agent } from '@atproto/api';
 import { BlobRef } from '@atproto/lexicon';
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 import sharp from 'sharp';
-import { FileConfig } from '../file/config/file-config.type';
+import { FileConfig, FileDriver } from '../file/config/file-config.type';
 import fileConfig from '../file/config/file.config';
 import { createFileS3Client } from '../file/s3-client.factory';
 
@@ -41,10 +43,24 @@ export class EventImageBlobService {
   // atmo's 900KB skip-if-small threshold.
   private static readonly MAX_BLOB_BYTES = 900 * 1024;
   private static readonly MAX_EDGE = 2048;
-  private static readonly LAST_RESORT_EDGE = 1280;
   private static readonly QUALITY_START = 80;
   private static readonly QUALITY_FLOOR = 45;
-  private static readonly LAST_RESORT_QUALITY = 70;
+
+  // Descending fallback ladder for images the 2048px quality loop cannot fit
+  // under the ceiling. WebP encodes the alpha channel losslessly, so a
+  // high-entropy RGBA image can stay oversized at any quality; the later rungs
+  // flatten the alpha away to break that. If even the last rung is oversized,
+  // the caller publishes without an image.
+  private static readonly FALLBACK_LADDER: ReadonlyArray<{
+    edge: number;
+    quality: number;
+    flatten: boolean;
+  }> = [
+    { edge: 1280, quality: 70, flatten: false },
+    { edge: 1024, quality: 60, flatten: false },
+    { edge: 800, quality: 55, flatten: true },
+    { edge: 640, quality: 50, flatten: true },
+  ];
 
   // Guards for re-hosting legacy full-URL images (see uploadExternalImage).
   private static readonly EXTERNAL_MAX_BYTES = 10 * 1024 * 1024;
@@ -110,8 +126,9 @@ export class EventImageBlobService {
     agent: Agent,
     bytes: Buffer,
     mimeType: string,
-  ): Promise<UploadedEventImage> {
+  ): Promise<UploadedEventImage | null> {
     const normalized = await this.normalizeForBlob(bytes, mimeType);
+    if (!normalized) return null;
     const res = await agent.uploadBlob(normalized.bytes, {
       encoding: normalized.mimeType,
     });
@@ -130,6 +147,20 @@ export class EventImageBlobService {
     key: string,
   ): Promise<{ bytes: Buffer; mimeType: string } | null> {
     const config = fileConfig() as FileConfig;
+
+    // Local file driver (dev/CI environments): the object lives on disk under
+    // ./files/<name>, which is also where the local download route serves it
+    // from. Reduce the stored path to its basename to address the file (this
+    // doubles as path-traversal protection).
+    if (config.driver === FileDriver.LOCAL) {
+      const name = basename(key);
+      const bytes = await fsPromises.readFile(join('./files', name));
+      return {
+        bytes: Buffer.from(bytes),
+        mimeType: this.mimeFromKey(name) || 'application/octet-stream',
+      };
+    }
+
     const s3 = createFileS3Client({
       region: config.awsS3Region ?? '',
       accessKeyId: config.accessKeyId ?? '',
@@ -199,29 +230,48 @@ export class EventImageBlobService {
         return null;
       }
 
-      const bytes = Buffer.from(await res.arrayBuffer());
-      if (bytes.length > EventImageBlobService.EXTERNAL_MAX_BYTES) {
-        this.logger.warn(
-          `External image "${url}" is ${bytes.length}B, over the ${EventImageBlobService.EXTERNAL_MAX_BYTES}B cap`,
-        );
+      if (!res.body) {
+        this.logger.warn(`External image fetch for "${url}" returned no body`);
         return null;
       }
 
-      return { bytes, mimeType: contentType.split(';')[0].trim() };
+      // Read the body incrementally so a server that omits or lies about
+      // Content-Length cannot force an arbitrarily large allocation: stop and
+      // abort the transfer the moment the running total exceeds the cap.
+      const chunks: Buffer[] = [];
+      let total = 0;
+      for await (const chunk of res.body as unknown as AsyncIterable<Uint8Array>) {
+        total += chunk.byteLength;
+        if (total > EventImageBlobService.EXTERNAL_MAX_BYTES) {
+          controller.abort();
+          this.logger.warn(
+            `External image "${url}" exceeded the ${EventImageBlobService.EXTERNAL_MAX_BYTES}B cap mid-download; aborting`,
+          );
+          return null;
+        }
+        chunks.push(Buffer.from(chunk));
+      }
+
+      return {
+        bytes: Buffer.concat(chunks),
+        mimeType: contentType.split(';')[0].trim(),
+      };
     } finally {
       clearTimeout(timer);
     }
   }
 
   /**
-   * Ensure the blob fits comfortably under the size ceiling and capture the
-   * final image dimensions for the media entry's aspect_ratio.
+   * Ensure the blob fits under the size ceiling and capture the final image
+   * dimensions for the media entry's aspect_ratio.
    *
    * Small images (<= MAX_BLOB_BYTES) are uploaded byte-for-byte (best fidelity;
    * preserves small GIFs/PNGs exactly). Larger ones are auto-oriented, resized
    * so the longest edge is <= 2048, and re-encoded to WebP (which handles alpha,
    * so a single codec covers both opaque and transparent images), stepping the
-   * quality down until under the ceiling.
+   * quality down until under the ceiling, then walking a bounded fallback
+   * ladder of smaller sizes. Returns null if nothing fits -- the caller then
+   * publishes without an image rather than uploading an over-ceiling blob.
    */
   private async normalizeForBlob(
     bytes: Buffer,
@@ -231,7 +281,7 @@ export class EventImageBlobService {
     mimeType: string;
     width?: number;
     height?: number;
-  }> {
+  } | null> {
     if (bytes.length <= EventImageBlobService.MAX_BLOB_BYTES) {
       // Uploaded as-is; probe dimensions for aspect_ratio. If the probe fails
       // (odd/unsupported format), omit dimensions rather than fail the upload.
@@ -273,20 +323,35 @@ export class EventImageBlobService {
       quality = Math.max(EventImageBlobService.QUALITY_FLOOR, quality - 10);
     }
 
-    // Last resort: guarantee we get under the ceiling by shrinking harder.
+    // Fallback ladder: shrink harder until it fits. Bounded -- if the last
+    // rung is still oversized, give up rather than upload an over-ceiling blob.
     if (out.length > EventImageBlobService.MAX_BLOB_BYTES) {
-      const result = await sharp(bytes, { failOn: 'none' })
-        .rotate()
-        .resize({
-          width: EventImageBlobService.LAST_RESORT_EDGE,
-          height: EventImageBlobService.LAST_RESORT_EDGE,
+      for (const rung of EventImageBlobService.FALLBACK_LADDER) {
+        let step = sharp(bytes, { failOn: 'none' }).rotate().resize({
+          width: rung.edge,
+          height: rung.edge,
           fit: 'inside',
           withoutEnlargement: true,
-        })
-        .webp({ quality: EventImageBlobService.LAST_RESORT_QUALITY })
-        .toBuffer({ resolveWithObject: true });
-      out = result.data;
-      info = result.info;
+        });
+        if (rung.flatten) {
+          // Drop the alpha channel: WebP stores alpha losslessly, so
+          // high-entropy transparency alone can keep the encode oversized.
+          step = step.flatten();
+        }
+        const result = await step
+          .webp({ quality: rung.quality })
+          .toBuffer({ resolveWithObject: true });
+        out = result.data;
+        info = result.info;
+        if (out.length <= EventImageBlobService.MAX_BLOB_BYTES) break;
+      }
+    }
+
+    if (out.length > EventImageBlobService.MAX_BLOB_BYTES) {
+      this.logger.warn(
+        `Could not normalize event image under ${EventImageBlobService.MAX_BLOB_BYTES}B (best attempt ${out.length}B from ${bytes.length}B ${mimeType}); skipping image`,
+      );
+      return null;
     }
 
     this.logger.debug(

--- a/src/bluesky/event-image-blob.service.ts
+++ b/src/bluesky/event-image-blob.service.ts
@@ -158,6 +158,10 @@ export class EventImageBlobService {
 
     add(config.cloudfrontDistributionDomain);
 
+    // Retired-but-retained media origins (e.g. an old CloudFront distribution
+    // still serving images baked into legacy records).
+    config.mediaAllowedLegacyOrigins?.forEach((h) => add(h));
+
     const bucket = config.awsDefaultS3Bucket;
     const endpointHost = this.hostOf(config.awsS3Endpoint);
     if (endpointHost) {

--- a/src/bluesky/event-image-blob.service.ts
+++ b/src/bluesky/event-image-blob.service.ts
@@ -8,6 +8,8 @@ import sharp from 'sharp';
 import { FileConfig, FileDriver } from '../file/config/file-config.type';
 import fileConfig from '../file/config/file.config';
 import { createFileS3Client } from '../file/s3-client.factory';
+import { AppConfig } from '../config/app-config.type';
+import appConfig from '../config/app.config';
 
 export interface UploadedEventImage {
   /** The blob reference to embed in the record (pins the blob against GC). */
@@ -20,6 +22,8 @@ export interface UploadedEventImage {
   width?: number;
   /** Final pixel height of the uploaded image, when it could be determined. */
   height?: number;
+  /** The object key the image was read from (for republish/dedup tracking). */
+  sourceKey: string;
 }
 
 /**
@@ -62,31 +66,44 @@ export class EventImageBlobService {
     { edge: 640, quality: 50, flatten: true },
   ];
 
-  // Guards for re-hosting legacy full-URL images (see uploadExternalImage).
-  private static readonly EXTERNAL_MAX_BYTES = 10 * 1024 * 1024;
-  private static readonly EXTERNAL_TIMEOUT_MS = 10_000;
-
   /**
-   * Fetch the image bytes from object storage, normalize if needed, and upload
-   * as a blob to the repo the agent is authenticated for. Returns null on any
-   * failure so the caller can publish the record without an image rather than
-   * failing the whole publish.
+   * Fetch the image bytes from OpenMeet object storage, normalize if needed, and
+   * upload as a blob to the repo the agent is authenticated for.
+   *
+   * `imageRef` is normally a raw object key. It may also be a legacy full URL
+   * left in the DB by older code; such a URL is honored only when it points at a
+   * recognized OpenMeet origin (CloudFront distribution, the S3/Spaces bucket,
+   * or the backend domain), in which case it is mapped back to an object key and
+   * read from our own bucket. An unrecognized/arbitrary URL is refused: the
+   * backend never issues an outbound request to it, so a stored URL cannot be
+   * used to reach loopback, private-network, or cloud-metadata endpoints (SSRF).
+   *
+   * Returns null on any failure or refusal so the caller can preserve or skip
+   * the image rather than failing the whole publish.
    */
   async uploadEventImage(
     agent: Agent,
-    imageKey: string,
+    imageRef: string,
   ): Promise<UploadedEventImage | null> {
     try {
-      const fetched = await this.fetchObject(imageKey);
+      const key = this.resolveObjectKey(imageRef);
+      if (!key) {
+        this.logger.warn(
+          `Event image ref is not a recognized OpenMeet object; skipping image ("${imageRef}")`,
+        );
+        return null;
+      }
+      const fetched = await this.fetchObject(key);
       if (!fetched) return null;
-      return await this.normalizeAndUpload(
+      const uploaded = await this.normalizeAndUpload(
         agent,
         fetched.bytes,
         fetched.mimeType,
       );
+      return uploaded ? { ...uploaded, sourceKey: key } : null;
     } catch (err) {
       this.logger.error(
-        `Failed to upload event image blob for key "${imageKey}": ${
+        `Failed to upload event image blob for ref "${imageRef}": ${
           err instanceof Error ? err.message : String(err)
         }`,
       );
@@ -95,29 +112,75 @@ export class EventImageBlobService {
   }
 
   /**
-   * Re-host a legacy/corrupted full-URL image as a PDS blob. Fetches the URL
-   * server-side (bounded by a timeout and size cap, image content-types only),
-   * runs it through the same normalize+upload pipeline, and returns null on any
-   * failure so the caller publishes without an image rather than baking the URL.
+   * Map an image reference to an object key in our own bucket, or null if it
+   * cannot be resolved safely. A bare key is returned as-is. A full http(s) URL
+   * is accepted only when its host is a recognized OpenMeet origin; its path
+   * (with a leading bucket segment stripped for path-style URLs) becomes the
+   * key. Any other URL returns null -- we never fetch it.
    */
-  async uploadExternalImage(
-    agent: Agent,
-    url: string,
-  ): Promise<UploadedEventImage | null> {
+  private resolveObjectKey(ref: string): string | null {
+    if (!/^https?:\/\//i.test(ref)) {
+      return ref; // already an object key
+    }
+    let url: URL;
     try {
-      const fetched = await this.fetchExternalImage(url);
-      if (!fetched) return null;
-      return await this.normalizeAndUpload(
-        agent,
-        fetched.bytes,
-        fetched.mimeType,
-      );
-    } catch (err) {
-      this.logger.warn(
-        `Failed to re-host external event image "${url}": ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
+      url = new URL(ref);
+    } catch {
+      return null;
+    }
+    if (!this.isOpenMeetOrigin(url.hostname)) {
+      return null;
+    }
+    const config = fileConfig() as FileConfig;
+    let path = decodeURIComponent(url.pathname).replace(/^\/+/, '');
+    // Path-style URLs (host is the endpoint, not <bucket>.<endpoint>) carry the
+    // bucket as the first path segment; strip it to leave the object key.
+    const bucket = config.awsDefaultS3Bucket;
+    if (bucket && (path === bucket || path.startsWith(`${bucket}/`))) {
+      path = path.slice(bucket.length).replace(/^\/+/, '');
+    }
+    return path.length > 0 ? path : null;
+  }
+
+  /**
+   * Hostnames trusted as OpenMeet-controlled media origins, derived from config:
+   * the CloudFront distribution, the S3/Spaces endpoint (path- and
+   * virtual-hosted-style), and the backend domain. A legacy stored URL is only
+   * mapped back to a key when its host matches one of these.
+   */
+  private isOpenMeetOrigin(hostname: string): boolean {
+    const config = fileConfig() as FileConfig;
+    const allowed = new Set<string>();
+    const add = (h?: string | null) => {
+      const parsed = this.hostOf(h);
+      if (parsed) allowed.add(parsed);
+    };
+
+    add(config.cloudfrontDistributionDomain);
+
+    const bucket = config.awsDefaultS3Bucket;
+    const endpointHost = this.hostOf(config.awsS3Endpoint);
+    if (endpointHost) {
+      allowed.add(endpointHost); // path-style: <endpoint>/<bucket>/<key>
+      if (bucket) allowed.add(`${bucket}.${endpointHost}`); // virtual-hosted
+    } else if (bucket && config.awsS3Region) {
+      // Default AWS endpoints when none is configured.
+      allowed.add(`s3.${config.awsS3Region}.amazonaws.com`);
+      allowed.add(`${bucket}.s3.${config.awsS3Region}.amazonaws.com`);
+    }
+
+    add((appConfig() as AppConfig).backendDomain);
+
+    return allowed.has(hostname.toLowerCase());
+  }
+
+  /** Normalize a bare host or a full URL down to a lowercase hostname. */
+  private hostOf(value?: string | null): string | null {
+    if (!value) return null;
+    try {
+      const withScheme = value.includes('://') ? value : `https://${value}`;
+      return new URL(withScheme).hostname.toLowerCase();
+    } catch {
       return null;
     }
   }
@@ -126,7 +189,7 @@ export class EventImageBlobService {
     agent: Agent,
     bytes: Buffer,
     mimeType: string,
-  ): Promise<UploadedEventImage | null> {
+  ): Promise<Omit<UploadedEventImage, 'sourceKey'> | null> {
     const normalized = await this.normalizeForBlob(bytes, mimeType);
     if (!normalized) return null;
     const res = await agent.uploadBlob(normalized.bytes, {
@@ -190,75 +253,6 @@ export class EventImageBlobService {
     const mimeType =
       res.ContentType || this.mimeFromKey(key) || 'application/octet-stream';
     return { bytes, mimeType };
-  }
-
-  /**
-   * Fetch an image from an arbitrary http(s) URL for re-hosting. Rejects
-   * non-image responses and anything over the size cap, and aborts on timeout,
-   * returning null so the caller publishes without an image.
-   */
-  private async fetchExternalImage(
-    url: string,
-  ): Promise<{ bytes: Buffer; mimeType: string } | null> {
-    const controller = new AbortController();
-    const timer = setTimeout(
-      () => controller.abort(),
-      EventImageBlobService.EXTERNAL_TIMEOUT_MS,
-    );
-    try {
-      const res = await fetch(url, { signal: controller.signal });
-      if (!res.ok) {
-        this.logger.warn(
-          `External image fetch for "${url}" returned HTTP ${res.status}`,
-        );
-        return null;
-      }
-
-      const contentType = res.headers.get('content-type') ?? '';
-      if (!contentType.toLowerCase().startsWith('image/')) {
-        this.logger.warn(
-          `External image fetch for "${url}" has non-image content-type "${contentType}"`,
-        );
-        return null;
-      }
-
-      const declaredLength = Number(res.headers.get('content-length') ?? '0');
-      if (declaredLength > EventImageBlobService.EXTERNAL_MAX_BYTES) {
-        this.logger.warn(
-          `External image "${url}" declares ${declaredLength}B, over the ${EventImageBlobService.EXTERNAL_MAX_BYTES}B cap`,
-        );
-        return null;
-      }
-
-      if (!res.body) {
-        this.logger.warn(`External image fetch for "${url}" returned no body`);
-        return null;
-      }
-
-      // Read the body incrementally so a server that omits or lies about
-      // Content-Length cannot force an arbitrarily large allocation: stop and
-      // abort the transfer the moment the running total exceeds the cap.
-      const chunks: Buffer[] = [];
-      let total = 0;
-      for await (const chunk of res.body as unknown as AsyncIterable<Uint8Array>) {
-        total += chunk.byteLength;
-        if (total > EventImageBlobService.EXTERNAL_MAX_BYTES) {
-          controller.abort();
-          this.logger.warn(
-            `External image "${url}" exceeded the ${EventImageBlobService.EXTERNAL_MAX_BYTES}B cap mid-download; aborting`,
-          );
-          return null;
-        }
-        chunks.push(Buffer.from(chunk));
-      }
-
-      return {
-        bytes: Buffer.concat(chunks),
-        mimeType: contentType.split(';')[0].trim(),
-      };
-    } finally {
-      clearTimeout(timer);
-    }
   }
 
   /**

--- a/src/bluesky/event-image-blob.service.ts
+++ b/src/bluesky/event-image-blob.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { Agent } from '@atproto/api';
 import { BlobRef } from '@atproto/lexicon';
 import { GetObjectCommand } from '@aws-sdk/client-s3';
@@ -11,39 +10,51 @@ import { createFileS3Client } from '../file/s3-client.factory';
 export interface UploadedEventImage {
   /** The blob reference to embed in the record (pins the blob against GC). */
   blob: BlobRef;
-  /** The blob CID string, used to build the getBlob URL. */
+  /** The blob CID string (a stable content identifier for the uploaded blob). */
   cid: string;
   mimeType: string;
   size: number;
+  /** Final pixel width of the uploaded image, when it could be determined. */
+  width?: number;
+  /** Final pixel height of the uploaded image, when it could be determined. */
+  height?: number;
 }
 
 /**
- * Uploads event images to the event owner's PDS as content-addressed blobs and
- * builds the stable, federated `com.atproto.sync.getBlob` URL that goes into the
- * durable event record.
+ * Uploads event images to the event owner's PDS as content-addressed blobs so
+ * they can be referenced from the durable event record via the ecosystem
+ * `media[]` convention (`{ role, content: <blob>, aspect_ratio }`).
  *
  * Why blobs instead of an S3/CDN URL: the record lives immutably in the user's
  * PDS repo, so its image must live in the same portable substrate. The bytes are
  * uploaded to the owner's PDS (user-owned, travels with the repo) and referenced
- * by CID. getBlob is a public, unauthenticated, immutable endpoint, so the URL is
- * safe to cache at a CDN and needs no signing.
+ * by the blob ref pinned in the record. No URL is baked into the record at all --
+ * consumers build a getBlob/CDN URL at render time from the blob ref and the
+ * owner's DID, so the CDN becomes a display-side concern rather than record data.
  */
 @Injectable()
 export class EventImageBlobService {
   private readonly logger = new Logger(EventImageBlobService.name);
 
-  // Keep blobs comfortably under the PDS default blob-upload limit (5 MB) and
-  // avoid bloating user repos. Images above this are resized/re-encoded first.
-  private static readonly MAX_BLOB_BYTES = 4 * 1024 * 1024;
-  private static readonly MAX_EDGE = 2000;
+  // Upload byte-for-byte below this size (best fidelity, preserves small
+  // GIFs/PNGs exactly); above it, re-encode to WebP under this ceiling. Matches
+  // atmo's 900KB skip-if-small threshold.
+  private static readonly MAX_BLOB_BYTES = 900 * 1024;
+  private static readonly MAX_EDGE = 2048;
+  private static readonly LAST_RESORT_EDGE = 1280;
+  private static readonly QUALITY_START = 80;
+  private static readonly QUALITY_FLOOR = 45;
+  private static readonly LAST_RESORT_QUALITY = 70;
 
-  constructor(private readonly configService: ConfigService) {}
+  // Guards for re-hosting legacy full-URL images (see uploadExternalImage).
+  private static readonly EXTERNAL_MAX_BYTES = 10 * 1024 * 1024;
+  private static readonly EXTERNAL_TIMEOUT_MS = 10_000;
 
   /**
-   * Fetch the image bytes from object storage, shrink if needed, and upload as a
-   * blob to the repo the agent is authenticated for. Returns null on any failure
-   * so the caller can publish the record without an image rather than failing the
-   * whole publish.
+   * Fetch the image bytes from object storage, normalize if needed, and upload
+   * as a blob to the repo the agent is authenticated for. Returns null on any
+   * failure so the caller can publish the record without an image rather than
+   * failing the whole publish.
    */
   async uploadEventImage(
     agent: Agent,
@@ -52,20 +63,11 @@ export class EventImageBlobService {
     try {
       const fetched = await this.fetchObject(imageKey);
       if (!fetched) return null;
-
-      const { bytes, mimeType } = await this.normalizeForBlob(
+      return await this.normalizeAndUpload(
+        agent,
         fetched.bytes,
         fetched.mimeType,
       );
-
-      const res = await agent.uploadBlob(bytes, { encoding: mimeType });
-      const blob = res.data.blob;
-      return {
-        blob,
-        cid: blob.ref.toString(),
-        mimeType,
-        size: bytes.length,
-      };
     } catch (err) {
       this.logger.error(
         `Failed to upload event image blob for key "${imageKey}": ${
@@ -77,40 +79,51 @@ export class EventImageBlobService {
   }
 
   /**
-   * Build the getBlob URL to bake into the record. Uses the configured public
-   * base URL (a CDN fronting OpenMeet's PDS) only when the owner is on OpenMeet's
-   * own PDS; otherwise the owner's real PDS host is used so the blob resolves.
+   * Re-host a legacy/corrupted full-URL image as a PDS blob. Fetches the URL
+   * server-side (bounded by a timeout and size cap, image content-types only),
+   * runs it through the same normalize+upload pipeline, and returns null on any
+   * failure so the caller publishes without an image rather than baking the URL.
    */
-  buildGetBlobUrl(userPdsUrl: string, did: string, cid: string): string {
-    const host = this.resolveBlobHost(userPdsUrl).replace(/\/+$/, '');
-    return `${host}/xrpc/com.atproto.sync.getBlob?did=${encodeURIComponent(
-      did,
-    )}&cid=${encodeURIComponent(cid)}`;
-  }
-
-  /**
-   * The CDN base URL is only valid for blobs served by OpenMeet's own PDS (it
-   * origins there). For users on any other PDS, bake their real PDS host.
-   */
-  private resolveBlobHost(userPdsUrl: string): string {
-    const config = fileConfig() as FileConfig;
-    const cdnBase = config.blobPublicBaseUrl;
-    const openmeetPds = this.configService.get<string>('pds.url', {
-      infer: true,
-    });
-
-    if (cdnBase && openmeetPds && this.sameHost(userPdsUrl, openmeetPds)) {
-      return cdnBase;
-    }
-    return userPdsUrl;
-  }
-
-  private sameHost(a: string, b: string): boolean {
+  async uploadExternalImage(
+    agent: Agent,
+    url: string,
+  ): Promise<UploadedEventImage | null> {
     try {
-      return new URL(a).host === new URL(b).host;
-    } catch {
-      return false;
+      const fetched = await this.fetchExternalImage(url);
+      if (!fetched) return null;
+      return await this.normalizeAndUpload(
+        agent,
+        fetched.bytes,
+        fetched.mimeType,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Failed to re-host external event image "${url}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return null;
     }
+  }
+
+  private async normalizeAndUpload(
+    agent: Agent,
+    bytes: Buffer,
+    mimeType: string,
+  ): Promise<UploadedEventImage> {
+    const normalized = await this.normalizeForBlob(bytes, mimeType);
+    const res = await agent.uploadBlob(normalized.bytes, {
+      encoding: normalized.mimeType,
+    });
+    const blob = res.data.blob;
+    return {
+      blob,
+      cid: blob.ref.toString(),
+      mimeType: normalized.mimeType,
+      size: normalized.bytes.length,
+      width: normalized.width,
+      height: normalized.height,
+    };
   }
 
   private async fetchObject(
@@ -139,7 +152,9 @@ export class EventImageBlobService {
 
     // AWS SDK v3 stream helper -> Uint8Array
     const bytes = Buffer.from(
-      await (res.Body as { transformToByteArray: () => Promise<Uint8Array> }).transformToByteArray(),
+      await (
+        res.Body as { transformToByteArray: () => Promise<Uint8Array> }
+      ).transformToByteArray(),
     );
     const mimeType =
       res.ContentType || this.mimeFromKey(key) || 'application/octet-stream';
@@ -147,58 +162,142 @@ export class EventImageBlobService {
   }
 
   /**
-   * Ensure the blob fits comfortably under the PDS limit. Images already small
-   * enough are uploaded byte-for-byte (best fidelity); larger ones are resized
-   * and re-encoded.
+   * Fetch an image from an arbitrary http(s) URL for re-hosting. Rejects
+   * non-image responses and anything over the size cap, and aborts on timeout,
+   * returning null so the caller publishes without an image.
+   */
+  private async fetchExternalImage(
+    url: string,
+  ): Promise<{ bytes: Buffer; mimeType: string } | null> {
+    const controller = new AbortController();
+    const timer = setTimeout(
+      () => controller.abort(),
+      EventImageBlobService.EXTERNAL_TIMEOUT_MS,
+    );
+    try {
+      const res = await fetch(url, { signal: controller.signal });
+      if (!res.ok) {
+        this.logger.warn(
+          `External image fetch for "${url}" returned HTTP ${res.status}`,
+        );
+        return null;
+      }
+
+      const contentType = res.headers.get('content-type') ?? '';
+      if (!contentType.toLowerCase().startsWith('image/')) {
+        this.logger.warn(
+          `External image fetch for "${url}" has non-image content-type "${contentType}"`,
+        );
+        return null;
+      }
+
+      const declaredLength = Number(res.headers.get('content-length') ?? '0');
+      if (declaredLength > EventImageBlobService.EXTERNAL_MAX_BYTES) {
+        this.logger.warn(
+          `External image "${url}" declares ${declaredLength}B, over the ${EventImageBlobService.EXTERNAL_MAX_BYTES}B cap`,
+        );
+        return null;
+      }
+
+      const bytes = Buffer.from(await res.arrayBuffer());
+      if (bytes.length > EventImageBlobService.EXTERNAL_MAX_BYTES) {
+        this.logger.warn(
+          `External image "${url}" is ${bytes.length}B, over the ${EventImageBlobService.EXTERNAL_MAX_BYTES}B cap`,
+        );
+        return null;
+      }
+
+      return { bytes, mimeType: contentType.split(';')[0].trim() };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Ensure the blob fits comfortably under the size ceiling and capture the
+   * final image dimensions for the media entry's aspect_ratio.
+   *
+   * Small images (<= MAX_BLOB_BYTES) are uploaded byte-for-byte (best fidelity;
+   * preserves small GIFs/PNGs exactly). Larger ones are auto-oriented, resized
+   * so the longest edge is <= 2048, and re-encoded to WebP (which handles alpha,
+   * so a single codec covers both opaque and transparent images), stepping the
+   * quality down until under the ceiling.
    */
   private async normalizeForBlob(
     bytes: Buffer,
     mimeType: string,
-  ): Promise<{ bytes: Buffer; mimeType: string }> {
+  ): Promise<{
+    bytes: Buffer;
+    mimeType: string;
+    width?: number;
+    height?: number;
+  }> {
     if (bytes.length <= EventImageBlobService.MAX_BLOB_BYTES) {
-      return { bytes, mimeType };
+      // Uploaded as-is; probe dimensions for aspect_ratio. If the probe fails
+      // (odd/unsupported format), omit dimensions rather than fail the upload.
+      let width: number | undefined;
+      let height: number | undefined;
+      try {
+        const meta = await sharp(bytes, { failOn: 'none' }).metadata();
+        width = meta.width;
+        height = meta.height;
+      } catch {
+        // leave width/height undefined
+      }
+      return { bytes, mimeType, width, height };
     }
 
-    const base = sharp(bytes, { failOn: 'none' }).rotate();
-    const meta = await base.metadata();
-    const resized = base.resize({
+    const pipeline = sharp(bytes, { failOn: 'none' }).rotate().resize({
       width: EventImageBlobService.MAX_EDGE,
       height: EventImageBlobService.MAX_EDGE,
       fit: 'inside',
       withoutEnlargement: true,
     });
 
-    // Preserve transparency where present; otherwise JPEG for best compression.
+    let quality = EventImageBlobService.QUALITY_START;
     let out: Buffer;
-    let outMime: string;
-    if (meta.hasAlpha) {
-      out = await resized.clone().png({ compressionLevel: 9 }).toBuffer();
-      outMime = 'image/png';
-    } else {
-      out = await resized.clone().jpeg({ quality: 82, mozjpeg: true }).toBuffer();
-      outMime = 'image/jpeg';
+    let info: sharp.OutputInfo;
+    for (;;) {
+      const result = await pipeline
+        .clone()
+        .webp({ quality })
+        .toBuffer({ resolveWithObject: true });
+      out = result.data;
+      info = result.info;
+      if (
+        out.length <= EventImageBlobService.MAX_BLOB_BYTES ||
+        quality <= EventImageBlobService.QUALITY_FLOOR
+      ) {
+        break;
+      }
+      quality = Math.max(EventImageBlobService.QUALITY_FLOOR, quality - 10);
     }
 
-    // Last-resort pass: guarantee we get under the limit even if it means
-    // dropping alpha, since an oversized blob would be rejected by the PDS.
+    // Last resort: guarantee we get under the ceiling by shrinking harder.
     if (out.length > EventImageBlobService.MAX_BLOB_BYTES) {
-      out = await sharp(bytes, { failOn: 'none' })
+      const result = await sharp(bytes, { failOn: 'none' })
         .rotate()
         .resize({
-          width: 1280,
-          height: 1280,
+          width: EventImageBlobService.LAST_RESORT_EDGE,
+          height: EventImageBlobService.LAST_RESORT_EDGE,
           fit: 'inside',
           withoutEnlargement: true,
         })
-        .jpeg({ quality: 78, mozjpeg: true })
-        .toBuffer();
-      outMime = 'image/jpeg';
+        .webp({ quality: EventImageBlobService.LAST_RESORT_QUALITY })
+        .toBuffer({ resolveWithObject: true });
+      out = result.data;
+      info = result.info;
     }
 
     this.logger.debug(
-      `Resized event image ${bytes.length}B (${mimeType}) -> ${out.length}B (${outMime})`,
+      `Normalized event image ${bytes.length}B (${mimeType}) -> ${out.length}B (image/webp, ${info.width}x${info.height})`,
     );
-    return { bytes: out, mimeType: outMime };
+    return {
+      bytes: out,
+      mimeType: 'image/webp',
+      width: info.width,
+      height: info.height,
+    };
   }
 
   private mimeFromKey(key: string): string | null {

--- a/src/bluesky/event-image-blob.service.ts
+++ b/src/bluesky/event-image-blob.service.ts
@@ -263,13 +263,14 @@ export class EventImageBlobService {
    * Ensure the blob fits under the size ceiling and capture the final image
    * dimensions for the media entry's aspect_ratio.
    *
-   * Small images (<= MAX_BLOB_BYTES) are uploaded byte-for-byte (best fidelity;
-   * preserves small GIFs/PNGs exactly). Larger ones are auto-oriented, resized
-   * so the longest edge is <= 2048, and re-encoded to WebP (which handles alpha,
-   * so a single codec covers both opaque and transparent images), stepping the
-   * quality down until under the ceiling, then walking a bounded fallback
-   * ladder of smaller sizes. Returns null if nothing fits -- the caller then
-   * publishes without an image rather than uploading an over-ceiling blob.
+   * Small images (<= MAX_BLOB_BYTES) are validated and uploaded byte-for-byte
+   * (best fidelity; preserves small GIFs/PNGs exactly). Larger ones are
+   * auto-oriented, resized so the longest edge is <= 2048, and re-encoded to
+   * WebP (which handles alpha, so a single codec covers both opaque and
+   * transparent images), stepping the quality down until under the ceiling,
+   * then walking a bounded fallback ladder of smaller sizes. Returns null if
+   * the object is not a decodable raster image, or nothing fits under the
+   * ceiling -- the caller then publishes without an image.
    */
   private async normalizeForBlob(
     bytes: Buffer,
@@ -281,18 +282,37 @@ export class EventImageBlobService {
     height?: number;
   } | null> {
     if (bytes.length <= EventImageBlobService.MAX_BLOB_BYTES) {
-      // Uploaded as-is; probe dimensions for aspect_ratio. If the probe fails
-      // (odd/unsupported format), omit dimensions rather than fail the upload.
-      let width: number | undefined;
-      let height: number | undefined;
+      // Validate the object really is a decodable raster image before uploading
+      // it byte-for-byte. The presigned upload flow trusts the client-supplied
+      // filename/size/content-type, so the stored object could be arbitrary or
+      // corrupted bytes; publishing those as an image blob would hand consumers
+      // an "image" they cannot decode. Derive the MIME from the detected format
+      // rather than trusting the (unvalidated) stored content-type.
+      let meta: sharp.Metadata;
       try {
-        const meta = await sharp(bytes, { failOn: 'none' }).metadata();
-        width = meta.width;
-        height = meta.height;
+        meta = await sharp(bytes).metadata();
       } catch {
-        // leave width/height undefined
+        this.logger.warn(
+          `Object is not a decodable image (${bytes.length}B); skipping image`,
+        );
+        return null;
       }
-      return { bytes, mimeType, width, height };
+      const detectedMime = this.mimeFromSharpFormat(meta.format);
+      if (!detectedMime || !meta.width || !meta.height) {
+        this.logger.warn(
+          `Object is not a supported raster image (format=${
+            meta.format ?? 'unknown'
+          }, ${meta.width ?? '?'}x${meta.height ?? '?'}); skipping image`,
+        );
+        return null;
+      }
+      // Validated raster preserved byte-for-byte, with a format-derived MIME.
+      return {
+        bytes,
+        mimeType: detectedMime,
+        width: meta.width,
+        height: meta.height,
+      };
     }
 
     const pipeline = sharp(bytes, { failOn: 'none' }).rotate().resize({
@@ -375,6 +395,28 @@ export class EventImageBlobService {
         return 'image/webp';
       case 'gif':
         return 'image/gif';
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * Map a sharp-detected format to the MIME we publish, restricted to supported
+   * raster images. Vector (svg) and unrecognized/undetected formats return null
+   * so the object is rejected rather than published as an undecodable image.
+   */
+  private mimeFromSharpFormat(format?: string): string | null {
+    switch (format) {
+      case 'jpeg':
+        return 'image/jpeg';
+      case 'png':
+        return 'image/png';
+      case 'webp':
+        return 'image/webp';
+      case 'gif':
+        return 'image/gif';
+      case 'avif':
+        return 'image/avif';
       default:
         return null;
     }

--- a/src/bluesky/event-image-blob.service.ts
+++ b/src/bluesky/event-image-blob.service.ts
@@ -1,0 +1,220 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Agent } from '@atproto/api';
+import { BlobRef } from '@atproto/lexicon';
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import sharp from 'sharp';
+import { FileConfig } from '../file/config/file-config.type';
+import fileConfig from '../file/config/file.config';
+import { createFileS3Client } from '../file/s3-client.factory';
+
+export interface UploadedEventImage {
+  /** The blob reference to embed in the record (pins the blob against GC). */
+  blob: BlobRef;
+  /** The blob CID string, used to build the getBlob URL. */
+  cid: string;
+  mimeType: string;
+  size: number;
+}
+
+/**
+ * Uploads event images to the event owner's PDS as content-addressed blobs and
+ * builds the stable, federated `com.atproto.sync.getBlob` URL that goes into the
+ * durable event record.
+ *
+ * Why blobs instead of an S3/CDN URL: the record lives immutably in the user's
+ * PDS repo, so its image must live in the same portable substrate. The bytes are
+ * uploaded to the owner's PDS (user-owned, travels with the repo) and referenced
+ * by CID. getBlob is a public, unauthenticated, immutable endpoint, so the URL is
+ * safe to cache at a CDN and needs no signing.
+ */
+@Injectable()
+export class EventImageBlobService {
+  private readonly logger = new Logger(EventImageBlobService.name);
+
+  // Keep blobs comfortably under the PDS default blob-upload limit (5 MB) and
+  // avoid bloating user repos. Images above this are resized/re-encoded first.
+  private static readonly MAX_BLOB_BYTES = 4 * 1024 * 1024;
+  private static readonly MAX_EDGE = 2000;
+
+  constructor(private readonly configService: ConfigService) {}
+
+  /**
+   * Fetch the image bytes from object storage, shrink if needed, and upload as a
+   * blob to the repo the agent is authenticated for. Returns null on any failure
+   * so the caller can publish the record without an image rather than failing the
+   * whole publish.
+   */
+  async uploadEventImage(
+    agent: Agent,
+    imageKey: string,
+  ): Promise<UploadedEventImage | null> {
+    try {
+      const fetched = await this.fetchObject(imageKey);
+      if (!fetched) return null;
+
+      const { bytes, mimeType } = await this.normalizeForBlob(
+        fetched.bytes,
+        fetched.mimeType,
+      );
+
+      const res = await agent.uploadBlob(bytes, { encoding: mimeType });
+      const blob = res.data.blob;
+      return {
+        blob,
+        cid: blob.ref.toString(),
+        mimeType,
+        size: bytes.length,
+      };
+    } catch (err) {
+      this.logger.error(
+        `Failed to upload event image blob for key "${imageKey}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Build the getBlob URL to bake into the record. Uses the configured public
+   * base URL (a CDN fronting OpenMeet's PDS) only when the owner is on OpenMeet's
+   * own PDS; otherwise the owner's real PDS host is used so the blob resolves.
+   */
+  buildGetBlobUrl(userPdsUrl: string, did: string, cid: string): string {
+    const host = this.resolveBlobHost(userPdsUrl).replace(/\/+$/, '');
+    return `${host}/xrpc/com.atproto.sync.getBlob?did=${encodeURIComponent(
+      did,
+    )}&cid=${encodeURIComponent(cid)}`;
+  }
+
+  /**
+   * The CDN base URL is only valid for blobs served by OpenMeet's own PDS (it
+   * origins there). For users on any other PDS, bake their real PDS host.
+   */
+  private resolveBlobHost(userPdsUrl: string): string {
+    const config = fileConfig() as FileConfig;
+    const cdnBase = config.blobPublicBaseUrl;
+    const openmeetPds = this.configService.get<string>('pds.url', {
+      infer: true,
+    });
+
+    if (cdnBase && openmeetPds && this.sameHost(userPdsUrl, openmeetPds)) {
+      return cdnBase;
+    }
+    return userPdsUrl;
+  }
+
+  private sameHost(a: string, b: string): boolean {
+    try {
+      return new URL(a).host === new URL(b).host;
+    } catch {
+      return false;
+    }
+  }
+
+  private async fetchObject(
+    key: string,
+  ): Promise<{ bytes: Buffer; mimeType: string } | null> {
+    const config = fileConfig() as FileConfig;
+    const s3 = createFileS3Client({
+      region: config.awsS3Region ?? '',
+      accessKeyId: config.accessKeyId ?? '',
+      secretAccessKey: config.secretAccessKey ?? '',
+      endpoint: config.awsS3Endpoint,
+      forcePathStyle: config.awsS3ForcePathStyle,
+    });
+
+    const res = await s3.send(
+      new GetObjectCommand({
+        Bucket: config.awsDefaultS3Bucket ?? '',
+        Key: key,
+      }),
+    );
+
+    if (!res.Body) {
+      this.logger.warn(`Object "${key}" returned no body`);
+      return null;
+    }
+
+    // AWS SDK v3 stream helper -> Uint8Array
+    const bytes = Buffer.from(
+      await (res.Body as { transformToByteArray: () => Promise<Uint8Array> }).transformToByteArray(),
+    );
+    const mimeType =
+      res.ContentType || this.mimeFromKey(key) || 'application/octet-stream';
+    return { bytes, mimeType };
+  }
+
+  /**
+   * Ensure the blob fits comfortably under the PDS limit. Images already small
+   * enough are uploaded byte-for-byte (best fidelity); larger ones are resized
+   * and re-encoded.
+   */
+  private async normalizeForBlob(
+    bytes: Buffer,
+    mimeType: string,
+  ): Promise<{ bytes: Buffer; mimeType: string }> {
+    if (bytes.length <= EventImageBlobService.MAX_BLOB_BYTES) {
+      return { bytes, mimeType };
+    }
+
+    const base = sharp(bytes, { failOn: 'none' }).rotate();
+    const meta = await base.metadata();
+    const resized = base.resize({
+      width: EventImageBlobService.MAX_EDGE,
+      height: EventImageBlobService.MAX_EDGE,
+      fit: 'inside',
+      withoutEnlargement: true,
+    });
+
+    // Preserve transparency where present; otherwise JPEG for best compression.
+    let out: Buffer;
+    let outMime: string;
+    if (meta.hasAlpha) {
+      out = await resized.clone().png({ compressionLevel: 9 }).toBuffer();
+      outMime = 'image/png';
+    } else {
+      out = await resized.clone().jpeg({ quality: 82, mozjpeg: true }).toBuffer();
+      outMime = 'image/jpeg';
+    }
+
+    // Last-resort pass: guarantee we get under the limit even if it means
+    // dropping alpha, since an oversized blob would be rejected by the PDS.
+    if (out.length > EventImageBlobService.MAX_BLOB_BYTES) {
+      out = await sharp(bytes, { failOn: 'none' })
+        .rotate()
+        .resize({
+          width: 1280,
+          height: 1280,
+          fit: 'inside',
+          withoutEnlargement: true,
+        })
+        .jpeg({ quality: 78, mozjpeg: true })
+        .toBuffer();
+      outMime = 'image/jpeg';
+    }
+
+    this.logger.debug(
+      `Resized event image ${bytes.length}B (${mimeType}) -> ${out.length}B (${outMime})`,
+    );
+    return { bytes: out, mimeType: outMime };
+  }
+
+  private mimeFromKey(key: string): string | null {
+    const ext = key.split('.').pop()?.toLowerCase();
+    switch (ext) {
+      case 'jpg':
+      case 'jpeg':
+        return 'image/jpeg';
+      case 'png':
+        return 'image/png';
+      case 'webp':
+        return 'image/webp';
+      case 'gif':
+        return 'image/gif';
+      default:
+        return null;
+    }
+  }
+}

--- a/src/file/config/file-config.type.ts
+++ b/src/file/config/file-config.type.ts
@@ -17,9 +17,4 @@ export type FileConfig = {
   cloudfrontKeyPairId?: string;
   cloudfrontPrivateKey?: string;
   maxFileSize: number;
-  // Public base URL fronting the PDS `com.atproto.sync.getBlob` endpoint (e.g. a
-  // managed CDN at https://media.openmeet.net). Baked into federated event
-  // records for images stored as PDS blobs on OpenMeet's own PDS. Unset => the
-  // user's own PDS host is used instead. See src/bluesky/event-image-blob.service.ts.
-  blobPublicBaseUrl?: string;
 };

--- a/src/file/config/file-config.type.ts
+++ b/src/file/config/file-config.type.ts
@@ -17,4 +17,9 @@ export type FileConfig = {
   cloudfrontKeyPairId?: string;
   cloudfrontPrivateKey?: string;
   maxFileSize: number;
+  // Public base URL fronting the PDS `com.atproto.sync.getBlob` endpoint (e.g. a
+  // managed CDN at https://media.openmeet.net). Baked into federated event
+  // records for images stored as PDS blobs on OpenMeet's own PDS. Unset => the
+  // user's own PDS host is used instead. See src/bluesky/event-image-blob.service.ts.
+  blobPublicBaseUrl?: string;
 };

--- a/src/file/config/file-config.type.ts
+++ b/src/file/config/file-config.type.ts
@@ -16,5 +16,10 @@ export type FileConfig = {
   cloudfrontDistributionDomain?: string;
   cloudfrontKeyPairId?: string;
   cloudfrontPrivateKey?: string;
+  // Extra hostnames trusted as OpenMeet-controlled media origins when mapping a
+  // legacy full-URL image reference back to an object key (e.g. a retired
+  // CloudFront distribution kept alive for images baked into old records). Read
+  // only -- the object is still fetched from our own bucket, never these hosts.
+  mediaAllowedLegacyOrigins?: string[];
   maxFileSize: number;
 };

--- a/src/file/config/file.config.ts
+++ b/src/file/config/file.config.ts
@@ -73,12 +73,6 @@ class EnvironmentVariablesValidator {
   @IsString()
   @IsOptional()
   CLOUDFRONT_PRIVATE_KEY: string;
-
-  // Optional CDN/base URL fronting the PDS getBlob endpoint for federated event
-  // record images (e.g. https://media.openmeet.net). Driver-independent.
-  @IsString()
-  @IsOptional()
-  BLOB_PUBLIC_BASE_URL: string;
 }
 
 export default registerAs<FileConfig>('file', () => {
@@ -97,7 +91,6 @@ export default registerAs<FileConfig>('file', () => {
     cloudfrontDistributionDomain: process.env.CLOUDFRONT_DISTRIBUTION_DOMAIN,
     cloudfrontKeyPairId: process.env.CLOUDFRONT_KEY_PAIR_ID,
     cloudfrontPrivateKey: process.env.CLOUDFRONT_PRIVATE_KEY,
-    blobPublicBaseUrl: process.env.BLOB_PUBLIC_BASE_URL,
     maxFileSize: parseInt(process.env.AWS_S3_MAX_FILE_SIZE ?? '5242880', 10), // 5mb
   };
 });

--- a/src/file/config/file.config.ts
+++ b/src/file/config/file.config.ts
@@ -73,6 +73,12 @@ class EnvironmentVariablesValidator {
   @IsString()
   @IsOptional()
   CLOUDFRONT_PRIVATE_KEY: string;
+
+  // Optional CDN/base URL fronting the PDS getBlob endpoint for federated event
+  // record images (e.g. https://media.openmeet.net). Driver-independent.
+  @IsString()
+  @IsOptional()
+  BLOB_PUBLIC_BASE_URL: string;
 }
 
 export default registerAs<FileConfig>('file', () => {
@@ -91,6 +97,7 @@ export default registerAs<FileConfig>('file', () => {
     cloudfrontDistributionDomain: process.env.CLOUDFRONT_DISTRIBUTION_DOMAIN,
     cloudfrontKeyPairId: process.env.CLOUDFRONT_KEY_PAIR_ID,
     cloudfrontPrivateKey: process.env.CLOUDFRONT_PRIVATE_KEY,
+    blobPublicBaseUrl: process.env.BLOB_PUBLIC_BASE_URL,
     maxFileSize: parseInt(process.env.AWS_S3_MAX_FILE_SIZE ?? '5242880', 10), // 5mb
   };
 });

--- a/src/file/config/file.config.ts
+++ b/src/file/config/file.config.ts
@@ -73,6 +73,13 @@ class EnvironmentVariablesValidator {
   @IsString()
   @IsOptional()
   CLOUDFRONT_PRIVATE_KEY: string;
+
+  // Comma-separated hostnames trusted as OpenMeet media origins when mapping a
+  // legacy full-URL image back to an object key (e.g. a retired CloudFront
+  // distribution). Optional; applies under any driver.
+  @IsString()
+  @IsOptional()
+  MEDIA_ALLOWED_LEGACY_ORIGINS: string;
 }
 
 export default registerAs<FileConfig>('file', () => {
@@ -91,6 +98,10 @@ export default registerAs<FileConfig>('file', () => {
     cloudfrontDistributionDomain: process.env.CLOUDFRONT_DISTRIBUTION_DOMAIN,
     cloudfrontKeyPairId: process.env.CLOUDFRONT_KEY_PAIR_ID,
     cloudfrontPrivateKey: process.env.CLOUDFRONT_PRIVATE_KEY,
+    mediaAllowedLegacyOrigins: (process.env.MEDIA_ALLOWED_LEGACY_ORIGINS ?? '')
+      .split(',')
+      .map((h) => h.trim())
+      .filter((h) => h.length > 0),
     maxFileSize: parseInt(process.env.AWS_S3_MAX_FILE_SIZE ?? '5242880', 10), // 5mb
   };
 });

--- a/test/atproto/atproto-event-image-blob.e2e-spec.ts
+++ b/test/atproto/atproto-event-image-blob.e2e-spec.ts
@@ -1,0 +1,296 @@
+import { randomBytes } from 'crypto';
+import { promises as fs } from 'fs';
+import request from 'supertest';
+import sharp from 'sharp';
+import { Client } from 'pg';
+import {
+  TESTING_APP_URL,
+  TESTING_TENANT_ID,
+  TESTING_PDS_URL,
+} from '../utils/constants';
+import { mailDevService } from '../utils/maildev-service';
+import { EmailVerificationTestHelpers } from '../utils/email-verification-helpers';
+import { createFile, createEvent } from '../utils/functions';
+import {
+  EventType,
+  EventVisibility,
+  EventStatus,
+} from '../../src/core/constants/constant';
+
+/**
+ * Event Image Blob Publishing E2E Tests
+ *
+ * Verifies the full image-blob publish path against the devnet PDS: an event
+ * with an attached image publishes its image as a real PDS blob (a real
+ * agent.uploadBlob + putRecord, not mocks) referenced from the record via the
+ * ecosystem media[] convention, with no URL baked into the record. The blob is
+ * then fetched back from the PDS via com.atproto.sync.getBlob.
+ *
+ * Fixture arrangement: the e2e harness has no S3, so the image bytes are
+ * seeded where the local file driver reads them (./files/<name> on the shared
+ * container filesystem -- tests run in the same container as the API) and the
+ * file record's stored path is pointed at that key. Everything downstream of
+ * the fixture (fetch, WebP normalization, uploadBlob, putRecord, getBlob) is
+ * the real production path.
+ *
+ * Run with: npm run test:e2e -- --testPathPattern=atproto-event-image-blob
+ */
+
+jest.setTimeout(120000);
+
+describe('AT Protocol Event Image Blob Publishing (e2e)', () => {
+  const app = TESTING_APP_URL;
+  const testRunId = Date.now();
+  const newUserEmail = `atproto-image-blob-${testRunId}@openmeet.net`;
+  const newUserPassword = 'testpassword123';
+  const eventName = `Image Blob Test Event ${testRunId}`;
+  const seededImageKey = `e2e-image-blob/${testRunId}.png`;
+  const seededImageFile = `./files/${testRunId}.png`;
+
+  let serverApp: ReturnType<typeof request.agent>;
+  let userToken: string;
+  let userDid: string;
+  let imageFileId: number;
+  let imageBytes: Buffer;
+  let eventSlug: string;
+  let eventRkey: string;
+  let pgClient: Client | null = null;
+
+  const waitForBackend = (ms = 1000) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
+  beforeAll(() => {
+    serverApp = request.agent(app).set('x-tenant-id', TESTING_TENANT_ID);
+  });
+
+  afterAll(async () => {
+    if (pgClient) {
+      await pgClient.end().catch(() => undefined);
+    }
+    await fs.unlink(seededImageFile).catch(() => undefined);
+  });
+
+  describe('1. User with AT Protocol identity', () => {
+    it('should register, verify, and log in a new email user', async () => {
+      const registerResponse = await serverApp
+        .post('/api/v1/auth/email/register')
+        .send({
+          email: newUserEmail,
+          password: newUserPassword,
+          firstName: 'ImageBlob',
+          lastName: `Test${testRunId}`,
+        });
+      expect(registerResponse.status).toBe(201);
+
+      await waitForBackend(2000);
+
+      const verificationEmail = await EmailVerificationTestHelpers.waitForEmail(
+        () => mailDevService.getEmails(),
+        (email) =>
+          email.to?.some(
+            (to) => to.address.toLowerCase() === newUserEmail.toLowerCase(),
+          ) &&
+          (email.subject?.includes('Code') ||
+            email.subject?.includes('Verify')),
+        30000,
+      );
+      expect(verificationEmail).toBeDefined();
+
+      const verificationCode =
+        EmailVerificationTestHelpers.extractVerificationCode(verificationEmail);
+      expect(verificationCode).toBeDefined();
+
+      const verifyResponse = await serverApp
+        .post('/api/v1/auth/verify-email-code')
+        .send({ email: newUserEmail, code: verificationCode });
+      expect(verifyResponse.status).toBe(200);
+
+      const loginResponse = await serverApp
+        .post('/api/v1/auth/email/login')
+        .send({ email: newUserEmail, password: newUserPassword });
+      expect(loginResponse.status).toBe(200);
+      expect(loginResponse.body.token).toBeDefined();
+      userToken = loginResponse.body.token;
+    });
+
+    it('should have an AT Protocol identity (custodial PDS account)', async () => {
+      // PDS account creation is async; poll until the identity appears.
+      let did: string | undefined;
+      for (let attempt = 0; attempt < 15 && !did; attempt++) {
+        await waitForBackend(2000);
+        const identityResponse = await serverApp
+          .get('/api/atproto/identity')
+          .set('Authorization', `Bearer ${userToken}`);
+        if (identityResponse.status === 200 && identityResponse.body?.did) {
+          did = identityResponse.body.did;
+        }
+      }
+
+      expect(did).toBeDefined();
+      expect(did).toMatch(/^did:(plc|web):/);
+      userDid = did as string;
+      console.log(`User AT Protocol identity: ${userDid}`);
+    });
+  });
+
+  describe('2. Seed an image fixture the publish path can read', () => {
+    it('should create a file record and stage the image bytes for the local driver', async () => {
+      // A random-noise PNG well over the 900KB normalization threshold (so the
+      // publish path must re-encode to WebP) but under the 5MB upload cap.
+      const width = 1400;
+      const height = 1050;
+      const raw = randomBytes(width * height * 3);
+      imageBytes = await sharp(raw, { raw: { width, height, channels: 3 } })
+        .png()
+        .toBuffer();
+      expect(imageBytes.length).toBeGreaterThan(900 * 1024);
+      expect(imageBytes.length).toBeLessThan(5 * 1024 * 1024);
+
+      const file = await createFile(app, userToken, {
+        fileName: `image-blob-${testRunId}.png`,
+        fileSize: imageBytes.length,
+        mimeType: 'image/png',
+      });
+      imageFileId = file.id;
+      expect(imageFileId).toBeDefined();
+
+      // The e2e harness has no object storage, so stage the bytes where the
+      // local file driver reads them (tests share the API container's
+      // filesystem) and point the record's stored path at that key.
+      await fs.mkdir('./files', { recursive: true });
+      await fs.writeFile(seededImageFile, imageBytes);
+
+      pgClient = new Client({
+        host: process.env.DATABASE_HOST,
+        port: parseInt(process.env.DATABASE_PORT || '5432', 10),
+        user: process.env.DATABASE_USERNAME,
+        password: process.env.DATABASE_PASSWORD,
+        database: process.env.DATABASE_NAME,
+      });
+      await pgClient.connect();
+      const updateResult = await pgClient.query(
+        `UPDATE "tenant_${TESTING_TENANT_ID}"."files" SET "path" = $1 WHERE "id" = $2`,
+        [seededImageKey, imageFileId],
+      );
+      expect(updateResult.rowCount).toBe(1);
+    });
+  });
+
+  describe('3. Publish an event with the image and verify the PDS record', () => {
+    it('should create a public event with the image and publish it to the PDS', async () => {
+      const event = await createEvent(app, userToken, {
+        name: eventName,
+        description: 'Event to verify image blob publishing',
+        type: EventType.InPerson,
+        location: 'Blob Test Location',
+        maxAttendees: 50,
+        visibility: EventVisibility.Public,
+        status: EventStatus.Published,
+        startDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        endDate: new Date(
+          Date.now() + 7 * 24 * 60 * 60 * 1000 + 2 * 60 * 60 * 1000,
+        ).toISOString(),
+        categories: [],
+        timeZone: 'America/New_York',
+        image: { id: imageFileId },
+      });
+      expect(event.slug).toBeDefined();
+      eventSlug = event.slug;
+
+      // Publishing runs during creation but poll to absorb any async lag.
+      let rkey: string | undefined;
+      for (let attempt = 0; attempt < 15 && !rkey; attempt++) {
+        await waitForBackend(2000);
+        const eventResponse = await serverApp
+          .get(`/api/events/${eventSlug}`)
+          .set('Authorization', `Bearer ${userToken}`);
+        expect(eventResponse.status).toBe(200);
+        if (eventResponse.body.atprotoRkey) {
+          rkey = eventResponse.body.atprotoRkey;
+        }
+      }
+
+      expect(rkey).toBeDefined();
+      eventRkey = rkey as string;
+      console.log(`Event published to PDS with rkey: ${eventRkey}`);
+    });
+
+    it('should reference the image via a media[] thumbnail blob with no URL baked in', async () => {
+      const pdsResponse = await request(TESTING_PDS_URL)
+        .get(
+          `/xrpc/com.atproto.repo.getRecord?repo=${userDid}&collection=community.lexicon.calendar.event&rkey=${eventRkey}`,
+        )
+        .set('Accept', 'application/json');
+      expect(pdsResponse.status).toBe(200);
+
+      const record = pdsResponse.body.value;
+      expect(record.name).toBe(eventName);
+
+      // media[]: exactly one thumbnail entry in the ecosystem shape.
+      expect(Array.isArray(record.media)).toBe(true);
+      const thumbnails = record.media.filter(
+        (m: any) => m.role === 'thumbnail',
+      );
+      expect(thumbnails).toHaveLength(1);
+      const thumbnail = thumbnails[0];
+
+      // content is a real blob ref, re-encoded to WebP (source was >900KB) and
+      // under the size ceiling.
+      expect(thumbnail.content?.$type).toBe('blob');
+      expect(thumbnail.content?.ref?.$link).toBeTruthy();
+      expect(thumbnail.content?.mimeType).toBe('image/webp');
+      expect(thumbnail.content?.size).toBeGreaterThan(0);
+      expect(thumbnail.content?.size).toBeLessThanOrEqual(900 * 1024);
+
+      // alt defaults to the event name; aspect_ratio is the final dimensions
+      // (1400x1050 is under the 2048 edge cap, so unchanged).
+      expect(thumbnail.alt).toBe(eventName);
+      expect(thumbnail.aspect_ratio).toEqual({ width: 1400, height: 1050 });
+
+      // The source key lives in the openMeetMeta extension, not the media
+      // entry; the legacy bespoke field is gone.
+      expect(record.openMeetMeta?.imageSourceKey).toBe(seededImageKey);
+      expect(record.openMeetMedia).toBeUndefined();
+
+      // No URL is baked into the record for the image.
+      const imageUri = (record.uris ?? []).find(
+        (u: any) => u.name === 'Event Image',
+      );
+      expect(imageUri).toBeUndefined();
+    });
+
+    it('should serve the blob bytes back via com.atproto.sync.getBlob', async () => {
+      const pdsResponse = await request(TESTING_PDS_URL)
+        .get(
+          `/xrpc/com.atproto.repo.getRecord?repo=${userDid}&collection=community.lexicon.calendar.event&rkey=${eventRkey}`,
+        )
+        .set('Accept', 'application/json');
+      expect(pdsResponse.status).toBe(200);
+      const thumbnail = pdsResponse.body.value.media.find(
+        (m: any) => m.role === 'thumbnail',
+      );
+      const cid = thumbnail.content.ref.$link;
+
+      const blobResponse = await fetch(
+        `${TESTING_PDS_URL}/xrpc/com.atproto.sync.getBlob?did=${encodeURIComponent(
+          userDid,
+        )}&cid=${encodeURIComponent(cid)}`,
+      );
+      expect(blobResponse.status).toBe(200);
+
+      const blobBytes = Buffer.from(await blobResponse.arrayBuffer());
+      expect(blobBytes.length).toBeGreaterThan(0);
+      expect(blobBytes.length).toBe(thumbnail.content.size);
+
+      // WebP magic bytes: RIFF....WEBP -- the blob really is the re-encoded
+      // WebP image, independent of whatever content-type header the PDS sets.
+      expect(blobBytes.subarray(0, 4).toString('ascii')).toBe('RIFF');
+      expect(blobBytes.subarray(8, 12).toString('ascii')).toBe('WEBP');
+      console.log(
+        `getBlob served ${blobBytes.length}B webp (content-type: ${blobResponse.headers.get(
+          'content-type',
+        )})`,
+      );
+    });
+  });
+});

--- a/test/atproto/atproto-event-image-blob.e2e-spec.ts
+++ b/test/atproto/atproto-event-image-blob.e2e-spec.ts
@@ -36,7 +36,7 @@ import {
  * Run with: npm run test:e2e -- --testPathPattern=atproto-event-image-blob
  */
 
-jest.setTimeout(120000);
+jest.setTimeout(180000);
 
 describe('AT Protocol Event Image Blob Publishing (e2e)', () => {
   const app = TESTING_APP_URL;
@@ -46,22 +46,174 @@ describe('AT Protocol Event Image Blob Publishing (e2e)', () => {
   const eventName = `Image Blob Test Event ${testRunId}`;
   const seededImageKey = `e2e-image-blob/${testRunId}.png`;
   const seededImageFile = `./files/${testRunId}.png`;
+  // Source image: 1400x1050 (under the 2048 edge cap, so dimensions survive)
+  // and >900KB (so the publish path must re-encode to WebP).
+  const sourceWidth = 1400;
+  const sourceHeight = 1050;
 
-  let serverApp: ReturnType<typeof request.agent>;
-  let userToken: string;
   let userDid: string;
-  let imageFileId: number;
-  let imageBytes: Buffer;
-  let eventSlug: string;
   let eventRkey: string;
   let pgClient: Client | null = null;
+  // The published record + its thumbnail entry, fetched once in beforeAll and
+  // asserted on by the contract tests below.
+  let publishedRecord: any;
+  let thumbnail: any;
 
   const waitForBackend = (ms = 1000) =>
     new Promise((resolve) => setTimeout(resolve, ms));
 
-  beforeAll(() => {
-    serverApp = request.agent(app).set('x-tenant-id', TESTING_TENANT_ID);
-  });
+  const getEventRecord = async () => {
+    const pdsResponse = await request(TESTING_PDS_URL)
+      .get(
+        `/xrpc/com.atproto.repo.getRecord?repo=${userDid}&collection=community.lexicon.calendar.event&rkey=${eventRkey}`,
+      )
+      .set('Accept', 'application/json');
+    expect(pdsResponse.status).toBe(200);
+    return pdsResponse.body.value;
+  };
+
+  // Full scenario setup: register a user, wait for the custodial PDS identity,
+  // seed an image fixture the local file driver can read, create+publish a
+  // public event with that image, then fetch the published record once. Kept in
+  // beforeAll so a setup failure surfaces as a setup failure (not a cascade of
+  // misleading assertion failures) and the tests below assert only the contract.
+  beforeAll(async () => {
+    const serverApp = request.agent(app).set('x-tenant-id', TESTING_TENANT_ID);
+
+    // --- register, verify, and log in a new email user ---
+    const registerResponse = await serverApp
+      .post('/api/v1/auth/email/register')
+      .send({
+        email: newUserEmail,
+        password: newUserPassword,
+        firstName: 'ImageBlob',
+        lastName: `Test${testRunId}`,
+      });
+    expect(registerResponse.status).toBe(201);
+
+    await waitForBackend(2000);
+
+    const verificationEmail = await EmailVerificationTestHelpers.waitForEmail(
+      () => mailDevService.getEmails(),
+      (email) =>
+        email.to?.some(
+          (to) => to.address.toLowerCase() === newUserEmail.toLowerCase(),
+        ) &&
+        (email.subject?.includes('Code') || email.subject?.includes('Verify')),
+      30000,
+    );
+    expect(verificationEmail).toBeDefined();
+
+    const verificationCode =
+      EmailVerificationTestHelpers.extractVerificationCode(verificationEmail);
+    expect(verificationCode).toBeDefined();
+
+    const verifyResponse = await serverApp
+      .post('/api/v1/auth/verify-email-code')
+      .send({ email: newUserEmail, code: verificationCode });
+    expect(verifyResponse.status).toBe(200);
+
+    const loginResponse = await serverApp
+      .post('/api/v1/auth/email/login')
+      .send({ email: newUserEmail, password: newUserPassword });
+    expect(loginResponse.status).toBe(200);
+    expect(loginResponse.body.token).toBeDefined();
+    const userToken = loginResponse.body.token;
+
+    // --- wait for the async custodial PDS account to appear ---
+    let did: string | undefined;
+    for (let attempt = 0; attempt < 15 && !did; attempt++) {
+      await waitForBackend(2000);
+      const identityResponse = await serverApp
+        .get('/api/atproto/identity')
+        .set('Authorization', `Bearer ${userToken}`);
+      if (identityResponse.status === 200 && identityResponse.body?.did) {
+        did = identityResponse.body.did;
+      }
+    }
+    expect(did).toBeDefined();
+    expect(did).toMatch(/^did:(plc|web):/);
+    userDid = did as string;
+
+    // --- seed the image fixture the publish path can read ---
+    // A random-noise PNG over the 900KB normalization threshold (forces WebP
+    // re-encode) but under the 5MB upload cap.
+    const raw = randomBytes(sourceWidth * sourceHeight * 3);
+    const imageBytes = await sharp(raw, {
+      raw: { width: sourceWidth, height: sourceHeight, channels: 3 },
+    })
+      .png()
+      .toBuffer();
+    expect(imageBytes.length).toBeGreaterThan(900 * 1024);
+    expect(imageBytes.length).toBeLessThan(5 * 1024 * 1024);
+
+    const file = await createFile(app, userToken, {
+      fileName: `image-blob-${testRunId}.png`,
+      fileSize: imageBytes.length,
+      mimeType: 'image/png',
+    });
+    const imageFileId = file.id;
+    expect(imageFileId).toBeDefined();
+
+    // The e2e harness has no object storage, so stage the bytes where the local
+    // file driver reads them (tests share the API container's filesystem) and
+    // point the record's stored path at that key.
+    await fs.mkdir('./files', { recursive: true });
+    await fs.writeFile(seededImageFile, imageBytes);
+
+    pgClient = new Client({
+      host: process.env.DATABASE_HOST,
+      port: parseInt(process.env.DATABASE_PORT || '5432', 10),
+      user: process.env.DATABASE_USERNAME,
+      password: process.env.DATABASE_PASSWORD,
+      database: process.env.DATABASE_NAME,
+    });
+    await pgClient.connect();
+    const updateResult = await pgClient.query(
+      `UPDATE "tenant_${TESTING_TENANT_ID}"."files" SET "path" = $1 WHERE "id" = $2`,
+      [seededImageKey, imageFileId],
+    );
+    expect(updateResult.rowCount).toBe(1);
+
+    // --- create a public event with the image and wait for it to publish ---
+    const event = await createEvent(app, userToken, {
+      name: eventName,
+      description: 'Event to verify image blob publishing',
+      type: EventType.InPerson,
+      location: 'Blob Test Location',
+      maxAttendees: 50,
+      visibility: EventVisibility.Public,
+      status: EventStatus.Published,
+      startDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+      endDate: new Date(
+        Date.now() + 7 * 24 * 60 * 60 * 1000 + 2 * 60 * 60 * 1000,
+      ).toISOString(),
+      categories: [],
+      timeZone: 'America/New_York',
+      image: { id: imageFileId },
+    });
+    expect(event.slug).toBeDefined();
+
+    let rkey: string | undefined;
+    for (let attempt = 0; attempt < 15 && !rkey; attempt++) {
+      await waitForBackend(2000);
+      const eventResponse = await serverApp
+        .get(`/api/events/${event.slug}`)
+        .set('Authorization', `Bearer ${userToken}`);
+      expect(eventResponse.status).toBe(200);
+      if (eventResponse.body.atprotoRkey) {
+        rkey = eventResponse.body.atprotoRkey;
+      }
+    }
+    expect(rkey).toBeDefined();
+    eventRkey = rkey as string;
+
+    // --- fetch the published record once for the assertions below ---
+    publishedRecord = await getEventRecord();
+    thumbnail = (publishedRecord.media ?? []).find(
+      (m: any) => m.role === 'thumbnail',
+    );
+  }, 180000);
 
   afterAll(async () => {
     if (pgClient) {
@@ -70,227 +222,65 @@ describe('AT Protocol Event Image Blob Publishing (e2e)', () => {
     await fs.unlink(seededImageFile).catch(() => undefined);
   });
 
-  describe('1. User with AT Protocol identity', () => {
-    it('should register, verify, and log in a new email user', async () => {
-      const registerResponse = await serverApp
-        .post('/api/v1/auth/email/register')
-        .send({
-          email: newUserEmail,
-          password: newUserPassword,
-          firstName: 'ImageBlob',
-          lastName: `Test${testRunId}`,
-        });
-      expect(registerResponse.status).toBe(201);
+  it('should reference the image via a single media[] thumbnail blob with no URL baked into the record', () => {
+    expect(publishedRecord.name).toBe(eventName);
 
-      await waitForBackend(2000);
+    // Exactly one thumbnail entry, in the ecosystem media[] shape.
+    const thumbnails = (publishedRecord.media ?? []).filter(
+      (m: any) => m.role === 'thumbnail',
+    );
+    expect(thumbnails).toHaveLength(1);
 
-      const verificationEmail = await EmailVerificationTestHelpers.waitForEmail(
-        () => mailDevService.getEmails(),
-        (email) =>
-          email.to?.some(
-            (to) => to.address.toLowerCase() === newUserEmail.toLowerCase(),
-          ) &&
-          (email.subject?.includes('Code') ||
-            email.subject?.includes('Verify')),
-        30000,
-      );
-      expect(verificationEmail).toBeDefined();
+    // content is a real blob ref, re-encoded to WebP (source was >900KB) and
+    // under the size ceiling.
+    expect(thumbnail.content?.$type).toBe('blob');
+    expect(thumbnail.content?.ref?.$link).toBeTruthy();
+    expect(thumbnail.content?.mimeType).toBe('image/webp');
+    expect(thumbnail.content?.size).toBeGreaterThan(0);
+    expect(thumbnail.content?.size).toBeLessThanOrEqual(900 * 1024);
 
-      const verificationCode =
-        EmailVerificationTestHelpers.extractVerificationCode(verificationEmail);
-      expect(verificationCode).toBeDefined();
-
-      const verifyResponse = await serverApp
-        .post('/api/v1/auth/verify-email-code')
-        .send({ email: newUserEmail, code: verificationCode });
-      expect(verifyResponse.status).toBe(200);
-
-      const loginResponse = await serverApp
-        .post('/api/v1/auth/email/login')
-        .send({ email: newUserEmail, password: newUserPassword });
-      expect(loginResponse.status).toBe(200);
-      expect(loginResponse.body.token).toBeDefined();
-      userToken = loginResponse.body.token;
+    // alt defaults to the event name; aspect_ratio is the final dimensions
+    // (1400x1050 is under the 2048 edge cap, so unchanged).
+    expect(thumbnail.alt).toBe(eventName);
+    expect(thumbnail.aspect_ratio).toEqual({
+      width: sourceWidth,
+      height: sourceHeight,
     });
 
-    it('should have an AT Protocol identity (custodial PDS account)', async () => {
-      // PDS account creation is async; poll until the identity appears.
-      let did: string | undefined;
-      for (let attempt = 0; attempt < 15 && !did; attempt++) {
-        await waitForBackend(2000);
-        const identityResponse = await serverApp
-          .get('/api/atproto/identity')
-          .set('Authorization', `Bearer ${userToken}`);
-        if (identityResponse.status === 200 && identityResponse.body?.did) {
-          did = identityResponse.body.did;
-        }
-      }
+    // The source key lives in the openMeetMeta extension, not the media entry;
+    // the legacy bespoke field is gone.
+    expect(publishedRecord.openMeetMeta?.imageSourceKey).toBe(seededImageKey);
+    expect(publishedRecord.openMeetMedia).toBeUndefined();
 
-      expect(did).toBeDefined();
-      expect(did).toMatch(/^did:(plc|web):/);
-      userDid = did as string;
-      console.log(`User AT Protocol identity: ${userDid}`);
-    });
+    // No URL is baked into the record for the image.
+    const imageUri = (publishedRecord.uris ?? []).find(
+      (u: any) => u.name === 'Event Image',
+    );
+    expect(imageUri).toBeUndefined();
   });
 
-  describe('2. Seed an image fixture the publish path can read', () => {
-    it('should create a file record and stage the image bytes for the local driver', async () => {
-      // A random-noise PNG well over the 900KB normalization threshold (so the
-      // publish path must re-encode to WebP) but under the 5MB upload cap.
-      const width = 1400;
-      const height = 1050;
-      const raw = randomBytes(width * height * 3);
-      imageBytes = await sharp(raw, { raw: { width, height, channels: 3 } })
-        .png()
-        .toBuffer();
-      expect(imageBytes.length).toBeGreaterThan(900 * 1024);
-      expect(imageBytes.length).toBeLessThan(5 * 1024 * 1024);
+  it('should serve the bounded, decodable WebP blob back via com.atproto.sync.getBlob', async () => {
+    const cid = thumbnail.content.ref.$link;
 
-      const file = await createFile(app, userToken, {
-        fileName: `image-blob-${testRunId}.png`,
-        fileSize: imageBytes.length,
-        mimeType: 'image/png',
-      });
-      imageFileId = file.id;
-      expect(imageFileId).toBeDefined();
+    const blobResponse = await fetch(
+      `${TESTING_PDS_URL}/xrpc/com.atproto.sync.getBlob?did=${encodeURIComponent(
+        userDid,
+      )}&cid=${encodeURIComponent(cid)}`,
+    );
+    expect(blobResponse.status).toBe(200);
 
-      // The e2e harness has no object storage, so stage the bytes where the
-      // local file driver reads them (tests share the API container's
-      // filesystem) and point the record's stored path at that key.
-      await fs.mkdir('./files', { recursive: true });
-      await fs.writeFile(seededImageFile, imageBytes);
+    const blobBytes = Buffer.from(await blobResponse.arrayBuffer());
+    // Bounded: exactly the size the record advertises, and under the ceiling.
+    expect(blobBytes.length).toBe(thumbnail.content.size);
+    expect(blobBytes.length).toBeLessThanOrEqual(900 * 1024);
 
-      pgClient = new Client({
-        host: process.env.DATABASE_HOST,
-        port: parseInt(process.env.DATABASE_PORT || '5432', 10),
-        user: process.env.DATABASE_USERNAME,
-        password: process.env.DATABASE_PASSWORD,
-        database: process.env.DATABASE_NAME,
-      });
-      await pgClient.connect();
-      const updateResult = await pgClient.query(
-        `UPDATE "tenant_${TESTING_TENANT_ID}"."files" SET "path" = $1 WHERE "id" = $2`,
-        [seededImageKey, imageFileId],
-      );
-      expect(updateResult.rowCount).toBe(1);
-    });
-  });
-
-  describe('3. Publish an event with the image and verify the PDS record', () => {
-    it('should create a public event with the image and publish it to the PDS', async () => {
-      const event = await createEvent(app, userToken, {
-        name: eventName,
-        description: 'Event to verify image blob publishing',
-        type: EventType.InPerson,
-        location: 'Blob Test Location',
-        maxAttendees: 50,
-        visibility: EventVisibility.Public,
-        status: EventStatus.Published,
-        startDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
-        endDate: new Date(
-          Date.now() + 7 * 24 * 60 * 60 * 1000 + 2 * 60 * 60 * 1000,
-        ).toISOString(),
-        categories: [],
-        timeZone: 'America/New_York',
-        image: { id: imageFileId },
-      });
-      expect(event.slug).toBeDefined();
-      eventSlug = event.slug;
-
-      // Publishing runs during creation but poll to absorb any async lag.
-      let rkey: string | undefined;
-      for (let attempt = 0; attempt < 15 && !rkey; attempt++) {
-        await waitForBackend(2000);
-        const eventResponse = await serverApp
-          .get(`/api/events/${eventSlug}`)
-          .set('Authorization', `Bearer ${userToken}`);
-        expect(eventResponse.status).toBe(200);
-        if (eventResponse.body.atprotoRkey) {
-          rkey = eventResponse.body.atprotoRkey;
-        }
-      }
-
-      expect(rkey).toBeDefined();
-      eventRkey = rkey as string;
-      console.log(`Event published to PDS with rkey: ${eventRkey}`);
-    });
-
-    it('should reference the image via a media[] thumbnail blob with no URL baked in', async () => {
-      const pdsResponse = await request(TESTING_PDS_URL)
-        .get(
-          `/xrpc/com.atproto.repo.getRecord?repo=${userDid}&collection=community.lexicon.calendar.event&rkey=${eventRkey}`,
-        )
-        .set('Accept', 'application/json');
-      expect(pdsResponse.status).toBe(200);
-
-      const record = pdsResponse.body.value;
-      expect(record.name).toBe(eventName);
-
-      // media[]: exactly one thumbnail entry in the ecosystem shape.
-      expect(Array.isArray(record.media)).toBe(true);
-      const thumbnails = record.media.filter(
-        (m: any) => m.role === 'thumbnail',
-      );
-      expect(thumbnails).toHaveLength(1);
-      const thumbnail = thumbnails[0];
-
-      // content is a real blob ref, re-encoded to WebP (source was >900KB) and
-      // under the size ceiling.
-      expect(thumbnail.content?.$type).toBe('blob');
-      expect(thumbnail.content?.ref?.$link).toBeTruthy();
-      expect(thumbnail.content?.mimeType).toBe('image/webp');
-      expect(thumbnail.content?.size).toBeGreaterThan(0);
-      expect(thumbnail.content?.size).toBeLessThanOrEqual(900 * 1024);
-
-      // alt defaults to the event name; aspect_ratio is the final dimensions
-      // (1400x1050 is under the 2048 edge cap, so unchanged).
-      expect(thumbnail.alt).toBe(eventName);
-      expect(thumbnail.aspect_ratio).toEqual({ width: 1400, height: 1050 });
-
-      // The source key lives in the openMeetMeta extension, not the media
-      // entry; the legacy bespoke field is gone.
-      expect(record.openMeetMeta?.imageSourceKey).toBe(seededImageKey);
-      expect(record.openMeetMedia).toBeUndefined();
-
-      // No URL is baked into the record for the image.
-      const imageUri = (record.uris ?? []).find(
-        (u: any) => u.name === 'Event Image',
-      );
-      expect(imageUri).toBeUndefined();
-    });
-
-    it('should serve the blob bytes back via com.atproto.sync.getBlob', async () => {
-      const pdsResponse = await request(TESTING_PDS_URL)
-        .get(
-          `/xrpc/com.atproto.repo.getRecord?repo=${userDid}&collection=community.lexicon.calendar.event&rkey=${eventRkey}`,
-        )
-        .set('Accept', 'application/json');
-      expect(pdsResponse.status).toBe(200);
-      const thumbnail = pdsResponse.body.value.media.find(
-        (m: any) => m.role === 'thumbnail',
-      );
-      const cid = thumbnail.content.ref.$link;
-
-      const blobResponse = await fetch(
-        `${TESTING_PDS_URL}/xrpc/com.atproto.sync.getBlob?did=${encodeURIComponent(
-          userDid,
-        )}&cid=${encodeURIComponent(cid)}`,
-      );
-      expect(blobResponse.status).toBe(200);
-
-      const blobBytes = Buffer.from(await blobResponse.arrayBuffer());
-      expect(blobBytes.length).toBeGreaterThan(0);
-      expect(blobBytes.length).toBe(thumbnail.content.size);
-
-      // WebP magic bytes: RIFF....WEBP -- the blob really is the re-encoded
-      // WebP image, independent of whatever content-type header the PDS sets.
-      expect(blobBytes.subarray(0, 4).toString('ascii')).toBe('RIFF');
-      expect(blobBytes.subarray(8, 12).toString('ascii')).toBe('WEBP');
-      console.log(
-        `getBlob served ${blobBytes.length}B webp (content-type: ${blobResponse.headers.get(
-          'content-type',
-        )})`,
-      );
-    });
+    // Decodable WebP: RIFF....WEBP magic bytes, and sharp can read its
+    // dimensions back (independent of the PDS content-type header).
+    expect(blobBytes.subarray(0, 4).toString('ascii')).toBe('RIFF');
+    expect(blobBytes.subarray(8, 12).toString('ascii')).toBe('WEBP');
+    const meta = await sharp(blobBytes).metadata();
+    expect(meta.format).toBe('webp');
+    expect(meta.width).toBe(sourceWidth);
+    expect(meta.height).toBe(sourceHeight);
   });
 });


### PR DESCRIPTION
## Problem

Event images written into federated `community.lexicon.calendar.event` records were baked as non-portable, environment-dependent URLs — `https://api.openmeet.net/<key>` under the current presigned-S3 file driver (which 404s: there is no GET-by-key route), and raw CloudFront before that. These records live **immutably** in users' PDS repos, so a broken or non-portable image URL can never be rewritten.

## Change

Upload the event image to the **owner's PDS as a content-addressed blob** and reference it from the record via the ecosystem **`media[]` convention** — no URL is baked into the record at all.

- **`media[]` shape.** The record carries a `media` array whose `thumbnail` entry is `{ role: 'thumbnail', content: <blob ref>, alt, aspect_ratio: { width, height } }`. This is the same shape other calendar-event implementations already write (see lexicon-community/lexicon#78), so consumers read our images with the same code path. `alt` (optional in the ecosystem shape) defaults to the event name as an accessibility fallback. Foreign entries another app may have written (for example a `header`) are preserved on republish; only our own `thumbnail` entry is replaced.
- **No URL in the record.** The bytes live in the same portable substrate as the immutable record (user-owned, served by the PDS), and the blob ref pins them against PDS garbage collection. URL construction is now a **render-time concern**: a consumer builds a `getBlob`/CDN URL from the blob ref and the owner's DID when displaying the event. Because nothing environment-specific is stored, the record can never carry a dead URL again.
- **CDN is a display-side config.** Fronting the public `getBlob` endpoint with a CDN is now purely a rendering choice for whoever displays the event; it is no longer baked into federated records, so the `BLOB_PUBLIC_BASE_URL` server setting is removed.
- **WebP normalization with an enforced ceiling.** Images ≤ 900KB upload byte-for-byte (preserving small GIFs/PNGs exactly); larger ones are auto-oriented, resized to a longest edge of 2048, and re-encoded to WebP with a stepped quality search, then a bounded descending fallback ladder (later rungs flatten alpha, which WebP encodes losslessly and which can otherwise defeat lossy compression). If nothing fits, the event publishes without an image — an over-ceiling blob is never uploaded. The final pixel dimensions populate `aspect_ratio`.
- **Legacy URL images self-heal.** Rows that stored a full `http(s)` image URL are re-hosted: the URL is fetched server-side (image content-types only, 10MB cap enforced by streaming the download with mid-stream abort, ~10s timeout) and uploaded as a blob rather than baked back in. On any failure the event simply publishes without an image.
- **Local file driver supported.** The blob pipeline can now read image bytes under the local file driver too (dev/CI environments), which previously published events without their images.

## Tests

- Unit — `event-image-blob.service.spec.ts`: byte-for-byte passthrough with dimension capture, WebP re-encode/resize, the high-entropy-RGBA ceiling case (fits or skips, never oversized), local-driver disk read, external-URL re-host, streaming abort on a lying Content-Length, and failure fallbacks (non-image, oversize, network error).
- Unit — `bluesky.service.spec.ts`: `media[]` thumbnail shape (role/content/alt/aspect_ratio), foreign `header` entry surviving republish, thumbnail removal when the image is cleared, `openMeetMeta.imageSourceKey`, legacy full-URL re-host, publish-without-image on upload failure, and the unknown-field round-trip.
- End-to-end — `test/atproto/atproto-event-image-blob.e2e-spec.ts` (devnet stack): publishes an event with an oversized image through a **real** `uploadBlob` + `putRecord`, then reads the PDS back directly — asserts the `media[]` thumbnail entry, `openMeetMeta.imageSourceKey`, no image URL in `uris[]`, and round-trips the blob via `com.atproto.sync.getBlob` (200, size match, WebP magic bytes).

## Rollout

Deploy; there are no infra prerequisites. Previously-published broken records self-heal on the next republish by their owner (the image is re-uploaded as a blob and the dead URL is dropped).

## Status

**Draft — do not merge yet.** Holding for review of the media architecture direction before landing.

Live-response surfaces (embeds, OG tags, appview JSON) still emit the dead `api.openmeet.net/<key>` from the same cutover regression; tracked separately (those are ephemeral responses, not federated-record paths).
