### PR TITLE
fix(event-series): return 403 not 401 when a non-owner updates/deletes a series

### DIFF
--- a/src/event-series/services/event-series.service.permission.spec.ts
+++ b/src/event-series/services/event-series.service.permission.spec.ts
@@ -1,0 +1,90 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { EventSeriesService } from './event-series.service';
+import { RecurrencePatternService } from './recurrence-pattern.service';
+import { EventManagementService } from '../../event/services/event-management.service';
+import { EventQueryService } from '../../event/services/event-query.service';
+import { TenantConnectionService } from '../../tenant/tenant.service';
+import { EventSeriesEntity } from '../infrastructure/persistence/relational/entities/event-series.entity';
+
+/**
+ * Regression guard: a non-owner update/delete must return 403 ForbiddenException
+ * (authenticated but not permitted), NOT 401. A 401 made the frontend axios
+ * interceptor treat it as an expired session, refresh the token, and replay the
+ * request forever (~5 req/s self-DoS). This exercises the REAL service (no
+ * jest.mock of the service under test, unlike event-series.service.spec.ts).
+ */
+describe('EventSeriesService — ownership guards', () => {
+  let service: EventSeriesService;
+  let module: TestingModule;
+  let mockRepo: any;
+
+  const seriesOwnedByAnotherUser = {
+    id: 1,
+    slug: 'someone-elses-series',
+    name: 'Someone Else\'s Series',
+    user: { id: 999 },
+  };
+
+  beforeEach(async () => {
+    mockRepo = { save: jest.fn(), delete: jest.fn() };
+
+    module = await Test.createTestingModule({
+      providers: [
+        EventSeriesService,
+        {
+          provide: RecurrencePatternService,
+          useValue: { validateRecurrenceRule: jest.fn().mockReturnValue(true) },
+        },
+        { provide: EventManagementService, useValue: { remove: jest.fn() } },
+        {
+          provide: EventQueryService,
+          useValue: { findEventsBySeriesSlug: jest.fn().mockResolvedValue([[]]) },
+        },
+        { provide: REQUEST, useValue: { tenantId: 'test-tenant' } },
+        {
+          provide: TenantConnectionService,
+          useValue: {
+            getTenantConnection: jest.fn().mockResolvedValue({
+              getRepository: () => mockRepo,
+            }),
+          },
+        },
+        { provide: getRepositoryToken(EventSeriesEntity), useValue: mockRepo },
+        { provide: DataSource, useValue: { getRepository: () => mockRepo } },
+      ],
+    }).compile();
+
+    service = await module.resolve<EventSeriesService>(EventSeriesService);
+    // The ownership check runs right after findBySlug; stub it so we exercise
+    // the guard, not the lookup.
+    jest
+      .spyOn(service, 'findBySlug')
+      .mockResolvedValue(seriesOwnedByAnotherUser as any);
+  });
+
+  afterEach(async () => {
+    if (module) {
+      await module.close();
+    }
+    jest.restoreAllMocks();
+  });
+
+  it('update() throws ForbiddenException (403) for a non-owner and does not persist', async () => {
+    // caller userId 1 != owner userId 999
+    const promise = service.update('someone-elses-series', {} as any, 1, 'test-tenant');
+    await expect(promise).rejects.toBeInstanceOf(ForbiddenException);
+    await expect(promise.catch((e) => e.getStatus())).resolves.toBe(403);
+    expect(mockRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('delete() throws ForbiddenException (403) for a non-owner and does not delete', async () => {
+    const promise = service.delete('someone-elses-series', 1, false, 'test-tenant');
+    await expect(promise).rejects.toBeInstanceOf(ForbiddenException);
+    await expect(promise.catch((e) => e.getStatus())).resolves.toBe(403);
+    expect(mockRepo.delete).not.toHaveBeenCalled();
+  });
+});

--- a/src/event-series/services/event-series.service.ts
+++ b/src/event-series/services/event-series.service.ts
@@ -5,7 +5,7 @@ import {
   Inject,
   forwardRef,
   Logger,
-  UnauthorizedException,
+  ForbiddenException,
   Scope,
 } from '@nestjs/common';
 import { EventSeriesEntity } from '../infrastructure/persistence/relational/entities/event-series.entity';
@@ -927,7 +927,7 @@ export class EventSeriesService {
 
       // Check if user has permission to update the series
       if (!series.user || series.user.id !== userId) {
-        throw new UnauthorizedException(
+        throw new ForbiddenException(
           'You do not have permission to update this series',
         );
       }
@@ -999,7 +999,7 @@ export class EventSeriesService {
 
       // Check if user has permission to delete the series
       if (!series.user || series.user.id !== userId) {
-        throw new UnauthorizedException(
+        throw new ForbiddenException(
           'You do not have permission to delete this series',
         );
       }


### PR DESCRIPTION
## Problem

`EventSeriesService.update()` and `.delete()` throw `UnauthorizedException`
(HTTP **401**) when the caller isn't the series owner. But the caller *is*
authenticated — they just lack permission, which is **403 Forbidden**.

The wrong status had a real operational cost. The web client's axios
interceptor treats every 401 as an expired session, so it refreshes the token
and replays the request. When the refresh **succeeds** but the request still
401s (a permission failure, not an expired token), the client loops
indefinitely (~5 req/s), driving a production error spike.

## Fix

Return `ForbiddenException` (403) from both ownership checks. This is the
correct HTTP semantics **and** a server-side circuit breaker: the interceptor
only enters the refresh/replay path on 401, so a 403 falls straight through
and cannot loop — even with the tab left open.

The companion frontend guard is in `openmeet-platform` (branch
`fix/axios-401-refresh-retry-loop`); either fix alone stops the loop, both is
belt-and-suspenders.

## Verification

- `event-series.service.permission.spec.ts` (new): non-owner `update`/`delete`
  → 403, and no write/delete is issued. Exercises the **real** service (the
  existing spec auto-mocks it).
- `npx jest src/event-series/services/` → 12 suites / 65 tests pass.
- `tsc --noEmit`: zero errors in the changed files.