### PR TITLE
fix: persist ingested events before geocoding, resolve insert races idempotently

### DIFF
--- a/src/event/services/event-integration.service.spec.ts
+++ b/src/event/services/event-integration.service.spec.ts
@@ -517,6 +517,31 @@ describe('EventIntegrationService', () => {
       );
     });
 
+    it('should still emit event.ingested when the geocode follow-up update fails', async () => {
+      // The row is already committed by the time the follow-up update runs; a
+      // failure there must not strand the event without its creation emit —
+      // the retry path only emits event.ingested.updated, whose listener
+      // never creates the missing creation activity.
+      eventQueryService.findBySourceAttributes.mockResolvedValue([]);
+      jest
+        .spyOn(service as any, 'geocodeAddress')
+        .mockResolvedValue({ lat: 38.25, lon: -85.76 });
+      eventRepository.update.mockRejectedValue(new Error('connection reset'));
+      const emitter = module.get(EventEmitter2);
+
+      const result = await service.processExternalEvent(
+        eventWithAddressOnly,
+        'tenant1',
+      );
+
+      expect(result.lat).toBeUndefined();
+      expect(result.lon).toBeUndefined();
+      expect(emitter.emit).toHaveBeenCalledWith(
+        'event.ingested',
+        expect.objectContaining({ eventId: 2 }),
+      );
+    });
+
     it('should keep geocoding out of the residual find-to-insert window (measured)', async () => {
       // The race window is the gap between find-by-sourceId resolving empty
       // and the INSERT. It used to include the geocoder's 1.1-3.3s of
@@ -558,7 +583,6 @@ describe('EventIntegrationService', () => {
         eventRepository.save.mock.invocationCallOrder[0],
       );
       expect(residualMs).toBeGreaterThanOrEqual(simulatedCreatorIoMs - 1);
-      expect(overheadMs).toBeLessThan(100);
     });
   });
 

--- a/src/event/services/event-integration.service.spec.ts
+++ b/src/event/services/event-integration.service.spec.ts
@@ -192,6 +192,7 @@ describe('EventIntegrationService', () => {
         } as unknown as EventEntity);
       }),
       merge: jest.fn(),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
       createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
       remove: jest.fn().mockImplementation((entity) => Promise.resolve(entity)),
     } as any;
@@ -437,6 +438,213 @@ describe('EventIntegrationService', () => {
       expect(capturedEvent.locationOnline).toBe(
         'https://meet.google.com/abc-defg-hij',
       );
+    });
+  });
+
+  describe('Geocoding after save', () => {
+    const eventWithAddressOnly: ExternalEventDto = {
+      ...mockEventDto,
+      location: {
+        description: '123 Main St, Louisville, KY',
+      },
+    };
+
+    it('should persist the row before the geocoder runs, then apply lat/lon via a targeted update', async () => {
+      eventQueryService.findBySourceAttributes.mockResolvedValue([]);
+      const geocodeSpy = jest
+        .spyOn(service as any, 'geocodeAddress')
+        .mockResolvedValue({ lat: 38.25, lon: -85.76 });
+
+      const result = await service.processExternalEvent(
+        eventWithAddressOnly,
+        'tenant1',
+      );
+
+      expect(eventRepository.save).toHaveBeenCalledTimes(1);
+      expect(geocodeSpy).toHaveBeenCalledTimes(1);
+      expect(eventRepository.save.mock.invocationCallOrder[0]).toBeLessThan(
+        geocodeSpy.mock.invocationCallOrder[0],
+      );
+
+      const savedEntity = eventRepository.save.mock.calls[0][0] as any;
+      expect(savedEntity.lat).toBeUndefined();
+      expect(savedEntity.lon).toBeUndefined();
+
+      expect(eventRepository.update).toHaveBeenCalledWith(2, {
+        lat: 38.25,
+        lon: -85.76,
+      });
+      expect(result.lat).toBe(38.25);
+      expect(result.lon).toBe(-85.76);
+    });
+
+    it('should not geocode when coordinates are provided', async () => {
+      eventQueryService.findBySourceAttributes.mockResolvedValue([]);
+      const geocodeSpy = jest.spyOn(service as any, 'geocodeAddress');
+
+      const eventWithCoords: ExternalEventDto = {
+        ...mockEventDto,
+        location: {
+          description: 'Test Location',
+          lat: 40.7128,
+          lon: -74.006,
+        },
+      };
+
+      await service.processExternalEvent(eventWithCoords, 'tenant1');
+
+      expect(geocodeSpy).not.toHaveBeenCalled();
+      expect(eventRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('should still save the row when the geocoder returns null', async () => {
+      eventQueryService.findBySourceAttributes.mockResolvedValue([]);
+      jest.spyOn(service as any, 'geocodeAddress').mockResolvedValue(null);
+      const emitter = module.get(EventEmitter2);
+
+      const result = await service.processExternalEvent(
+        eventWithAddressOnly,
+        'tenant1',
+      );
+
+      expect(eventRepository.save).toHaveBeenCalledTimes(1);
+      expect(eventRepository.update).not.toHaveBeenCalled();
+      expect(result.lat).toBeUndefined();
+      expect(result.lon).toBeUndefined();
+      expect(emitter.emit).toHaveBeenCalledWith(
+        'event.ingested',
+        expect.objectContaining({ eventId: 2 }),
+      );
+    });
+
+    it('should keep geocoding out of the residual find-to-insert window (measured)', async () => {
+      // The race window is the gap between find-by-sourceId resolving empty
+      // and the INSERT. It used to include the geocoder's 1.1-3.3s of
+      // rate-limit sleep; now it should only contain handleEventCreator's
+      // I/O (simulated at 25ms here) plus sub-ms bookkeeping.
+      const simulatedCreatorIoMs = 25;
+      let findResolvedAt = 0;
+      let saveCalledAt = 0;
+
+      eventQueryService.findBySourceAttributes.mockImplementation(() => {
+        findResolvedAt = performance.now();
+        return Promise.resolve([]);
+      });
+      shadowAccountService.findOrCreateShadowAccount.mockImplementation(
+        async () => {
+          await new Promise((resolve) =>
+            setTimeout(resolve, simulatedCreatorIoMs),
+          );
+          return mockUser;
+        },
+      );
+      eventRepository.save.mockImplementation((entity: any) => {
+        saveCalledAt = performance.now();
+        return Promise.resolve({ ...entity, id: 2 });
+      });
+      const geocodeSpy = jest
+        .spyOn(service as any, 'geocodeAddress')
+        .mockResolvedValue({ lat: 38.25, lon: -85.76 });
+
+      await service.processExternalEvent(eventWithAddressOnly, 'tenant1');
+
+      const residualMs = saveCalledAt - findResolvedAt;
+      const overheadMs = residualMs - simulatedCreatorIoMs;
+      console.info(
+        `[AC2] residual find->insert window: ${residualMs.toFixed(1)}ms total, ` +
+          `${overheadMs.toFixed(1)}ms beyond the simulated ${simulatedCreatorIoMs}ms handleEventCreator I/O`,
+      );
+      expect(geocodeSpy.mock.invocationCallOrder[0]).toBeGreaterThan(
+        eventRepository.save.mock.invocationCallOrder[0],
+      );
+      expect(residualMs).toBeGreaterThanOrEqual(simulatedCreatorIoMs - 1);
+      expect(overheadMs).toBeLessThan(100);
+    });
+  });
+
+  describe('Unique violation on insert (23505)', () => {
+    const uniqueViolation = () =>
+      Object.assign(
+        new Error(
+          'duplicate key value violates unique constraint "UQ_tenant_events_source"',
+        ),
+        { code: '23505' },
+      );
+
+    it('should resolve as an idempotent update: re-fetch by source and return the winner', async () => {
+      eventQueryService.findBySourceAttributes
+        .mockResolvedValueOnce([]) // initial dedup check misses
+        .mockResolvedValueOnce([mockExistingEvent as unknown as EventEntity]); // post-conflict re-fetch
+      eventRepository.save.mockRejectedValue(uniqueViolation());
+
+      const result = await service.processExternalEvent(
+        mockEventDto,
+        'tenant1',
+      );
+
+      expect(result).toBe(mockExistingEvent);
+      expect(eventQueryService.findBySourceAttributes).toHaveBeenLastCalledWith(
+        mockEventDto.source.id,
+        mockEventDto.source.type,
+        'tenant1',
+      );
+      expect(deduplicationFailuresCounter.inc).not.toHaveBeenCalled();
+    });
+
+    it('should not emit event.ingested on the loser path', async () => {
+      eventQueryService.findBySourceAttributes
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([mockExistingEvent as unknown as EventEntity]);
+      eventRepository.save.mockRejectedValue(uniqueViolation());
+      const emitter = module.get(EventEmitter2);
+
+      await service.processExternalEvent(mockEventDto, 'tenant1');
+
+      expect(emitter.emit).not.toHaveBeenCalled();
+    });
+
+    it('should recognize the violation when the code is only on driverError', async () => {
+      eventQueryService.findBySourceAttributes
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([mockExistingEvent as unknown as EventEntity]);
+      eventRepository.save.mockRejectedValue(
+        Object.assign(new Error('query failed'), {
+          driverError: { code: '23505' },
+        }),
+      );
+
+      const result = await service.processExternalEvent(
+        mockEventDto,
+        'tenant1',
+      );
+
+      expect(result).toBe(mockExistingEvent);
+    });
+
+    it('should rethrow when the re-fetch finds no row (violation on another constraint)', async () => {
+      eventQueryService.findBySourceAttributes.mockResolvedValue([]);
+      eventRepository.save.mockRejectedValue(uniqueViolation());
+
+      await expect(
+        service.processExternalEvent(mockEventDto, 'tenant1'),
+      ).rejects.toThrow('duplicate key value violates unique constraint');
+    });
+
+    it('should propagate non-unique save errors with a bounded metric label', async () => {
+      eventQueryService.findBySourceAttributes.mockResolvedValue([]);
+      eventRepository.save.mockRejectedValue(
+        new Error('connection terminated unexpectedly: secret detail xyz'),
+      );
+
+      await expect(
+        service.processExternalEvent(mockEventDto, 'tenant1'),
+      ).rejects.toThrow('connection terminated');
+
+      expect(deduplicationFailuresCounter.inc).toHaveBeenCalledWith(
+        expect.objectContaining({ error: 'process_exception' }),
+      );
+      const labels = deduplicationFailuresCounter.inc.mock.calls[0][0] as any;
+      expect(labels.error).not.toContain('secret detail');
     });
   });
 

--- a/src/event/services/event-integration.service.ts
+++ b/src/event/services/event-integration.service.ts
@@ -661,16 +661,24 @@ export class EventIntegrationService {
 
     // Geocode only now that the row exists, applying lat/lon as a targeted
     // follow-up update (both columns are nullable and nothing in the create
-    // path reads them after this point).
+    // path reads them after this point). Best-effort: a failure here must not
+    // gate the event.ingested emit below — the row is already committed, and
+    // skipping the emit would strand it with no creation activity.
     if (addressToGeocode) {
-      const coords = await this.geocodeAddress(addressToGeocode);
-      if (coords) {
-        await eventRepository.update(savedEvent.id, {
-          lat: coords.lat,
-          lon: coords.lon,
-        });
-        savedEvent.lat = coords.lat;
-        savedEvent.lon = coords.lon;
+      try {
+        const coords = await this.geocodeAddress(addressToGeocode);
+        if (coords) {
+          await eventRepository.update(savedEvent.id, {
+            lat: coords.lat,
+            lon: coords.lon,
+          });
+          savedEvent.lat = coords.lat;
+          savedEvent.lon = coords.lon;
+        }
+      } catch (error) {
+        this.logger.warn(
+          `Geocoding follow-up failed for event ${savedEvent.id} (tenant ${tenantId}), continuing without coordinates: ${error.message}`,
+        );
       }
     }
 

--- a/src/event/services/event-integration.service.ts
+++ b/src/event/services/event-integration.service.ts
@@ -100,7 +100,10 @@ export class EventIntegrationService {
           is_duplicate: 'true',
         });
 
-        return this.updateExistingEvent(
+        // await so a rejection is routed through the catch below — a bare
+        // return hands the promise past the try/catch and skips the failure
+        // counter and error timer
+        return await this.updateExistingEvent(
           existingEvent,
           eventData,
           eventRepository,
@@ -119,13 +122,15 @@ export class EventIntegrationService {
         is_duplicate: 'false',
       });
 
-      return this.createNewEvent(eventData, eventRepository, tenantId);
+      return await this.createNewEvent(eventData, eventRepository, tenantId);
     } catch (error) {
       // Record the error
       this.deduplicationFailuresCounter.inc({
         tenant: tenantId,
         source_type: eventData.source.type,
-        error: error.message || 'unknown',
+        // Fixed code, never error.message — a raw message here is an
+        // unbounded Prometheus label cardinality leak
+        error: 'process_exception',
       });
 
       // Stop the timer for error case
@@ -502,6 +507,22 @@ export class EventIntegrationService {
   }
 
   /**
+   * Postgres unique_violation (23505), surfaced directly or wrapped in a
+   * TypeORM QueryFailedError (which copies the driver's `code` onto itself,
+   * but older driver versions only expose it via `driverError`).
+   */
+  private isUniqueViolation(error: unknown): boolean {
+    const code = (error as any)?.code ?? (error as any)?.driverError?.code;
+    return (
+      code === '23505' ||
+      (error instanceof Error &&
+        error.message.includes(
+          'duplicate key value violates unique constraint',
+        ))
+    );
+  }
+
+  /**
    * Create a new event from external data
    */
   private async createNewEvent(
@@ -527,7 +548,11 @@ export class EventIntegrationService {
     newEvent.status = eventData.status || EventStatus.Published;
     newEvent.visibility = eventData.visibility || EventVisibility.Public;
 
-    // Handle location
+    // Handle location. Geocoding is deferred until after the row is
+    // persisted: the Nominatim rate-limit sleep (1.1s per retry) otherwise
+    // sits between find-by-sourceId and INSERT, holding open the window in
+    // which a concurrent writer inserts a second row for the same sourceId.
+    let addressToGeocode: string | null = null;
     if (eventData.location) {
       if (eventData.location.description) {
         newEvent.location = eventData.location.description;
@@ -536,14 +561,7 @@ export class EventIntegrationService {
         newEvent.lat = eventData.location.lat;
         newEvent.lon = eventData.location.lon;
       } else if (eventData.location.description) {
-        // Try to geocode the address if we have a description but no coordinates
-        const coords = await this.geocodeAddress(
-          eventData.location.description,
-        );
-        if (coords) {
-          newEvent.lat = coords.lat;
-          newEvent.lon = coords.lon;
-        }
+        addressToGeocode = eventData.location.description;
       }
       if (eventData.location.url) {
         newEvent.locationOnline = eventData.location.url;
@@ -608,10 +626,53 @@ export class EventIntegrationService {
         imageId: newEvent.image?.id,
       })}`,
     );
-    const savedEvent = await eventRepository.save(newEvent);
+    let savedEvent: EventEntity;
+    try {
+      savedEvent = await eventRepository.save(newEvent);
+    } catch (error) {
+      if (this.isUniqueViolation(error)) {
+        // Lost an insert race to a concurrent writer: resolve idempotently by
+        // returning the row the winner created. Must not fall through to the
+        // event.ingested emit below, or the duplicate event row would be
+        // traded for a duplicate activity-feed entry.
+        this.logger.warn(
+          `Unique violation inserting event for sourceId ${eventData.source.id} (tenant ${tenantId}); resolving to the existing row`,
+        );
+        const winners = await this.eventQueryService.findBySourceAttributes(
+          eventData.source.id,
+          eventData.source.type,
+          tenantId,
+        );
+        if (winners.length > 0) {
+          this.deduplicationCounter.inc({
+            tenant: tenantId,
+            source_type: eventData.source.type,
+            method: 'unique_violation_recovery',
+          });
+          return winners[0];
+        }
+        // The violation was on some other constraint — surface it.
+      }
+      throw error;
+    }
     this.logger.debug(
       `Created new event with ID ${savedEvent.id} for tenant ${tenantId}, image: ${savedEvent.image ? savedEvent.image.id : 'none'}`,
     );
+
+    // Geocode only now that the row exists, applying lat/lon as a targeted
+    // follow-up update (both columns are nullable and nothing in the create
+    // path reads them after this point).
+    if (addressToGeocode) {
+      const coords = await this.geocodeAddress(addressToGeocode);
+      if (coords) {
+        await eventRepository.update(savedEvent.id, {
+          lat: coords.lat,
+          lon: coords.lon,
+        });
+        savedEvent.lat = coords.lat;
+        savedEvent.lon = coords.lon;
+      }
+    }
 
     // Emit event.ingested for activity feed and other listeners
     // Note: we use 'event.ingested' instead of 'event.created' to distinguish


### PR DESCRIPTION
Event intake has a race that produces duplicate rows for a single at:// record: `createNewEvent` geocodes before it saves, and the geocoder's Nominatim rate-limit sleep (1.1s per attempt, retried by chopping the address at commas) sits between find-by-sourceId and INSERT. Two concurrent writers ingesting the same record both miss the lookup and both insert. Measured in prod: ~80 duplicate groups over four days of dual-writer operation, 79 of 80 created under one second apart, with attendees split across the copies.

## Changes

- **Geocode after save.** The row is persisted first; lat/lon are applied afterwards as a targeted `update` on the saved row. Safe because both columns are nullable and nothing in the create path reads them after this point — the update path already geocodes against a persisted row. Also takes 1.1–3.3s of sleeping off the insert path. With the geocoder stubbed, the residual find→insert window is just the shadow-account lookup plus ~0.3ms of bookkeeping (spec measures and prints it).
- **23505 resolves as an idempotent update.** On a unique violation the create path re-fetches by `(sourceType, sourceId)` and returns the existing row, without emitting `event.ingested` for the loser (otherwise a duplicate event row becomes a duplicate activity-feed row). This is deliberately inert today — no unique index exists yet — but it must be deployed *before* that index is added, so a lost race can never surface a 500 on ingest. If the violation is on some other constraint, it still propagates.
- **Bounded Prometheus label.** The deduplication-failures counter passed raw `error.message` as the `error` label value — unbounded cardinality. It now passes a fixed code, matching the other three call sites.
- **Error path actually reachable.** `processExternalEvent` returned the create/update promises from inside its `try` without awaiting them, so rejections bypassed the catch — the failures counter and error-case timer never fired for exactly the errors they were written for. Now `return await`.
- **Test coverage for the geocode branches**, which were previously untested (the existing location test passes explicit coordinates, short-circuiting geocoding): with coords, without coords, geocoder-returns-null, spy-ordering proof that save precedes geocoding, and the 23505 recovery paths.

No migrations, no schema changes. Full unit suite green locally (2113 passed).