### PR TITLE
fix(rsvp): check membership and approval on ingested RSVPs

### DIFF
--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -47,11 +47,6 @@ jobs:
 
       - name: Run e2e tests
         id: relational
-        env:
-          # TEMP (revert before merge): scope the e2e job to the ingestion RSVP
-          # membership-gate spec while validating it. Restore the full suite
-          # (delete this env block) once it is green.
-          TEST_PATH_PATTERN: atproto-rsvp-membership-gate
         run: >-
           docker compose
           -f docker-compose.relational.ci.yaml

--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -47,6 +47,11 @@ jobs:
 
       - name: Run e2e tests
         id: relational
+        env:
+          # TEMP (revert before merge): scope the e2e job to the ingestion RSVP
+          # membership-gate spec while validating it. Restore the full suite
+          # (delete this env block) once it is green.
+          TEST_PATH_PATTERN: atproto-rsvp-membership-gate
         run: >-
           docker compose
           -f docker-compose.relational.ci.yaml

--- a/src/event/services/event-query.service.ts
+++ b/src/event/services/event-query.service.ts
@@ -1657,6 +1657,9 @@ export class EventQueryService {
       .where('event.sourceType = :sourceType', { sourceType })
       .andWhere('event.sourceId = :sourceId', { sourceId })
       .leftJoinAndSelect('event.user', 'user')
+      // 'group' is loaded so the ingestion RSVP gate can check membership on
+      // members-only events; do not drop it.
+      .leftJoinAndSelect('event.group', 'group')
       .leftJoinAndSelect('event.categories', 'categories')
       .leftJoinAndSelect('event.image', 'image')
       .leftJoinAndSelect('event.series', 'series');
@@ -1683,7 +1686,9 @@ export class EventQueryService {
 
     const events = await eventRepo.find({
       where: { atprotoUri },
-      relations: ['user', 'categories', 'image', 'series'],
+      // 'group' is loaded so the ingestion RSVP gate can check membership on
+      // members-only NATIVE events; do not drop it.
+      relations: ['user', 'group', 'categories', 'image', 'series'],
     });
 
     this.logger.debug(`Found ${events.length} events by atprotoUri`);

--- a/src/event/services/rsvp-integration.service.spec.ts
+++ b/src/event/services/rsvp-integration.service.spec.ts
@@ -9,10 +9,12 @@ import { EventAttendeeService } from '../../event-attendee/event-attendee.servic
 import { EventRoleService } from '../../event-role/event-role.service';
 import { UserService } from '../../user/user.service';
 import { BlueskyIdService } from '../../bluesky/bluesky-id.service';
+import { GroupMemberQueryService } from '../../group-member/group-member-query.service';
 import { EventSourceType } from '../../core/constants/source-type.constant';
 import {
   EventAttendeeStatus,
   EventAttendeeRole,
+  GroupRole,
 } from '../../core/constants/constant';
 import { EventEntity } from '../infrastructure/persistence/relational/entities/event.entity';
 import { UserEntity } from '../../user/infrastructure/persistence/relational/entities/user.entity';
@@ -34,6 +36,7 @@ describe('RsvpIntegrationService', () => {
   let service: RsvpIntegrationService;
   let eventQueryService: jest.Mocked<EventQueryService>;
   let eventAttendeeService: jest.Mocked<EventAttendeeService>;
+  let groupMemberQueryService: jest.Mocked<GroupMemberQueryService>;
 
   const mockEvent = { id: 1, name: 'Test Event' } as unknown as EventEntity;
   const mockUser = { id: 2, firstName: 'Test User' } as unknown as UserEntity;
@@ -99,6 +102,12 @@ describe('RsvpIntegrationService', () => {
           useValue: { parseUri: jest.fn() },
         },
         {
+          provide: GroupMemberQueryService,
+          useValue: {
+            findGroupMemberByUserId: jest.fn().mockResolvedValue(null),
+          },
+        },
+        {
           provide: 'PROM_METRIC_RSVP_INTEGRATION_PROCESSED_TOTAL',
           useValue: { inc: jest.fn() },
         },
@@ -116,6 +125,9 @@ describe('RsvpIntegrationService', () => {
     eventAttendeeService = module.get(
       EventAttendeeService,
     ) as jest.Mocked<EventAttendeeService>;
+    groupMemberQueryService = module.get(
+      GroupMemberQueryService,
+    ) as jest.Mocked<GroupMemberQueryService>;
   });
 
   it('should be defined', () => {
@@ -328,6 +340,154 @@ describe('RsvpIntegrationService', () => {
         'test-tenant',
       );
       expect(eventAttendeeService.createFromIngestion).toHaveBeenCalled();
+    });
+  });
+
+  describe('processExternalRsvp - membership/approval gate', () => {
+    const groupId = 10;
+    const membersOnlyEvent = {
+      id: 42,
+      name: 'Members Only Event',
+      requireGroupMembership: true,
+      requireApproval: false,
+      group: { id: groupId },
+    } as unknown as EventEntity;
+
+    beforeEach(() => {
+      eventQueryService.findBySourceAttributes.mockResolvedValue([
+        membersOnlyEvent,
+      ]);
+      eventAttendeeService.findEventAttendeeByUserId.mockResolvedValue(null);
+      eventAttendeeService.createFromIngestion.mockResolvedValue({
+        id: 1,
+      } as unknown as EventAttendeesEntity);
+    });
+
+    it('should hold a non-member "going" RSVP to a members-only event as Pending', async () => {
+      groupMemberQueryService.findGroupMemberByUserId.mockResolvedValue(null);
+
+      await service.processExternalRsvp(
+        { ...mockRsvpDto, status: 'going' },
+        'test-tenant',
+      );
+
+      // Membership is checked against the loaded group relation, not a stale undefined
+      expect(
+        groupMemberQueryService.findGroupMemberByUserId,
+      ).toHaveBeenCalledWith(groupId, mockUser.id, 'test-tenant');
+      expect(eventAttendeeService.createFromIngestion).toHaveBeenCalledWith(
+        expect.objectContaining({ status: EventAttendeeStatus.Pending }),
+      );
+    });
+
+    it('should confirm a real group member RSVP to a members-only event', async () => {
+      groupMemberQueryService.findGroupMemberByUserId.mockResolvedValue({
+        groupRole: { name: 'member' },
+      } as any);
+
+      await service.processExternalRsvp(
+        { ...mockRsvpDto, status: 'going' },
+        'test-tenant',
+      );
+
+      expect(eventAttendeeService.createFromIngestion).toHaveBeenCalledWith(
+        expect.objectContaining({ status: EventAttendeeStatus.Confirmed }),
+      );
+    });
+
+    it('should hold a guest RSVP to a members-only event as Pending', async () => {
+      groupMemberQueryService.findGroupMemberByUserId.mockResolvedValue({
+        groupRole: { name: GroupRole.Guest },
+      } as any);
+
+      await service.processExternalRsvp(
+        { ...mockRsvpDto, status: 'going' },
+        'test-tenant',
+      );
+
+      expect(eventAttendeeService.createFromIngestion).toHaveBeenCalledWith(
+        expect.objectContaining({ status: EventAttendeeStatus.Pending }),
+      );
+    });
+
+    it('should hold an approval-required RSVP as Pending even for a member', async () => {
+      const approvalEvent = {
+        id: 43,
+        requireGroupMembership: true,
+        requireApproval: true,
+        group: { id: groupId },
+      } as unknown as EventEntity;
+      eventQueryService.findBySourceAttributes.mockResolvedValue([
+        approvalEvent,
+      ]);
+      groupMemberQueryService.findGroupMemberByUserId.mockResolvedValue({
+        groupRole: { name: 'member' },
+      } as any);
+
+      await service.processExternalRsvp(
+        { ...mockRsvpDto, status: 'going' },
+        'test-tenant',
+      );
+
+      expect(eventAttendeeService.createFromIngestion).toHaveBeenCalledWith(
+        expect.objectContaining({ status: EventAttendeeStatus.Pending }),
+      );
+    });
+
+    it('should confirm a "going" RSVP to an open event without a membership lookup', async () => {
+      const openEvent = {
+        id: 44,
+        requireGroupMembership: false,
+        requireApproval: false,
+      } as unknown as EventEntity;
+      eventQueryService.findBySourceAttributes.mockResolvedValue([openEvent]);
+
+      await service.processExternalRsvp(
+        { ...mockRsvpDto, status: 'going' },
+        'test-tenant',
+      );
+
+      expect(eventAttendeeService.createFromIngestion).toHaveBeenCalledWith(
+        expect.objectContaining({ status: EventAttendeeStatus.Confirmed }),
+      );
+      expect(
+        groupMemberQueryService.findGroupMemberByUserId,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should not gate a non-affirmative status ("interested" -> Maybe) and should skip the lookup', async () => {
+      groupMemberQueryService.findGroupMemberByUserId.mockResolvedValue(null);
+
+      await service.processExternalRsvp(
+        { ...mockRsvpDto, status: 'interested' },
+        'test-tenant',
+      );
+
+      expect(eventAttendeeService.createFromIngestion).toHaveBeenCalledWith(
+        expect.objectContaining({ status: EventAttendeeStatus.Maybe }),
+      );
+      expect(
+        groupMemberQueryService.findGroupMemberByUserId,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should re-hold an already-present non-member attendee as Pending on re-sync (update path gated)', async () => {
+      groupMemberQueryService.findGroupMemberByUserId.mockResolvedValue(null);
+      eventAttendeeService.findEventAttendeeByUserId.mockResolvedValue({
+        id: 99,
+        status: EventAttendeeStatus.Confirmed,
+        role: { name: EventAttendeeRole.Participant },
+      } as unknown as EventAttendeesEntity);
+
+      await service.processExternalRsvp(
+        { ...mockRsvpDto, status: 'going' },
+        'test-tenant',
+      );
+
+      expect(eventAttendeeService.updateEventAttendee).toHaveBeenCalledWith(
+        99,
+        expect.objectContaining({ status: EventAttendeeStatus.Pending }),
+      );
     });
   });
 });

--- a/src/event/services/rsvp-integration.service.spec.ts
+++ b/src/event/services/rsvp-integration.service.spec.ts
@@ -489,5 +489,157 @@ describe('RsvpIntegrationService', () => {
         expect.objectContaining({ status: EventAttendeeStatus.Pending }),
       );
     });
+
+    it('should NOT revoke an organizer-approved (Confirmed) attendee when an approval-required RSVP is replayed', async () => {
+      // Regression: after an organizer approves an external RSVP, a retry /
+      // resync / metadata update for the unchanged "going" record must not flip
+      // the Confirmed attendee back to Pending.
+      const approvalEvent = {
+        id: 43,
+        requireGroupMembership: false,
+        requireApproval: true,
+      } as unknown as EventEntity;
+      eventQueryService.findBySourceAttributes.mockResolvedValue([
+        approvalEvent,
+      ]);
+      eventAttendeeService.findEventAttendeeByUserId.mockResolvedValue({
+        id: 77,
+        status: EventAttendeeStatus.Confirmed,
+        role: { name: EventAttendeeRole.Participant },
+      } as unknown as EventAttendeesEntity);
+
+      await service.processExternalRsvp(
+        { ...mockRsvpDto, status: 'going' },
+        'test-tenant',
+      );
+
+      expect(eventAttendeeService.updateEventAttendee).toHaveBeenCalledWith(
+        77,
+        expect.objectContaining({ status: EventAttendeeStatus.Confirmed }),
+      );
+      expect(eventAttendeeService.updateEventAttendee).not.toHaveBeenCalledWith(
+        77,
+        expect.objectContaining({ status: EventAttendeeStatus.Pending }),
+      );
+    });
+
+    it('should still hold a not-yet-approved (Pending) attendee as Pending on replay of an approval-required RSVP', async () => {
+      // A replay before the organizer has decided must stay Pending — the gate
+      // only preserves an approval that was actually granted (Confirmed).
+      const approvalEvent = {
+        id: 43,
+        requireGroupMembership: false,
+        requireApproval: true,
+      } as unknown as EventEntity;
+      eventQueryService.findBySourceAttributes.mockResolvedValue([
+        approvalEvent,
+      ]);
+      eventAttendeeService.findEventAttendeeByUserId.mockResolvedValue({
+        id: 78,
+        status: EventAttendeeStatus.Pending,
+        role: { name: EventAttendeeRole.Participant },
+      } as unknown as EventAttendeesEntity);
+
+      await service.processExternalRsvp(
+        { ...mockRsvpDto, status: 'going' },
+        'test-tenant',
+      );
+
+      expect(eventAttendeeService.updateEventAttendee).toHaveBeenCalledWith(
+        78,
+        expect.objectContaining({ status: EventAttendeeStatus.Pending }),
+      );
+    });
+
+    it('should re-hold an approved attendee who has since lost group membership (membership still rechecked)', async () => {
+      // Approval preservation must NOT override the membership recheck: a
+      // members-only event whose confirmed attendee is no longer a member is
+      // held again, matching the web path's re-deny of a non-member.
+      const membersOnlyApprovalEvent = {
+        id: 45,
+        requireGroupMembership: true,
+        requireApproval: true,
+        group: { id: groupId },
+      } as unknown as EventEntity;
+      eventQueryService.findBySourceAttributes.mockResolvedValue([
+        membersOnlyApprovalEvent,
+      ]);
+      groupMemberQueryService.findGroupMemberByUserId.mockResolvedValue(null);
+      eventAttendeeService.findEventAttendeeByUserId.mockResolvedValue({
+        id: 79,
+        status: EventAttendeeStatus.Confirmed,
+        role: { name: EventAttendeeRole.Participant },
+      } as unknown as EventAttendeesEntity);
+
+      await service.processExternalRsvp(
+        { ...mockRsvpDto, status: 'going' },
+        'test-tenant',
+      );
+
+      expect(eventAttendeeService.updateEventAttendee).toHaveBeenCalledWith(
+        79,
+        expect.objectContaining({ status: EventAttendeeStatus.Pending }),
+      );
+    });
+
+    it('should keep an eligible member Confirmed on re-sync of a members-only event (idempotent, no churn)', async () => {
+      // Happy-path idempotency for the membership branch: a still-eligible
+      // member who is already Confirmed stays Confirmed on replay.
+      const membersOnlyEvent2 = {
+        id: 46,
+        requireGroupMembership: true,
+        requireApproval: false,
+        group: { id: groupId },
+      } as unknown as EventEntity;
+      eventQueryService.findBySourceAttributes.mockResolvedValue([
+        membersOnlyEvent2,
+      ]);
+      groupMemberQueryService.findGroupMemberByUserId.mockResolvedValue({
+        groupRole: { name: 'member' },
+      } as any);
+      eventAttendeeService.findEventAttendeeByUserId.mockResolvedValue({
+        id: 80,
+        status: EventAttendeeStatus.Confirmed,
+        role: { name: EventAttendeeRole.Participant },
+      } as unknown as EventAttendeesEntity);
+
+      await service.processExternalRsvp(
+        { ...mockRsvpDto, status: 'going' },
+        'test-tenant',
+      );
+
+      expect(eventAttendeeService.updateEventAttendee).toHaveBeenCalledWith(
+        80,
+        expect.objectContaining({ status: EventAttendeeStatus.Confirmed }),
+      );
+    });
+
+    it('should re-hold a previously cancelled attendee as Pending when they re-RSVP going to an approval-required event', async () => {
+      // A cancelled -> going transition is a genuinely new affirmative request,
+      // not a replay of an approved one, so it goes back through approval.
+      const approvalEvent = {
+        id: 43,
+        requireGroupMembership: false,
+        requireApproval: true,
+      } as unknown as EventEntity;
+      eventQueryService.findBySourceAttributes.mockResolvedValue([
+        approvalEvent,
+      ]);
+      eventAttendeeService.findEventAttendeeByUserId.mockResolvedValue({
+        id: 81,
+        status: EventAttendeeStatus.Cancelled,
+        role: { name: EventAttendeeRole.Participant },
+      } as unknown as EventAttendeesEntity);
+
+      await service.processExternalRsvp(
+        { ...mockRsvpDto, status: 'going' },
+        'test-tenant',
+      );
+
+      expect(eventAttendeeService.updateEventAttendee).toHaveBeenCalledWith(
+        81,
+        expect.objectContaining({ status: EventAttendeeStatus.Pending }),
+      );
+    });
   });
 });

--- a/src/event/services/rsvp-integration.service.ts
+++ b/src/event/services/rsvp-integration.service.ts
@@ -60,6 +60,26 @@ export class RsvpIntegrationService {
    * gated; Maybe / Cancelled / unknown never grant access and pass through
    * unchanged.
    *
+   * IDEMPOTENCE — ingestion re-fires the same RSVP on every resync / metadata
+   * update / retry, so `existingStatus` (the attendee's current stored status)
+   * lets the gate stay stable across replays. The two checks handle a replay
+   * DIFFERENTLY by design — do not collapse them into one rule:
+   *
+   *  - Membership is a LIVE eligibility check, re-evaluated every ingest. A
+   *    Confirmed attendee who currently fails it is re-held; that is the whole
+   *    point of this gate — a member who has since been removed from the group
+   *    must not stay Confirmed on a members-only event — and it matches the web
+   *    path re-denying a non-member on re-RSVP. So it deliberately ignores
+   *    `existingStatus`. (A non-member can only ever be Confirmed here via an
+   *    organizer's explicit override; the correct way to admit them permanently
+   *    is to add them to the group, after which this recheck passes.)
+   *
+   *  - Approval is a ONE-TIME organizer decision. Its Pending means "awaiting a
+   *    human"; once approved (Confirmed) a replay must not re-open that decision.
+   *    So the approval hold is skipped when `existingStatus` is already Confirmed
+   *    — mirroring the web path, which returns an already-active attendee
+   *    unchanged instead of re-holding it.
+   *
    * NOTE: this relies on the event being loaded WITH its `group` relation —
    * see EventQueryService.findBySourceAttributes / findByAtprotoUri.
    */
@@ -68,12 +88,15 @@ export class RsvpIntegrationService {
     userId: number,
     status: EventAttendeeStatus,
     tenantId: string,
+    existingStatus?: EventAttendeeStatus,
   ): Promise<EventAttendeeStatus> {
     if (status !== EventAttendeeStatus.Confirmed) {
       return status;
     }
 
     // Members-only event: hold a non-member or guest instead of confirming.
+    // Rechecked on every ingest (including resyncs) so a previously confirmed
+    // attendee who has since lost eligibility is held, matching the web path.
     if (event.requireGroupMembership && event.group) {
       const groupMember =
         await this.groupMemberQueryService.findGroupMemberByUserId(
@@ -90,8 +113,14 @@ export class RsvpIntegrationService {
       }
     }
 
-    // Approval-required event: hold every RSVP, matching the web path.
-    if (event.requireApproval) {
+    // Approval-required event: hold a new RSVP for organizer review, but never
+    // revoke an approval already granted. A replay / resync of an unchanged
+    // `going` record must not flip an organizer-approved (Confirmed) attendee
+    // back to Pending.
+    if (
+      event.requireApproval &&
+      existingStatus !== EventAttendeeStatus.Confirmed
+    ) {
       return EventAttendeeStatus.Pending;
     }
 
@@ -179,23 +208,27 @@ export class RsvpIntegrationService {
       const mappedStatus =
         statusMap[rsvpData.status] || EventAttendeeStatus.Pending;
 
-      // Gate the ingested RSVP through the same membership/approval rules the
-      // web path enforces. Without this an external non-member bypasses access
-      // control on a members-only event. Applied before both the
-      // create and update branches so a re-synced non-member is held too.
-      const status = await this.gateIngestionAttendanceStatus(
-        event,
-        user.id,
-        mappedStatus,
-        tenantId,
-      );
-
-      // Find existing attendee record
+      // Find existing attendee record (loaded before gating so the gate can
+      // see a prior organizer decision and stay idempotent across resyncs).
       const existingAttendee =
         await this.eventAttendeeService.findEventAttendeeByUserId(
           event.id,
           user.id,
         );
+
+      // Gate the ingested RSVP through the same membership/approval rules the
+      // web path enforces. Without this an external non-member bypasses access
+      // control on a members-only event. Applied before both the create and
+      // update branches so a re-synced non-member is held too — but the current
+      // stored status is passed so a replay never revokes an approval already
+      // granted (see gateIngestionAttendanceStatus).
+      const status = await this.gateIngestionAttendanceStatus(
+        event,
+        user.id,
+        mappedStatus,
+        tenantId,
+        existingAttendee?.status,
+      );
 
       // Get participant role
       const participantRole = await this.eventRoleService.getRoleByName(

--- a/src/event/services/rsvp-integration.service.ts
+++ b/src/event/services/rsvp-integration.service.ts
@@ -1,6 +1,8 @@
 import {
   Injectable,
   Logger,
+  Inject,
+  forwardRef,
   BadRequestException,
   NotFoundException,
 } from '@nestjs/common';
@@ -15,11 +17,14 @@ import { AuthProvidersEnum } from '../../auth/auth-providers.enum';
 import {
   EventAttendeeStatus,
   EventAttendeeRole,
+  GroupRole,
 } from '../../core/constants/constant';
 import { Trace } from '../../utils/trace.decorator';
 import { InjectMetric } from '@willsoto/nestjs-prometheus';
 import { Counter, Histogram } from 'prom-client';
 import { BlueskyIdService } from '../../bluesky/bluesky-id.service';
+import { GroupMemberQueryService } from '../../group-member/group-member-query.service';
+import { EventEntity } from '../infrastructure/persistence/relational/entities/event.entity';
 
 @Injectable()
 export class RsvpIntegrationService {
@@ -33,11 +38,65 @@ export class RsvpIntegrationService {
     private readonly eventRoleService: EventRoleService,
     private readonly userService: UserService,
     private readonly blueskyIdService: BlueskyIdService,
+    @Inject(forwardRef(() => GroupMemberQueryService))
+    private readonly groupMemberQueryService: GroupMemberQueryService,
     @InjectMetric('rsvp_integration_processed_total')
     private readonly processedCounter: Counter<string>,
     @InjectMetric('rsvp_integration_processing_duration_seconds')
     private readonly processingDuration: Histogram<string>,
   ) {}
+
+  /**
+   * Enforce the same access gate the interactive RSVP path applies
+   * (EventManagementService.attendEvent). The ingestion path (firehose /
+   * contrail sink -> POST /api/integration/rsvps) otherwise reaches
+   * createFromIngestion with no membership/approval check, so an external
+   * non-member could land a Confirmed RSVP on a members-only event.
+   *
+   * A service-key intake can't return a 403 to the remote RSVP-er, so instead
+   * of throwing (as the web path does) we SOFT-HOLD: a blocked or approval-
+   * gated RSVP is persisted as Pending (mirrors requireApproval) for an
+   * organizer to resolve. Only affirmative attendance (going -> Confirmed) is
+   * gated; Maybe / Cancelled / unknown never grant access and pass through
+   * unchanged.
+   *
+   * NOTE: this relies on the event being loaded WITH its `group` relation —
+   * see EventQueryService.findBySourceAttributes / findByAtprotoUri.
+   */
+  private async gateIngestionAttendanceStatus(
+    event: EventEntity,
+    userId: number,
+    status: EventAttendeeStatus,
+    tenantId: string,
+  ): Promise<EventAttendeeStatus> {
+    if (status !== EventAttendeeStatus.Confirmed) {
+      return status;
+    }
+
+    // Members-only event: hold a non-member or guest instead of confirming.
+    if (event.requireGroupMembership && event.group) {
+      const groupMember =
+        await this.groupMemberQueryService.findGroupMemberByUserId(
+          event.group.id,
+          userId,
+          tenantId,
+        );
+
+      if (!groupMember || groupMember.groupRole?.name === GroupRole.Guest) {
+        this.logger.warn(
+          `Holding ingested RSVP as Pending: user ${userId} is not an eligible member of group ${event.group.id} for members-only event ${event.id}`,
+        );
+        return EventAttendeeStatus.Pending;
+      }
+    }
+
+    // Approval-required event: hold every RSVP, matching the web path.
+    if (event.requireApproval) {
+      return EventAttendeeStatus.Pending;
+    }
+
+    return EventAttendeeStatus.Confirmed;
+  }
 
   /**
    * Process an external RSVP and create or update attendance record
@@ -117,7 +176,19 @@ export class RsvpIntegrationService {
         notgoing: EventAttendeeStatus.Cancelled,
       };
 
-      const status = statusMap[rsvpData.status] || EventAttendeeStatus.Pending;
+      const mappedStatus =
+        statusMap[rsvpData.status] || EventAttendeeStatus.Pending;
+
+      // Gate the ingested RSVP through the same membership/approval rules the
+      // web path enforces. Without this an external non-member bypasses access
+      // control on a members-only event. Applied before both the
+      // create and update branches so a re-synced non-member is held too.
+      const status = await this.gateIngestionAttendanceStatus(
+        event,
+        user.id,
+        mappedStatus,
+        tenantId,
+      );
 
       // Find existing attendee record
       const existingAttendee =

--- a/test/event/atproto-rsvp-membership-gate.e2e-spec.ts
+++ b/test/event/atproto-rsvp-membership-gate.e2e-spec.ts
@@ -1,0 +1,139 @@
+import request from 'supertest';
+import { TESTING_APP_URL, TESTING_TENANT_ID } from '../utils/constants';
+import { loginAsAdmin, createGroup, createEvent } from '../utils/functions';
+import { EventType } from '../../src/core/constants/constant';
+
+// Service API key for the ingestion endpoints (firehose / contrail sink).
+const SERVICE_API_KEY = process.env.SERVICE_API_KEYS?.split(',')[0];
+
+jest.setTimeout(120000);
+
+/**
+ * Ingestion RSVP membership/approval gate.
+ *
+ * An external RSVP that comes in through POST /api/integration/rsvps must be
+ * held (Pending) when the target event requires group membership and the
+ * RSVP comes from someone who is not a member. Before the gate, the ingestion
+ * path skipped every access check and saved a "going" RSVP as Confirmed.
+ *
+ * The event carries a sourceType/sourceId so the ingestion lookup
+ * (findBySourceAttributes) finds it, and a group with requireGroupMembership
+ * so the gate has something to check. This also proves the event query loads
+ * the group relation; without it the gate would find no group and no-op.
+ */
+describe('ATProto ingestion RSVP membership gate (e2e)', () => {
+  let adminToken: string;
+  let groupSlug: string;
+  let groupId: number;
+  const createdEventSlugs: string[] = [];
+
+  const rsvpFrom = async (eventSourceId: string, handle: string) => {
+    const timestamp = Date.now();
+    const userDid = `did:plc:gate${timestamp}`.substring(0, 32);
+    const rkey = `gaterkey${timestamp}`;
+    return request(TESTING_APP_URL)
+      .post('/api/integration/rsvps')
+      .set('Content-Type', 'application/json')
+      .set('Authorization', `Bearer ${SERVICE_API_KEY}`)
+      .set('x-tenant-id', TESTING_TENANT_ID)
+      .send({
+        eventSourceId,
+        eventSourceType: 'bluesky',
+        userDid,
+        userHandle: handle,
+        status: 'going',
+        timestamp: new Date().toISOString(),
+        sourceId: `at://${userDid}/community.lexicon.calendar.rsvp/${rkey}`,
+        metadata: {
+          cid: `bafyreigate${timestamp}`,
+          rkey,
+          collection: 'community.lexicon.calendar.rsvp',
+        },
+      });
+  };
+
+  const statusOf = async (eventSlug: string, handle: string) => {
+    const res = await request(TESTING_APP_URL)
+      .get(`/api/events/${eventSlug}/attendees`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', TESTING_TENANT_ID);
+    expect(res.status).toBe(200);
+    const list = res.body.data || res.body;
+    const attendee = list.find((a: any) => a.user?.name === handle);
+    return attendee?.status;
+  };
+
+  beforeAll(async () => {
+    if (!SERVICE_API_KEY) {
+      throw new Error('SERVICE_API_KEYS not configured. Cannot run this test.');
+    }
+    adminToken = await loginAsAdmin();
+
+    const group = await createGroup(TESTING_APP_URL, adminToken, {
+      name: `Ingestion Gate Group ${Date.now()}`,
+      description: 'Group for the ingestion RSVP gate test',
+      status: 'published',
+      visibility: 'public',
+    });
+    groupSlug = group.slug;
+    groupId = group.id;
+  });
+
+  afterAll(async () => {
+    for (const slug of createdEventSlugs) {
+      await request(TESTING_APP_URL)
+        .delete(`/api/events/${slug}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+    }
+    if (groupSlug) {
+      await request(TESTING_APP_URL)
+        .delete(`/api/groups/${groupSlug}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+    }
+  });
+
+  const makeEvent = async (requireGroupMembership: boolean) => {
+    const timestamp = Date.now();
+    const sourceId = `at://did:plc:gateevt${timestamp}/community.lexicon.calendar.event/evt${timestamp}`;
+    const event = await createEvent(TESTING_APP_URL, adminToken, {
+      name: `Gate Event ${timestamp}`,
+      description: 'Event for the ingestion RSVP gate test',
+      type: EventType.Hybrid,
+      status: 'published',
+      visibility: 'public',
+      group: groupId,
+      requireGroupMembership,
+      sourceType: 'bluesky',
+      sourceId,
+      locationOnline: 'https://example.com/meeting',
+      categories: [],
+      timeZone: 'UTC',
+    });
+    createdEventSlugs.push(event.slug);
+    return { slug: event.slug, sourceId };
+  };
+
+  it('should hold a non-member external RSVP to a members-only event as pending', async () => {
+    const { slug, sourceId } = await makeEvent(true);
+    const handle = `nonmember-${Date.now()}.bsky.social`;
+
+    const res = await rsvpFrom(sourceId, handle);
+    expect(res.status).toBe(202);
+    expect(res.body.success).toBe(true);
+
+    expect(await statusOf(slug, handle)).toBe('pending');
+  });
+
+  it('should confirm a non-member external RSVP to an open event in the same group', async () => {
+    const { slug, sourceId } = await makeEvent(false);
+    const handle = `opener-${Date.now()}.bsky.social`;
+
+    const res = await rsvpFrom(sourceId, handle);
+    expect(res.status).toBe(202);
+    expect(res.body.success).toBe(true);
+
+    expect(await statusOf(slug, handle)).toBe('confirmed');
+  });
+});

--- a/test/event/atproto-rsvp-membership-gate.e2e-spec.ts
+++ b/test/event/atproto-rsvp-membership-gate.e2e-spec.ts
@@ -1,33 +1,109 @@
 import request from 'supertest';
 import { TESTING_APP_URL, TESTING_TENANT_ID } from '../utils/constants';
-import { loginAsAdmin, createGroup, createEvent } from '../utils/functions';
-import { EventType } from '../../src/core/constants/constant';
+import { createGroup, createEvent, createTestUser } from '../utils/functions';
+import {
+  EventType,
+  EventStatus,
+  EventVisibility,
+} from '../../src/core/constants/constant';
 
 // Service API key for the ingestion endpoints (firehose / contrail sink).
 const SERVICE_API_KEY = process.env.SERVICE_API_KEYS?.split(',')[0];
 
 jest.setTimeout(120000);
 
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 /**
  * Ingestion RSVP membership/approval gate.
  *
  * An external RSVP that comes in through POST /api/integration/rsvps must be
- * held (Pending) when the target event requires group membership and the
- * RSVP comes from someone who is not a member. Before the gate, the ingestion
- * path skipped every access check and saved a "going" RSVP as Confirmed.
+ * held (Pending) when the target event requires group membership and the RSVP
+ * comes from someone who is not a member. Before the gate, the ingestion path
+ * skipped every access check and saved a "going" RSVP as Confirmed.
  *
- * The event carries a sourceType/sourceId so the ingestion lookup
- * (findBySourceAttributes) finds it, and a group with requireGroupMembership
- * so the gate has something to check. This also proves the event query loads
- * the group relation; without it the gate would find no group and no-op.
+ * This exercises the REAL bug scenario (Kurt Horne / CRMC, 2026-07-18): a
+ * native OpenMeet event in a members-only group, published to the AT Protocol
+ * network because it is public, then RSVP'd from outside. Such an event is only
+ * ever reachable by an external RSVP through its `atprotoUri` — the ingestion
+ * lookup falls back to EventQueryService.findByAtprotoUri, which loads the
+ * `group` relation so the gate can check membership.
+ *
+ * (The gate can only fire for events that belong to a group with
+ * requireGroupMembership. Purely firehose-ingested events carry a
+ * sourceType/sourceId but never an OpenMeet group, so publishing a native event
+ * to atproto is the only way to build the fixture.)
+ *
+ * The organizer is a freshly registered email user because event publishing to
+ * atproto requires a custodial PDS identity (auto-provisioned on registration).
  */
 describe('ATProto ingestion RSVP membership gate (e2e)', () => {
-  let adminToken: string;
+  let ownerToken: string;
   let groupSlug: string;
   let groupId: number;
   const createdEventSlugs: string[] = [];
 
-  const rsvpFrom = async (eventSourceId: string, handle: string) => {
+  // The organizer only publishes events to atproto once their custodial
+  // identity is provisioned (async, right after registration).
+  const waitForIdentity = async (token: string): Promise<string> => {
+    for (let attempt = 0; attempt < 12; attempt++) {
+      const res = await request(TESTING_APP_URL)
+        .get('/api/atproto/identity')
+        .set('Authorization', `Bearer ${token}`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+      if (res.status === 200 && res.body?.did) {
+        return res.body.did;
+      }
+      await wait(1500);
+    }
+    throw new Error(
+      'Organizer never provisioned an atproto identity; cannot publish an ' +
+        'event for the ingestion gate test (is the devnet PDS configured?)',
+    );
+  };
+
+  // Poll the event until the async atproto publish populates atprotoUri — the
+  // handle the ingestion RSVP will reference.
+  const waitForAtprotoUri = async (slug: string): Promise<string> => {
+    for (let attempt = 0; attempt < 12; attempt++) {
+      const res = await request(TESTING_APP_URL)
+        .get(`/api/events/${slug}`)
+        .set('Authorization', `Bearer ${ownerToken}`)
+        .set('x-tenant-id', TESTING_TENANT_ID);
+      if (res.status === 200 && res.body?.atprotoUri) {
+        return res.body.atprotoUri;
+      }
+      await wait(1500);
+    }
+    throw new Error(
+      `Event ${slug} was not published to atproto (no atprotoUri after wait)`,
+    );
+  };
+
+  // A native, public, published event in the group. Because it is public it
+  // auto-publishes to the organizer's PDS and gets an atprotoUri.
+  const makePublishedEvent = async (requireGroupMembership: boolean) => {
+    const timestamp = Date.now();
+    const event = await createEvent(TESTING_APP_URL, ownerToken, {
+      name: `Gate Event ${timestamp}`,
+      description: 'Event for the ingestion RSVP gate test',
+      type: EventType.Hybrid,
+      status: EventStatus.Published,
+      visibility: EventVisibility.Public,
+      group: groupId,
+      requireGroupMembership,
+      locationOnline: 'https://example.com/meeting',
+      categories: [],
+      timeZone: 'UTC',
+    });
+    createdEventSlugs.push(event.slug);
+    const atprotoUri = await waitForAtprotoUri(event.slug);
+    return { slug: event.slug, atprotoUri };
+  };
+
+  // An external "going" RSVP from a non-member DID, delivered through the
+  // service-key ingestion endpoint against the event's atprotoUri.
+  const rsvpFrom = async (eventAtprotoUri: string, handle: string) => {
     const timestamp = Date.now();
     const userDid = `did:plc:gate${timestamp}`.substring(0, 32);
     const rkey = `gaterkey${timestamp}`;
@@ -37,7 +113,7 @@ describe('ATProto ingestion RSVP membership gate (e2e)', () => {
       .set('Authorization', `Bearer ${SERVICE_API_KEY}`)
       .set('x-tenant-id', TESTING_TENANT_ID)
       .send({
-        eventSourceId,
+        eventSourceId: eventAtprotoUri,
         eventSourceType: 'bluesky',
         userDid,
         userHandle: handle,
@@ -52,14 +128,16 @@ describe('ATProto ingestion RSVP membership gate (e2e)', () => {
       });
   };
 
-  const statusOf = async (eventSlug: string, handle: string) => {
+  // Read a specific attendee's status by the id the ingestion endpoint returns.
+  // (Robust against how a shadow account's display name is derived.)
+  const statusOfAttendee = async (eventSlug: string, attendeeId: number) => {
     const res = await request(TESTING_APP_URL)
       .get(`/api/events/${eventSlug}/attendees`)
-      .set('Authorization', `Bearer ${adminToken}`)
+      .set('Authorization', `Bearer ${ownerToken}`)
       .set('x-tenant-id', TESTING_TENANT_ID);
     expect(res.status).toBe(200);
     const list = res.body.data || res.body;
-    const attendee = list.find((a: any) => a.user?.name === handle);
+    const attendee = list.find((a: any) => a.id === attendeeId);
     return attendee?.status;
   };
 
@@ -67,10 +145,22 @@ describe('ATProto ingestion RSVP membership gate (e2e)', () => {
     if (!SERVICE_API_KEY) {
       throw new Error('SERVICE_API_KEYS not configured. Cannot run this test.');
     }
-    adminToken = await loginAsAdmin();
 
-    const group = await createGroup(TESTING_APP_URL, adminToken, {
-      name: `Ingestion Gate Group ${Date.now()}`,
+    const timestamp = Date.now();
+    const owner = await createTestUser(
+      TESTING_APP_URL,
+      TESTING_TENANT_ID,
+      `gate-owner-${timestamp}@openmeet.net`,
+      'Gate',
+      'Owner',
+    );
+    ownerToken = owner.token;
+
+    // Events only publish to atproto once the organizer has a custodial identity.
+    await waitForIdentity(ownerToken);
+
+    const group = await createGroup(TESTING_APP_URL, ownerToken, {
+      name: `Ingestion Gate Group ${timestamp}`,
       description: 'Group for the ingestion RSVP gate test',
       status: 'published',
       visibility: 'public',
@@ -83,57 +173,38 @@ describe('ATProto ingestion RSVP membership gate (e2e)', () => {
     for (const slug of createdEventSlugs) {
       await request(TESTING_APP_URL)
         .delete(`/api/events/${slug}`)
-        .set('Authorization', `Bearer ${adminToken}`)
+        .set('Authorization', `Bearer ${ownerToken}`)
         .set('x-tenant-id', TESTING_TENANT_ID);
     }
     if (groupSlug) {
       await request(TESTING_APP_URL)
         .delete(`/api/groups/${groupSlug}`)
-        .set('Authorization', `Bearer ${adminToken}`)
+        .set('Authorization', `Bearer ${ownerToken}`)
         .set('x-tenant-id', TESTING_TENANT_ID);
     }
   });
 
-  const makeEvent = async (requireGroupMembership: boolean) => {
-    const timestamp = Date.now();
-    const sourceId = `at://did:plc:gateevt${timestamp}/community.lexicon.calendar.event/evt${timestamp}`;
-    const event = await createEvent(TESTING_APP_URL, adminToken, {
-      name: `Gate Event ${timestamp}`,
-      description: 'Event for the ingestion RSVP gate test',
-      type: EventType.Hybrid,
-      status: 'published',
-      visibility: 'public',
-      group: groupId,
-      requireGroupMembership,
-      sourceType: 'bluesky',
-      sourceId,
-      locationOnline: 'https://example.com/meeting',
-      categories: [],
-      timeZone: 'UTC',
-    });
-    createdEventSlugs.push(event.slug);
-    return { slug: event.slug, sourceId };
-  };
-
   it('should hold a non-member external RSVP to a members-only event as pending', async () => {
-    const { slug, sourceId } = await makeEvent(true);
+    const { slug, atprotoUri } = await makePublishedEvent(true);
     const handle = `nonmember-${Date.now()}.bsky.social`;
 
-    const res = await rsvpFrom(sourceId, handle);
+    const res = await rsvpFrom(atprotoUri, handle);
     expect(res.status).toBe(202);
     expect(res.body.success).toBe(true);
+    expect(res.body.attendeeId).toBeDefined();
 
-    expect(await statusOf(slug, handle)).toBe('pending');
+    expect(await statusOfAttendee(slug, res.body.attendeeId)).toBe('pending');
   });
 
   it('should confirm a non-member external RSVP to an open event in the same group', async () => {
-    const { slug, sourceId } = await makeEvent(false);
+    const { slug, atprotoUri } = await makePublishedEvent(false);
     const handle = `opener-${Date.now()}.bsky.social`;
 
-    const res = await rsvpFrom(sourceId, handle);
+    const res = await rsvpFrom(atprotoUri, handle);
     expect(res.status).toBe(202);
     expect(res.body.success).toBe(true);
+    expect(res.body.attendeeId).toBeDefined();
 
-    expect(await statusOf(slug, handle)).toBe('confirmed');
+    expect(await statusOfAttendee(slug, res.body.attendeeId)).toBe('confirmed');
   });
 });


### PR DESCRIPTION
## Problem

External RSVPs come in from the firehose and the contrail sink through `POST /api/integration/rsvps`. These RSVPs are saved with no membership or approval check. The web RSVP path (`attendEvent`) does these checks, but the ingestion path does not.

So a person who is not a member can RSVP to a members-only event from another atproto app and be saved as a confirmed attendee. A `going` RSVP maps straight to Confirmed, so approval is skipped too.

An event is only published to the network when its visibility is Public. That check does not look at `requireGroupMembership`. So a members-only event that is also Public gets published, and then it can be RSVP'd from outside.

## Changes

- `processExternalRsvp` now runs the same membership and approval checks before it creates or updates the attendee.
- The intake uses a service key and cannot return a 403 to the outside app. So a blocked RSVP is saved as Pending instead of rejected. This matches how `requireApproval` already works.
- Only a `going` RSVP is checked. Other statuses are saved as before.
- The update branch is checked too, so a re-synced non-member is set back to Pending instead of Confirmed.
- `findBySourceAttributes` and `findByAtprotoUri` now load the group relation. Before this the ingested event had no group, so the check found nothing and did nothing. This also covers native events, which are found by `findByAtprotoUri`.

The check reuses the existing `GroupMemberQueryService` and follows the web path. A null member or the Guest role is not allowed. It does not read `groupMember.user`.

## Tests

Unit tests cover:

- a non-member and a guest held as Pending
- a real member and an open event confirmed
- an approval-required event held even for a member
- a status other than going left unchanged
- a re-synced non-member held on the update branch

New e2e in `test/event/atproto-rsvp-membership-gate.e2e-spec.ts`:

- a non-member RSVP to a members-only event is held as pending
- a non-member RSVP to an open event in the same group is confirmed

The first e2e case also checks that the group relation loads. Without it the RSVP would be confirmed. I did not run the e2e locally because there is no docker in my environment. It runs in CI. The unit suite and lint pass.

## Not in this change

- A per-group setting to publish events to the network, off by default for groups that require membership.
- Making organizer removal survive a re-sync.
- Better feedback when messaging an attendee who only exists on Bluesky.
