### PR TITLE
fix(atproto): dead-letter InvalidSwap conflicts instead of retrying forever

### DIFF
--- a/src/atproto-publisher/atproto-publisher.service.spec.ts
+++ b/src/atproto-publisher/atproto-publisher.service.spec.ts
@@ -552,6 +552,44 @@ describe('AtprotoPublisherService', () => {
       expect(result.action).toBe('conflict');
     });
 
+    // Regression for the InvalidSwap retry-loop: reproduce the error exactly
+    // as it reaches this service in production. BlueskyService re-wraps
+    // the XRPCError, so the message is 'Failed to create Bluesky event "…":
+    // Record was at <cid>' (no 'InvalidSwap' substring) and @atproto maps the
+    // HTTP 409 to status 400 (not 409) — the only reliable signal is the
+    // preserved XRPC error code. The old detection matched neither field, so
+    // the conflict re-threw and the scheduler retried the same doomed swap
+    // forever. Detection must key on the error code.
+    it('should return conflict for a re-wrapped InvalidSwap where only the error code survives', async () => {
+      const event = createMockEvent();
+      const mockIdentity = {
+        id: 1,
+        userUlid: 'user-ulid-123',
+        did: 'did:plc:testuser123',
+      } as UserAtprotoIdentityEntity;
+
+      atprotoIdentityService.ensureIdentityForUser.mockResolvedValue(
+        mockIdentity,
+      );
+      pdsSessionService.getSessionForUser.mockResolvedValue(mockSessionResult);
+
+      const conflictError = Object.assign(
+        new Error(
+          'Failed to create Bluesky event "WA Beaches and Backroads": ' +
+            'Record was at bafyreibqcjzzelrtosahftdlxtn2cznknazxokzuccfihgxhygxkog25bm',
+        ),
+        // Shape BlueskyService.createEventRecord now produces: the XRPC status
+        // (409 → 400 after @atproto's httpResponseCodeToEnum) and error code
+        // survive the re-wrap. Message deliberately lacks 'InvalidSwap'.
+        { status: 400, error: 'InvalidSwap' },
+      );
+      blueskyService.createEventRecord.mockRejectedValue(conflictError);
+
+      const result = await service.publishEvent(event, tenantId);
+
+      expect(result.action).toBe('conflict');
+    });
+
     it('should re-throw non-validation errors from BlueskyService', async () => {
       const event = createMockEvent();
       const mockIdentity = {

--- a/src/atproto-publisher/atproto-publisher.service.ts
+++ b/src/atproto-publisher/atproto-publisher.service.ts
@@ -331,10 +331,17 @@ export class AtprotoPublisherService {
       cid = result.cid;
       publishedRecord = result.record;
     } catch (error) {
-      // Handle swapRecord conflict (409 InvalidSwap)
+      // Handle swapRecord conflict (InvalidSwap). The PDS rejects an
+      // optimistic-concurrency mismatch with XRPC error code 'InvalidSwap' —
+      // match on that code, it is the only reliable signal. @atproto maps the
+      // HTTP 409 to ResponseType.InvalidRequest (400), so `.status === 409`
+      // never holds, and the human message is 'Record was at <cid>' (no
+      // 'InvalidSwap' substring). The status/message checks are kept only as
+      // defensive fallbacks.
       if (
         error instanceof Error &&
-        ((error as any).status === 409 ||
+        ((error as any).error === 'InvalidSwap' ||
+          (error as any).status === 409 ||
           error.message?.includes('InvalidSwap'))
       ) {
         this.logger.warn(

--- a/src/bluesky/bluesky.service.spec.ts
+++ b/src/bluesky/bluesky.service.spec.ts
@@ -874,6 +874,55 @@ describe('BlueskyService', () => {
       ).rejects.toThrow();
     });
 
+    it('should preserve the XRPC error code when putRecord fails with InvalidSwap', async () => {
+      // A swapRecord mismatch surfaces as an XRPCError: @atproto maps the HTTP
+      // 409 to status 400, the code lives in `.error`, and the human message
+      // is 'Record was at <cid>' (no 'InvalidSwap' substring). This re-wrap
+      // must carry that code through so AtprotoPublisherService can classify
+      // the conflict and the sync scheduler can dead-letter instead of looping
+      // the same doomed swap forever.
+      const event = {
+        name: 'WA Beaches and Backroads',
+        description: 'Test Description',
+        startDate: new Date('2023-12-01T12:00:00Z'),
+        endDate: new Date('2023-12-01T14:00:00Z'),
+        type: EventType.Hybrid,
+        status: EventStatus.Published,
+        createdAt: new Date('2023-11-01T00:00:00Z'),
+      } as EventEntity;
+
+      const did = 'test-did';
+      const handle = 'test.handle';
+      const tenantId = 'test-tenant';
+
+      mockAgentImplementation.com.atproto.repo.getRecord.mockRejectedValueOnce({
+        status: 404,
+      });
+      const invalidSwap = Object.assign(
+        new Error(
+          'Record was at bafyreibqcjzzelrtosahftdlxtn2cznknazxokzuccfihgxhygxkog25bm',
+        ),
+        { status: 400, error: 'InvalidSwap' },
+      );
+      mockAgentImplementation.com.atproto.repo.putRecord.mockRejectedValueOnce(
+        invalidSwap,
+      );
+
+      let thrown: any;
+      try {
+        await service.createEventRecord(event, did, handle, tenantId);
+      } catch (e) {
+        thrown = e;
+      }
+
+      expect(thrown).toBeDefined();
+      expect(thrown.message).toContain('Failed to create Bluesky event');
+      expect(thrown.message).toContain('Record was at');
+      // The conflict signal must survive the re-wrap.
+      expect(thrown.error).toBe('InvalidSwap');
+      expect(thrown.status).toBe(400);
+    });
+
     it('should use correct ATProto schema for geo locations ($type, latitude/longitude as strings, name)', async () => {
       // Arrange
       const event = {

--- a/src/bluesky/bluesky.service.ts
+++ b/src/bluesky/bluesky.service.ts
@@ -616,11 +616,19 @@ export class BlueskyService {
         errorObject: error,
       });
 
-      // Enhance error message for debugging
+      // Enhance error message for debugging, but preserve the underlying XRPC
+      // signal so callers can still classify recoverable failures after this
+      // re-wrap. In particular the optimistic-concurrency conflict (swapRecord
+      // mismatch) arrives as an XRPCError with error code 'InvalidSwap' and
+      // message 'Record was at <cid>' — neither survives a bare
+      // `new Error(msg)`, which is why AtprotoSyncScheduler retried it forever
+      // instead of dead-lettering.
       const enhancedError = new Error(
         `Failed to create Bluesky event "${event.name}": ${error.message}`,
-      );
+      ) as Error & { status?: unknown; error?: string };
       enhancedError.stack = error.stack;
+      enhancedError.status = error.status;
+      enhancedError.error = error.error;
       throw enhancedError;
     }
   }


### PR DESCRIPTION
## Problem

The ATProto pending-sync scheduler (`AtprotoSyncScheduler.handlePendingSyncRetry`) re-publishes any event flagged pending-sync every 5 minutes. On do-prod one event has been failing that republish with `InvalidSwap` on every single cycle for days — the stored `swapRecord` CID no longer matches the record on the PDS, so the compare-and-swap can never succeed. The PDS record itself is intact; this is API-side bookkeeping drift (pending-sync rows left with stale swap CIDs). Symptoms: continuous `ERROR` log spam and a wasted sync-lock cycle each run. Other tenants likely have similarly wedged events.

The code *already* has a dead-letter path for this: a `conflict` result makes the scheduler mark the event synced (a local-only write — no PDS mutation) to stop the loop and let the firehose reconcile. Two compounding defects meant that path never fired:

1. **Wrong fields checked.** `AtprotoPublisherService` classified conflicts via `status === 409` or a message containing `"InvalidSwap"`. But a real `@atproto` `XRPCError` maps HTTP 409 to `status` **400** (via `httpResponseCodeToEnum`), and the code lives in `.error` — the human `message` is `"Record was at <cid>"`. Neither check ever matched a real conflict.
2. **Signal stripped on re-wrap.** `BlueskyService.createEventRecord` caught the `XRPCError` and re-threw a bare `new Error(...)`, dropping `.status`/`.error` — so even a corrected check downstream had nothing to read.

The existing unit tests passed only because they hand-set `.status = 409` on a plain `Error`, a shape the real client never produces.

## Fix

- Detect conflicts on the XRPC error **code** (`error === 'InvalidSwap'`), keeping the status/message checks as defensive fallbacks.
- Preserve `.status` and `.error` on the enhanced error thrown by `createEventRecord` so the signal survives the re-wrap.

With the signal intact, a swap conflict returns `action: 'conflict'`, the scheduler marks the event synced, and the retry loop stops. No PDS write, no laundering a stale swap past the compare-and-swap.

## Tests

Adds a regression test at each layer that reproduces the **real** production error shape (status 400, code in `.error`, message `"Record was at <cid>"` with no `InvalidSwap` substring). Both fail on `main` and pass with the fix. Full suites for `bluesky.service`, `atproto-publisher.service`, and `atproto-sync-scheduler` are green (123 tests).

## Follow-ups (not in this PR)

- The same re-wrap also blunts the *validation-error* classification downstream (message no longer starts with the expected prefix). Sibling issue, left alone to keep this change tight.
- A general attempt/age bound on the pending-sync retry would dead-letter *any* perpetually-failing publish, not just swap conflicts — worth considering, though possibly mooted if publishing moves to Contrail.