### PR TITLE
feat(event-series): let group admins/owners manage their group's series

### DIFF
--- a/src/event-series/event-series.module.ts
+++ b/src/event-series/event-series.module.ts
@@ -9,6 +9,7 @@ import { RecurrencePatternService } from './services/recurrence-pattern.service'
 import { EventEntity } from '../event/infrastructure/persistence/relational/entities/event.entity';
 import { TenantModule } from '../tenant/tenant.module';
 import { UserModule } from '../user/user.module';
+import { GroupMemberModule } from '../group-member/group-member.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { UserModule } from '../user/user.module';
     forwardRef(() => EventModule),
     TenantModule,
     forwardRef(() => UserModule),
+    forwardRef(() => GroupMemberModule),
   ],
   controllers: [EventSeriesController],
   providers: [

--- a/src/event-series/services/event-series-occurrence.permission.spec.ts
+++ b/src/event-series/services/event-series-occurrence.permission.spec.ts
@@ -1,0 +1,123 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { EventSeriesOccurrenceService } from './event-series-occurrence.service';
+import { EventSeriesService } from './event-series.service';
+import { RecurrencePatternService } from './recurrence-pattern.service';
+import { EventManagementService } from '../../event/services/event-management.service';
+import { EventQueryService } from '../../event/services/event-query.service';
+import { UserService } from '../../user/user.service';
+import { TenantConnectionService } from '../../tenant/tenant.service';
+import { GroupMemberService } from '../../group-member/group-member.service';
+
+/**
+ * updateFutureOccurrences() must enforce the same series-management
+ * authorization as update()/delete() (owner, or MANAGE_EVENTS on the series'
+ * group). This wires the REAL EventSeriesService into the REAL occurrence
+ * service so the shared assertCanManageSeries runs for real; only its
+ * collaborators are mocked. A caller who passes authorization proceeds to the
+ * template lookup (which we stub to null → NotFoundException, proving the
+ * request got past the gate); an unauthorized caller is rejected with 403
+ * before any occurrence work happens.
+ */
+describe('EventSeriesOccurrenceService — updateFutureOccurrences authorization', () => {
+  let occurrenceService: EventSeriesOccurrenceService;
+  let module: TestingModule;
+  let mockGroupMemberService: { findGroupMemberByUserId: jest.Mock };
+  let mockEventQueryService: {
+    findEventBySlug: jest.Mock;
+    findEventsBySeriesSlug: jest.Mock;
+  };
+
+  const OWNER_ID = 999;
+  const OTHER_ID = 1;
+  const GROUP = { id: 168 };
+
+  const memberWith = (perms: string[]) => ({
+    groupRole: { groupPermissions: perms.map((name) => ({ name })) },
+  });
+
+  beforeEach(async () => {
+    mockGroupMemberService = { findGroupMemberByUserId: jest.fn() };
+    mockEventQueryService = {
+      // template lookup returns null → NotFoundException *after* the auth gate.
+      findEventBySlug: jest.fn().mockResolvedValue(null),
+      findEventsBySeriesSlug: jest.fn().mockResolvedValue([[]]),
+    };
+
+    module = await Test.createTestingModule({
+      providers: [
+        EventSeriesService,
+        EventSeriesOccurrenceService,
+        {
+          provide: RecurrencePatternService,
+          useValue: {
+            validateRecurrenceRule: jest.fn(),
+            generateOccurrences: jest.fn().mockReturnValue([]),
+          },
+        },
+        { provide: EventManagementService, useValue: { update: jest.fn(), remove: jest.fn() } },
+        { provide: EventQueryService, useValue: mockEventQueryService },
+        { provide: REQUEST, useValue: { tenantId: 'test-tenant' } },
+        {
+          provide: TenantConnectionService,
+          useValue: {
+            getTenantConnection: jest.fn().mockResolvedValue({
+              getRepository: () => ({}),
+            }),
+          },
+        },
+        { provide: GroupMemberService, useValue: mockGroupMemberService },
+        { provide: UserService, useValue: {} },
+      ],
+    }).compile();
+
+    occurrenceService = await module.resolve<EventSeriesOccurrenceService>(
+      EventSeriesOccurrenceService,
+    );
+    // Spy findBySlug on the exact EventSeriesService instance the occurrence
+    // service holds, so the real assertCanManageSeries runs against our series.
+    const seriesService = (occurrenceService as any)
+      .eventSeriesService as EventSeriesService;
+    jest.spyOn(seriesService, 'findBySlug').mockResolvedValue({
+      id: 1,
+      slug: 'the-series',
+      templateEventSlug: 'tmpl',
+      user: { id: OWNER_ID },
+      group: GROUP,
+    } as any);
+  });
+
+  afterEach(async () => {
+    if (module) {
+      await module.close();
+    }
+    jest.restoreAllMocks();
+  });
+
+  it('authorizes the series owner (proceeds past the gate to the template lookup)', async () => {
+    await expect(
+      occurrenceService.updateFutureOccurrences('the-series', '2026-01-01', {}, OWNER_ID),
+    ).rejects.toBeInstanceOf(NotFoundException);
+    expect(mockEventQueryService.findEventBySlug).toHaveBeenCalled();
+  });
+
+  it('authorizes a non-owner who holds MANAGE_EVENTS on the series group', async () => {
+    mockGroupMemberService.findGroupMemberByUserId.mockResolvedValue(
+      memberWith(['MANAGE_EVENTS']),
+    );
+    await expect(
+      occurrenceService.updateFutureOccurrences('the-series', '2026-01-01', {}, OTHER_ID),
+    ).rejects.toBeInstanceOf(NotFoundException);
+    expect(mockEventQueryService.findEventBySlug).toHaveBeenCalled();
+  });
+
+  it('rejects (403) an unauthorized caller and does no occurrence work', async () => {
+    mockGroupMemberService.findGroupMemberByUserId.mockResolvedValue(null);
+    const p = occurrenceService.updateFutureOccurrences('the-series', '2026-01-01', {}, OTHER_ID);
+    await expect(p).rejects.toBeInstanceOf(ForbiddenException);
+    await expect(p.catch((e) => e.getStatus())).resolves.toBe(403);
+    // Authorization short-circuits before any template / occurrence work.
+    expect(mockEventQueryService.findEventBySlug).not.toHaveBeenCalled();
+  });
+});

--- a/src/event-series/services/event-series-occurrence.service.ts
+++ b/src/event-series/services/event-series-occurrence.service.ts
@@ -1062,6 +1062,13 @@ export class EventSeriesOccurrenceService {
       // Get the series
       const series = await this.eventSeriesService.findBySlug(seriesSlug);
 
+      // Owner, or a group admin/owner with MANAGE_EVENTS on the series' group.
+      await this.eventSeriesService.assertCanManageSeries(
+        series,
+        userId,
+        'update',
+      );
+
       // Get the template event
       const templateEvent = series.templateEventSlug
         ? await this.eventQueryService.findEventBySlug(series.templateEventSlug)

--- a/src/event-series/services/event-series.service.permission.spec.ts
+++ b/src/event-series/services/event-series.service.permission.spec.ts
@@ -106,7 +106,7 @@ describe('EventSeriesService — ownership guards', () => {
       expect(mockGroupMemberService.findGroupMemberByUserId).not.toHaveBeenCalled();
     });
 
-    it('allows a non-owner who holds MANAGE_EVENTS on the series group', async () => {
+    it('allows a non-owner who holds MANAGE_EVENTS, WITHOUT transferring ownership to them', async () => {
       stubSeries({ withGroup: true });
       mockGroupMemberService.findGroupMemberByUserId.mockResolvedValue(
         memberWith(['MANAGE_EVENTS']),
@@ -115,6 +115,11 @@ describe('EventSeriesService — ownership guards', () => {
         service.update('the-series', {} as any, OTHER_ID, 'test-tenant'),
       ).resolves.toBeDefined();
       expect(mockRepo.save).toHaveBeenCalled();
+      // The persisted series must keep the ORIGINAL owner — an admin editing it
+      // must never become the owner (which would grant permanent owner-fast-path
+      // access even after losing MANAGE_EVENTS / leaving the group).
+      const saved = mockRepo.save.mock.calls[0][0];
+      expect(saved.user).toEqual({ id: OWNER_ID });
     });
 
     it('rejects (403) a group member lacking MANAGE_EVENTS', async () => {

--- a/src/event-series/services/event-series.service.permission.spec.ts
+++ b/src/event-series/services/event-series.service.permission.spec.ts
@@ -8,29 +8,52 @@ import { RecurrencePatternService } from './recurrence-pattern.service';
 import { EventManagementService } from '../../event/services/event-management.service';
 import { EventQueryService } from '../../event/services/event-query.service';
 import { TenantConnectionService } from '../../tenant/tenant.service';
+import { GroupMemberService } from '../../group-member/group-member.service';
 import { EventSeriesEntity } from '../infrastructure/persistence/relational/entities/event-series.entity';
 
 /**
- * Regression guard: a non-owner update/delete must return 403 ForbiddenException
- * (authenticated but not permitted), NOT 401. A 401 made the frontend axios
- * interceptor treat it as an expired session, refresh the token, and replay the
- * request forever (~5 req/s self-DoS). This exercises the REAL service (no
- * jest.mock of the service under test, unlike event-series.service.spec.ts).
+ * Authorization for modifying an existing event series.
+ *
+ * Modifying a series (update / delete) requires either:
+ *   - being the series owner (series.user.id), or
+ *   - holding MANAGE_EVENTS on the series' group (the same group permission
+ *     that governs event management).
+ *
+ * A standalone series (no group) stays owner-only. Non-owner, non-permitted
+ * callers get 403 Forbidden — never 401 (a 401 made the web client's axios
+ * interceptor treat it as an expired session and replay the request forever,
+ * a ~5 req/s self-DoS). Exercises the REAL service (event-series.service.spec.ts
+ * auto-mocks it).
  */
 describe('EventSeriesService — ownership guards', () => {
   let service: EventSeriesService;
   let module: TestingModule;
   let mockRepo: any;
+  let mockGroupMemberService: { findGroupMemberByUserId: jest.Mock };
 
-  const seriesOwnedByAnotherUser = {
-    id: 1,
-    slug: 'someone-elses-series',
-    name: 'Someone Else\'s Series',
-    user: { id: 999 },
-  };
+  const OWNER_ID = 999;
+  const OTHER_ID = 1;
+  const GROUP = { id: 168, slug: 'the-group' };
+
+  const memberWith = (perms: string[]) => ({
+    groupRole: { groupPermissions: perms.map((name) => ({ name })) },
+  });
+
+  const stubSeries = (opts: { withGroup: boolean }) =>
+    jest.spyOn(service, 'findBySlug').mockResolvedValue({
+      id: 1,
+      slug: 'the-series',
+      name: 'The Series',
+      user: { id: OWNER_ID },
+      group: opts.withGroup ? GROUP : null,
+    } as any);
 
   beforeEach(async () => {
-    mockRepo = { save: jest.fn(), delete: jest.fn() };
+    mockRepo = {
+      save: jest.fn().mockResolvedValue({ id: 1 }),
+      delete: jest.fn().mockResolvedValue({ affected: 1 }),
+    };
+    mockGroupMemberService = { findGroupMemberByUserId: jest.fn() };
 
     module = await Test.createTestingModule({
       providers: [
@@ -39,7 +62,7 @@ describe('EventSeriesService — ownership guards', () => {
           provide: RecurrencePatternService,
           useValue: { validateRecurrenceRule: jest.fn().mockReturnValue(true) },
         },
-        { provide: EventManagementService, useValue: { remove: jest.fn() } },
+        { provide: EventManagementService, useValue: { update: jest.fn(), remove: jest.fn() } },
         {
           provide: EventQueryService,
           useValue: { findEventsBySeriesSlug: jest.fn().mockResolvedValue([[]]) },
@@ -53,17 +76,18 @@ describe('EventSeriesService — ownership guards', () => {
             }),
           },
         },
+        { provide: GroupMemberService, useValue: mockGroupMemberService },
         { provide: getRepositoryToken(EventSeriesEntity), useValue: mockRepo },
         { provide: DataSource, useValue: { getRepository: () => mockRepo } },
       ],
     }).compile();
 
     service = await module.resolve<EventSeriesService>(EventSeriesService);
-    // The ownership check runs right after findBySlug; stub it so we exercise
-    // the guard, not the lookup.
-    jest
-      .spyOn(service, 'findBySlug')
-      .mockResolvedValue(seriesOwnedByAnotherUser as any);
+    // findBySlug is stubbed per-test, so the lazy repo never initializes; set it
+    // directly so the allowed paths (save/delete) have a repository to call.
+    (service as any).eventSeriesRepository = mockRepo;
+    // update() re-fetches via findById after save.
+    jest.spyOn(service, 'findById').mockResolvedValue({ id: 1, slug: 'the-series' } as any);
   });
 
   afterEach(async () => {
@@ -73,18 +97,82 @@ describe('EventSeriesService — ownership guards', () => {
     jest.restoreAllMocks();
   });
 
-  it('update() throws ForbiddenException (403) for a non-owner and does not persist', async () => {
-    // caller userId 1 != owner userId 999
-    const promise = service.update('someone-elses-series', {} as any, 1, 'test-tenant');
-    await expect(promise).rejects.toBeInstanceOf(ForbiddenException);
-    await expect(promise.catch((e) => e.getStatus())).resolves.toBe(403);
-    expect(mockRepo.save).not.toHaveBeenCalled();
+  describe('update()', () => {
+    it('allows the series owner (no group lookup needed)', async () => {
+      stubSeries({ withGroup: true });
+      await expect(
+        service.update('the-series', {} as any, OWNER_ID, 'test-tenant'),
+      ).resolves.toBeDefined();
+      expect(mockGroupMemberService.findGroupMemberByUserId).not.toHaveBeenCalled();
+    });
+
+    it('allows a non-owner who holds MANAGE_EVENTS on the series group', async () => {
+      stubSeries({ withGroup: true });
+      mockGroupMemberService.findGroupMemberByUserId.mockResolvedValue(
+        memberWith(['MANAGE_EVENTS']),
+      );
+      await expect(
+        service.update('the-series', {} as any, OTHER_ID, 'test-tenant'),
+      ).resolves.toBeDefined();
+      expect(mockRepo.save).toHaveBeenCalled();
+    });
+
+    it('rejects (403) a group member lacking MANAGE_EVENTS', async () => {
+      stubSeries({ withGroup: true });
+      mockGroupMemberService.findGroupMemberByUserId.mockResolvedValue(
+        memberWith(['MESSAGE_MEMBERS']),
+      );
+      const p = service.update('the-series', {} as any, OTHER_ID, 'test-tenant');
+      await expect(p).rejects.toBeInstanceOf(ForbiddenException);
+      await expect(p.catch((e) => e.getStatus())).resolves.toBe(403);
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects (403) a non-owner who is not a group member', async () => {
+      stubSeries({ withGroup: true });
+      mockGroupMemberService.findGroupMemberByUserId.mockResolvedValue(null);
+      await expect(
+        service.update('the-series', {} as any, OTHER_ID, 'test-tenant'),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects (403) a non-owner on a standalone (group-less) series without checking group perms', async () => {
+      stubSeries({ withGroup: false });
+      await expect(
+        service.update('the-series', {} as any, OTHER_ID, 'test-tenant'),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(mockGroupMemberService.findGroupMemberByUserId).not.toHaveBeenCalled();
+    });
   });
 
-  it('delete() throws ForbiddenException (403) for a non-owner and does not delete', async () => {
-    const promise = service.delete('someone-elses-series', 1, false, 'test-tenant');
-    await expect(promise).rejects.toBeInstanceOf(ForbiddenException);
-    await expect(promise.catch((e) => e.getStatus())).resolves.toBe(403);
-    expect(mockRepo.delete).not.toHaveBeenCalled();
+  describe('delete()', () => {
+    it('allows a non-owner who holds MANAGE_EVENTS on the series group', async () => {
+      stubSeries({ withGroup: true });
+      mockGroupMemberService.findGroupMemberByUserId.mockResolvedValue(
+        memberWith(['MANAGE_EVENTS']),
+      );
+      await expect(
+        service.delete('the-series', OTHER_ID, false, 'test-tenant'),
+      ).resolves.toBeUndefined();
+      expect(mockRepo.delete).toHaveBeenCalledWith(1);
+    });
+
+    it('rejects (403) a non-owner who is not a group member', async () => {
+      stubSeries({ withGroup: true });
+      mockGroupMemberService.findGroupMemberByUserId.mockResolvedValue(null);
+      const p = service.delete('the-series', OTHER_ID, false, 'test-tenant');
+      await expect(p).rejects.toBeInstanceOf(ForbiddenException);
+      await expect(p.catch((e) => e.getStatus())).resolves.toBe(403);
+      expect(mockRepo.delete).not.toHaveBeenCalled();
+    });
+
+    it('rejects (403) a non-owner on a standalone (group-less) series', async () => {
+      stubSeries({ withGroup: false });
+      await expect(
+        service.delete('the-series', OTHER_ID, false, 'test-tenant'),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(mockGroupMemberService.findGroupMemberByUserId).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/event-series/services/event-series.service.ts
+++ b/src/event-series/services/event-series.service.ts
@@ -21,6 +21,8 @@ import { TenantConnectionService } from '../../tenant/tenant.service';
 import { CreateSeriesFromEventDto } from '../dto/create-series-from-event.dto';
 import { Repository } from 'typeorm';
 import { CreateEventDto } from '../../event/dto/create-event.dto';
+import { GroupMemberService } from '../../group-member/group-member.service';
+import { GroupPermission } from '../../core/constants/constant';
 
 @Injectable({ scope: Scope.REQUEST })
 export class EventSeriesService {
@@ -35,8 +37,52 @@ export class EventSeriesService {
     private readonly eventQueryService: EventQueryService,
     @Inject(REQUEST) private readonly request: any,
     private readonly tenantConnectionService: TenantConnectionService,
+    @Inject(forwardRef(() => GroupMemberService))
+    private readonly groupMemberService: GroupMemberService,
   ) {
     // Initialize repository lazily when methods are called
+  }
+
+  /**
+   * Authorize a mutation of an existing series.
+   *
+   * The series owner may always manage it. For a series that belongs to a
+   * group, anyone holding MANAGE_EVENTS on that group may manage it too — the
+   * same group permission that governs event management, so group owners and
+   * admins can manage their group's series (not only the exact creator).
+   * Standalone (group-less) series remain owner-only.
+   *
+   * Throws ForbiddenException (403 — authenticated but not permitted) if none
+   * of these hold. It must be 403, not 401: a 401 makes the web client treat
+   * the response as an expired session and replay the request in a loop.
+   */
+  async assertCanManageSeries(
+    series: EventSeriesEntity,
+    userId: number,
+    action = 'modify',
+  ): Promise<void> {
+    // Series owner can always manage it.
+    if (series.user && series.user.id === userId) {
+      return;
+    }
+
+    // Group series: allow holders of MANAGE_EVENTS on the series' group.
+    if (series.group && series.group.id) {
+      const member = await this.groupMemberService.findGroupMemberByUserId(
+        series.group.id,
+        userId,
+      );
+      const groupPermissions = member?.groupRole?.groupPermissions || [];
+      if (
+        groupPermissions.some((p) => p.name === GroupPermission.ManageEvents)
+      ) {
+        return;
+      }
+    }
+
+    throw new ForbiddenException(
+      `You do not have permission to ${action} this series`,
+    );
   }
 
   @Trace('event-series.initializeRepository')
@@ -925,12 +971,8 @@ export class EventSeriesService {
       // Find the series by slug
       const series = await this.findBySlug(slug, tenantId);
 
-      // Check if user has permission to update the series
-      if (!series.user || series.user.id !== userId) {
-        throw new ForbiddenException(
-          'You do not have permission to update this series',
-        );
-      }
+      // Owner, or a group admin/owner with MANAGE_EVENTS on the series' group.
+      await this.assertCanManageSeries(series, userId, 'update');
 
       // If recurrence rule is provided, validate it
       if (updateEventSeriesDto.recurrenceRule) {
@@ -997,12 +1039,8 @@ export class EventSeriesService {
       // Find the series by slug
       const series = await this.findBySlug(slug, tenantId);
 
-      // Check if user has permission to delete the series
-      if (!series.user || series.user.id !== userId) {
-        throw new ForbiddenException(
-          'You do not have permission to delete this series',
-        );
-      }
+      // Owner, or a group admin/owner with MANAGE_EVENTS on the series' group.
+      await this.assertCanManageSeries(series, userId, 'delete');
 
       if (deleteEvents) {
         // Get all events in the series

--- a/src/event-series/services/event-series.service.ts
+++ b/src/event-series/services/event-series.service.ts
@@ -979,11 +979,12 @@ export class EventSeriesService {
         this.validateRecurrenceRule(updateEventSeriesDto.recurrenceRule);
       }
 
-      // Create an update object with the user relationship properly set
+      // Create an update object, preserving the original owner. Updating must
+      // NEVER transfer ownership: a non-owner group manager (MANAGE_EVENTS) may
+      // call update(), so the acting userId is not necessarily the owner.
       const updateData = {
         ...updateEventSeriesDto,
-        // Ensure the user relationship is maintained
-        user: { id: userId } as any,
+        user: series.user ? ({ id: series.user.id } as any) : series.user,
       };
 
       this.logger.log(


### PR DESCRIPTION
## Problem

Modifying an existing event series (`update`, `delete`, `updateFutureOccurrences`)
was gated on **strict series ownership** — only the exact account recorded as
`series.userId` could edit or delete it. So a **group admin**, or the group
owner when a *different* account created the series, was locked out of their
own group's series. The equivalent **event** endpoints already allow this via
the `MANAGE_EVENTS` group permission (`PermissionsGuard`, `context: 'event'`) —
the series endpoints just never got that treatment (they had no `@Permissions`
guard, only a hand-rolled owner check in the service).

`updateFutureOccurrences` had **no** ownership check at all.

## Fix

Add `EventSeriesService.assertCanManageSeries(series, userId, action)`:

- the **series owner** may always manage it;
- for a **group series**, anyone holding **`MANAGE_EVENTS`** on that group may
  too (the same permission that governs event management — so group owners and
  admins can manage the group's series, not only the exact creator);
- **standalone** (group-less) series stay **owner-only**.

Denials are `403 Forbidden` (authenticated but not permitted), never 401.
Wired into `update()`, `delete()`, and `updateFutureOccurrences()`.

## Verification

- New/extended `event-series.service.permission.spec.ts` (8 cases): owner
  allowed; non-owner with `MANAGE_EVENTS` allowed (update + delete); group
  member lacking it → 403; non-member → 403; standalone non-owner → 403 (no
  group lookup). Exercises the **real** service.
- `npx jest src/event-series/` → **20 suites / 113 tests pass**, no regressions.
- `tsc --noEmit`: zero errors in the changed source files.
- DI: `GroupMemberService` injected via `forwardRef`; `GroupMemberModule` /
  `GroupRoleModule` import no event/series module (no cycle); scopes compatible.

Builds on #592 (the 401→403 hotfix).