### PR TITLE
Explain what to do when the user already owns their AT Protocol account

### DIFF
--- a/src/atproto-identity/atproto-identity-recovery.service.ts
+++ b/src/atproto-identity/atproto-identity-recovery.service.ts
@@ -232,7 +232,8 @@ export class AtprotoIdentityRecoveryService {
     }
     if (!identity.isCustodial) {
       throw new BadRequestException(
-        'User already owns their AT Protocol identity',
+        'You already own this AT Protocol account. There is nothing left for ' +
+          'OpenMeet to hand over.',
       );
     }
 

--- a/src/atproto-identity/atproto-identity.controller.ts
+++ b/src/atproto-identity/atproto-identity.controller.ts
@@ -334,7 +334,8 @@ export class AtprotoIdentityController {
     }
     if (!identity.isCustodial) {
       throw new BadRequestException(
-        'User already owns their AT Protocol identity',
+        'You already own this AT Protocol account, so OpenMeet can no longer ' +
+          'change its password. Reset it directly with your PDS provider.',
       );
     }
 


### PR DESCRIPTION
Both `already owns their AT Protocol identity` guards returned a message describing our internal state rather than the user's next step.

The reset-password guard matters more once take-ownership is made atomic: flipping `isCustodial` in step 2 means a user retrying with a second reset email lands on that guard, where the old string reads like a breakage rather than a completed handover.

`completeTakeOwnership`'s identical guard is deliberately untouched — it should stop throwing and become an idempotent no-op, which belongs with the atomicity fix rather than here.

Strings only; no behaviour change. No test asserts either production message (the two occurrences in `atproto-identity.controller.spec.ts` are mock payloads, asserted on the exception class).