### PR TITLE
Hide draft and private occurrences from anonymous series reads

### DIFF
--- a/src/event/event.controller.spec.ts
+++ b/src/event/event.controller.spec.ts
@@ -85,6 +85,7 @@ const mockEventQueryService = {
   getEventsByCreator: jest.fn(),
   getEventsByAttendee: jest.fn(),
   showEventBySlug: jest.fn(),
+  findEventsBySeriesSlug: jest.fn(),
 };
 
 const mockEventRecommendationService = {
@@ -728,6 +729,80 @@ describe('EventController', () => {
       await expect(
         controller.syncAtproto('non-existent-event', mockUser),
       ).rejects.toThrow('Event not found');
+    });
+  });
+  describe('getEventsBySeries', () => {
+    const buildEvent = () =>
+      ({
+        ...mockEvent,
+        sourceData: { did: 'did:plc:abc123', handle: 'someone.bsky.social' },
+        matrixRoomId: '!room:matrix.openmeet.net',
+      }) as unknown as EventEntity;
+
+    beforeEach(() => {
+      mockEventQueryService.findEventsBySeriesSlug.mockReset();
+    });
+
+    it('should restrict the query to publicly visible occurrences for anonymous callers', async () => {
+      mockEventQueryService.findEventsBySeriesSlug.mockResolvedValue([[], 0]);
+
+      await controller.getEventsBySeries('test-series', {} as any, {
+        user: undefined,
+      });
+
+      expect(mockEventQueryService.findEventsBySeriesSlug).toHaveBeenCalledWith(
+        'test-series',
+        expect.objectContaining({ publicOnly: true }),
+      );
+    });
+
+    it('should leave the query unrestricted for authenticated callers', async () => {
+      mockEventQueryService.findEventsBySeriesSlug.mockResolvedValue([[], 0]);
+
+      await controller.getEventsBySeries('test-series', {} as any, {
+        user: mockUser,
+      });
+
+      expect(mockEventQueryService.findEventsBySeriesSlug).toHaveBeenCalledWith(
+        'test-series',
+        expect.objectContaining({ publicOnly: false }),
+      );
+    });
+
+    it('should withhold sourceData and matrixRoomId from anonymous callers', async () => {
+      mockEventQueryService.findEventsBySeriesSlug.mockResolvedValue([
+        [buildEvent()],
+        1,
+      ]);
+
+      const result = await controller.getEventsBySeries(
+        'test-series',
+        {} as any,
+        { user: undefined },
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].sourceData).toBeNull();
+      expect(result[0].matrixRoomId).toBeNull();
+    });
+
+    it('should leave those fields intact for authenticated callers', async () => {
+      mockEventQueryService.findEventsBySeriesSlug.mockResolvedValue([
+        [buildEvent()],
+        1,
+      ]);
+
+      const result = await controller.getEventsBySeries(
+        'test-series',
+        {} as any,
+        { user: mockUser },
+      );
+
+      expect(result[0].sourceData).toEqual({
+        did: 'did:plc:abc123',
+        handle: 'someone.bsky.social',
+      });
+      expect(result[0].matrixRoomId).toBe('!room:matrix.openmeet.net');
     });
   });
 });

--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -452,11 +452,18 @@ export class EventController {
         `Starting database query for series ${seriesSlug} events at ${new Date().toISOString()}`,
       );
 
+      // This route is @Public() and VisibilityGuard cannot check it. The guard
+      // reads a :slug param, and the only param here is :seriesSlug, so the
+      // guard falls through and allows the request. Anonymous callers get the
+      // same restriction the guard would have applied, enforced in the query.
+      const isAnonymous = !_req.user;
+
       const findEventsPromise = this.eventQueryService.findEventsBySeriesSlug(
         seriesSlug,
         {
           page: +pagination.page || 1,
           limit: +pagination.limit || 10,
+          publicOnly: isAnonymous,
         },
       );
 
@@ -486,6 +493,19 @@ export class EventController {
       this.logger.log(
         `Returning ${events.length} events for series ${seriesSlug}`,
       );
+
+      // Neither entity carries @Exclude, so every loaded column would be sent.
+      // sourceData holds the original poster's DID, handle, CID and rkey, and
+      // matrixRoomId is an internal room address. Remove both before they go
+      // to an unauthenticated caller.
+      if (isAnonymous) {
+        for (const event of events) {
+          event.sourceData = null;
+          // Column is nullable; the entity types it as a bare string.
+          event.matrixRoomId = null as unknown as string;
+        }
+      }
+
       return events;
     } catch (error) {
       this.logger.error(

--- a/src/event/services/event-query.service.spec.ts
+++ b/src/event/services/event-query.service.spec.ts
@@ -1001,4 +1001,80 @@ describe('EventQueryService', () => {
       expect(result).toHaveLength(0);
     });
   });
+  describe('findEventsBySeriesSlug visibility predicate', () => {
+    const buildQueryBuilderMock = () => ({
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+    });
+
+    const runWith = async (options: {
+      page: number;
+      limit: number;
+      publicOnly?: boolean;
+    }) => {
+      const qb = buildQueryBuilderMock();
+      jest
+        .spyOn(service['tenantConnectionService'], 'getTenantConnection')
+        .mockResolvedValue({
+          getRepository: jest.fn().mockReturnValue({
+            createQueryBuilder: jest.fn().mockReturnValue(qb),
+          }),
+        } as any);
+
+      await service.findEventsBySeriesSlug('test-series', options);
+      return qb;
+    };
+
+    it('should restrict status and visibility when publicOnly is set', async () => {
+      const qb = await runWith({ page: 1, limit: 10, publicOnly: true });
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'event.status IN (:...visibleStatuses)',
+        {
+          visibleStatuses: [EventStatus.Published, EventStatus.Cancelled],
+        },
+      );
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'event.visibility IN (:...publicVisibilities)',
+        {
+          publicVisibilities: [
+            EventVisibility.Public,
+            EventVisibility.Unlisted,
+          ],
+        },
+      );
+    });
+
+    it('should never expose draft, pending or private occurrences when publicOnly is set', async () => {
+      const qb = await runWith({ page: 1, limit: 10, publicOnly: true });
+
+      const statusCall = qb.andWhere.mock.calls.find(
+        (call) => call[0] === 'event.status IN (:...visibleStatuses)',
+      );
+      const visibilityCall = qb.andWhere.mock.calls.find(
+        (call) => call[0] === 'event.visibility IN (:...publicVisibilities)',
+      );
+
+      expect(statusCall).toBeDefined();
+      expect(visibilityCall).toBeDefined();
+
+      const allowedStatuses = statusCall![1].visibleStatuses;
+      const allowedVisibilities = visibilityCall![1].publicVisibilities;
+
+      expect(allowedStatuses).not.toContain(EventStatus.Draft);
+      expect(allowedStatuses).not.toContain(EventStatus.Pending);
+      expect(allowedVisibilities).not.toContain(EventVisibility.Private);
+    });
+
+    it('should not restrict the query when publicOnly is unset', async () => {
+      const qb = await runWith({ page: 1, limit: 10 });
+
+      expect(qb.andWhere).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/event/services/event-query.service.ts
+++ b/src/event/services/event-query.service.ts
@@ -1697,11 +1697,17 @@ export class EventQueryService {
 
   /**
    * Find all events (occurrences) that belong to a series by the series slug
+   *
+   * Pass publicOnly when the results are going to an unauthenticated caller.
+   * It limits the query to occurrences that are safe to show anonymously.
+   * Internal callers such as series materialization and template lookup must
+   * leave it unset. They need to see every occurrence, drafts included, or
+   * they will create duplicates of occurrences that already exist.
    */
   @Trace('event-query.findEventsBySeriesSlug')
   async findEventsBySeriesSlug(
     seriesSlug: string,
-    options?: { page: number; limit: number },
+    options?: { page: number; limit: number; publicOnly?: boolean },
   ): Promise<[EventEntity[], number]> {
     try {
       await this.initializeRepository();
@@ -1722,6 +1728,21 @@ export class EventQueryService {
         .orderBy('event.startDate', 'ASC')
         .skip((page - 1) * limit)
         .take(limit);
+
+      // This is the same rule VisibilityGuard applies to GET /events/:slug.
+      // It runs in SQL rather than after the fetch so paging stays correct.
+      if (options?.publicOnly) {
+        queryBuilder
+          .andWhere('event.status IN (:...visibleStatuses)', {
+            visibleStatuses: [EventStatus.Published, EventStatus.Cancelled],
+          })
+          .andWhere('event.visibility IN (:...publicVisibilities)', {
+            publicVisibilities: [
+              EventVisibility.Public,
+              EventVisibility.Unlisted,
+            ],
+          });
+      }
 
       try {
         const [events, total] = await queryBuilder.getManyAndCount();


### PR DESCRIPTION
## The problem

`GET /api/events/series/:seriesSlug/events` is a public route with no status or
visibility filter. Anonymous callers received draft and private occurrences of a
series along with the published ones. This is live today.

`VisibilityGuard` is applied to the route but never checks it. The guard reads a
`:slug` route param, and the only param on this route is `:seriesSlug`, so the
guard finds no event to look up and allows the request through.

The response also carried every loaded column, because neither `EventEntity` nor
`GroupEntity` has any `@Exclude` decorators. That included `sourceData`, which
holds the original poster's DID, handle, CID and rkey, and the internal
`matrixRoomId`.

## The fix

`findEventsBySeriesSlug` takes a new optional `publicOnly` flag. When set, it adds
the same predicate the guard already applies to `GET /events/:slug`: published or
cancelled status, and public or unlisted visibility. The predicate runs in SQL
rather than after the fetch, so paging stays correct.

The controller sets the flag when the request has no user. Signed-in callers get
the same results they get today.

For anonymous callers the controller also clears `sourceData` and `matrixRoomId`.
`sourceId` is left in place because the web app renders it as the public AT
Protocol attribution link for events imported from Bluesky.

## Why the flag is opt-in

About twelve internal callers share this method, including series materialization,
the existence check, and template lookup. Those need to see every occurrence.
If drafts were hidden from them they would treat existing occurrences as missing
and create duplicates. Only the public controller path passes the flag.

`VisibilityGuard` itself is unchanged. Teaching it about series would mean adding
a series lookup and a new branch to a guard that many routes depend on. The query
predicate gives the same result with a smaller blast radius.

## Status values

The filter allows published and cancelled, not published alone. That matches the
guard at `visibility.guard.ts` and the other public queries in
`event-query.service.ts`. Without cancelled, a cancelled occurrence would quietly
disappear from a public series list instead of showing as cancelled.

## Tests

Seven new tests, at both layers.

Four on the controller cover which callers get the restricted query and that the
two fields are cleared for anonymous callers only.

Three on the query service assert the predicates themselves, including that draft,
pending and private are all excluded, and that leaving `publicOnly` unset keeps
the query unrestricted so materialization still sees every occurrence.

Both layers are needed. The controller tests mock the query method, so on their
own they only prove the controller asks for a restricted query, not that the
query applies the restriction. Deleting the two predicates left all four
controller tests passing with the leak restored. The query service tests fail in
that case.

## Not in this change

Anonymous access is what this fixes. Any authenticated user can still read every
occurrence and every field on this endpoint, which is existing behavior and is
tracked separately.

The endpoint also has no date filter, so a caller with no parameters gets the ten
oldest occurrences rather than upcoming ones. That is a real bug but it is not a
leak, and it is tracked separately.