### PR TITLE
fix(health): readiness probe returns 503 when the database is down

### DIFF
--- a/src/health/health.controller.spec.ts
+++ b/src/health/health.controller.spec.ts
@@ -1,8 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
 import { HealthController } from './health.controller';
 import {
+  HealthCheckError,
   HealthCheckService,
   HttpHealthIndicator,
+  TerminusModule,
   TypeOrmHealthIndicator,
 } from '@nestjs/terminus';
 import { MatrixHealthIndicator } from '../matrix/health/matrix.health';
@@ -10,11 +14,28 @@ import { MatrixHealthIndicator } from '../matrix/health/matrix.health';
 describe('HealthController', () => {
   let controller: HealthController;
   let healthCheckService: HealthCheckService;
+  let dbIndicator: { pingCheck: jest.Mock };
+  let matrixIndicator: { isHealthy: jest.Mock };
 
   beforeEach(async () => {
     healthCheckService = {
       check: jest.fn(),
     } as any;
+    dbIndicator = {
+      pingCheck: jest.fn().mockResolvedValue({ database: { status: 'up' } }),
+    };
+    matrixIndicator = {
+      isHealthy: jest.fn().mockResolvedValue({
+        status: 'up',
+        matrix: {
+          serverAvailable: true,
+          tokenState: 'valid',
+          tokenValid: true,
+          adminPrivilegesValid: true,
+          serverUrl: 'https://matrix.example.org',
+        },
+      }),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [HealthController],
@@ -29,22 +50,11 @@ describe('HealthController', () => {
         },
         {
           provide: TypeOrmHealthIndicator,
-          useValue: {},
+          useValue: dbIndicator,
         },
         {
           provide: MatrixHealthIndicator,
-          useValue: {
-            isHealthy: jest.fn().mockResolvedValue({
-              status: 'up',
-              matrix: {
-                serverAvailable: true,
-                tokenState: 'valid',
-                tokenValid: true,
-                adminPrivilegesValid: true,
-                serverUrl: 'https://matrix.example.org',
-              },
-            }),
-          },
+          useValue: matrixIndicator,
         },
       ],
     }).compile();
@@ -68,16 +78,31 @@ describe('HealthController', () => {
       });
     });
 
-    it('should return status error when database is disconnected', async () => {
-      const error = new Error('Database connection failed');
+    it('should propagate the ServiceUnavailableException when the database is disconnected, so the probe sees a 503', async () => {
+      // health.check() throws ServiceUnavailableException on a failed check;
+      // readiness must let it reach the HTTP layer instead of returning a 200 body.
+      const error = new Error('Health Check has failed!');
       jest.spyOn(healthCheckService, 'check').mockRejectedValue(error);
 
-      const result = await controller.readiness();
-      expect(result).toEqual({
-        status: 'error',
-        database: 'disconnected',
-        error: error.message,
-      });
+      await expect(controller.readiness()).rejects.toBe(error);
+    });
+
+    it('should gate on the database only — matrix is not part of readiness', async () => {
+      // Decision (TS, 2026-08-23): a Matrix outage degrades chat, not the API,
+      // and must not pull api pods out of the Service endpoints.
+      jest
+        .spyOn(healthCheckService, 'check')
+        .mockImplementation(async (checks) => {
+          for (const check of checks) {
+            await check();
+          }
+          return { status: 'ok' } as any;
+        });
+
+      await controller.readiness();
+
+      expect(dbIndicator.pingCheck).toHaveBeenCalledWith('database');
+      expect(matrixIndicator.isHealthy).not.toHaveBeenCalled();
     });
   });
 
@@ -105,5 +130,51 @@ describe('HealthController', () => {
       const result = await controller.liveness();
       expect(result).toEqual(expect.objectContaining({ status: 'error' }));
     });
+  });
+});
+
+describe('HealthController (HTTP, real Terminus check pipeline)', () => {
+  let app: INestApplication;
+  const dbIndicator = { pingCheck: jest.fn() };
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [TerminusModule],
+      controllers: [HealthController],
+      providers: [
+        { provide: HttpHealthIndicator, useValue: {} },
+        { provide: TypeOrmHealthIndicator, useValue: dbIndicator },
+        { provide: MatrixHealthIndicator, useValue: { isHealthy: jest.fn() } },
+      ],
+    }).compile();
+
+    app = module.createNestApplication({ logger: false });
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should answer 503 when the database ping fails', async () => {
+    dbIndicator.pingCheck.mockRejectedValue(
+      new HealthCheckError('TypeOrm health check failed', {
+        database: { status: 'down' },
+      }),
+    );
+
+    const res = await request(app.getHttpServer()).get('/health/readiness');
+
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe('error');
+  });
+
+  it('should answer 200 when the database ping succeeds', async () => {
+    dbIndicator.pingCheck.mockResolvedValue({ database: { status: 'up' } });
+
+    const res = await request(app.getHttpServer()).get('/health/readiness');
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
   });
 });

--- a/src/health/health.controller.spec.ts
+++ b/src/health/health.controller.spec.ts
@@ -10,6 +10,7 @@ import {
   TypeOrmHealthIndicator,
 } from '@nestjs/terminus';
 import { MatrixHealthIndicator } from '../matrix/health/matrix.health';
+import { GlobalExceptionFilter } from '../filters/global-exception.filter';
 
 describe('HealthController', () => {
   let controller: HealthController;
@@ -149,6 +150,9 @@ describe('HealthController (HTTP, real Terminus check pipeline)', () => {
     }).compile();
 
     app = module.createNestApplication({ logger: false });
+    // Mirror production: GlobalExceptionFilter (APP_FILTER in InterceptorsModule)
+    // catches the ServiceUnavailableException, keeps its 503, and rewrites the body.
+    app.useGlobalFilters(new GlobalExceptionFilter({ inc: jest.fn() } as any));
     await app.init();
   });
 
@@ -166,7 +170,8 @@ describe('HealthController (HTTP, real Terminus check pipeline)', () => {
     const res = await request(app.getHttpServer()).get('/health/readiness');
 
     expect(res.status).toBe(503);
-    expect(res.body.status).toBe('error');
+    expect(res.body.statusCode).toBe(503);
+    expect(res.body.path).toBe('/health/readiness');
   });
 
   it('should answer 200 when the database ping succeeds', async () => {

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -38,18 +38,11 @@ export class HealthController {
   @Get('readiness')
   @ApiOperation({ summary: 'Readiness probe' })
   async readiness() {
-    try {
-      return await this.health.check([
-        () => this.db.pingCheck('database'),
-        () => this.matrix.isHealthy('matrix'),
-      ]);
-    } catch (error) {
-      return {
-        status: 'error',
-        database: 'disconnected',
-        error: error.message,
-      };
-    }
+    // Let the ServiceUnavailableException propagate: the 503 is how the probe
+    // learns the pod cannot serve, so Kubernetes pulls it from the Service.
+    // Database only — a Matrix outage degrades chat, not the API, and must not
+    // take every api pod out of rotation (see /health/matrix for that signal).
+    return await this.health.check([() => this.db.pingCheck('database')]);
   }
 
   @HealthCheck()


### PR DESCRIPTION
## Problem

`readiness()` wrapped the Terminus check in a try/catch and returned a plain object on failure, which NestJS serializes as HTTP 200. So a pod that can't reach Postgres passes its readiness probe:

- a pod that loses the database stays in the Service endpoints and keeps taking traffic
- a `maxUnavailable=0` rolling update into a broken DB config replaces both pods and completes "successfully"
- the startup probe points at the same path, so it can't catch a DB-broken start either

The old behavior was observed before the fix: with the database ping failing, `GET /health/readiness` answered 200 through the real Terminus pipeline (the new HTTP-level spec, run pre-fix, failed with `Expected: 503, Received: 200`).

## Fix

- Let the `ServiceUnavailableException` propagate — the 503 is how the probe reports "not ready".
- Readiness now gates on the **database only**. Matrix was in the check alongside the DB ping; once the 503 propagates, a Matrix outage would have pulled every api pod out of Service. A Matrix outage degrades chat, not the API, so it comes out of readiness — `/health/matrix` still carries that signal. `liveness` is unchanged (its always-OK behavior is deliberate).

The spec test asserting the error body (`should return status error when database is disconnected`) encoded the old behavior and is flipped deliberately: it now asserts propagation. New HTTP-level tests cover 503 on DB-down, 200 healthy, and matrix staying out of readiness.

## Consumers checked

`GlobalExceptionFilter` (registered via `APP_FILTER` in `InterceptorsModule`) catches the propagated exception, **keeps the 503** (`getStatus()` for any `HttpException`), and rewrites the body to `{statusCode, message, path, timestamp}` — the HTTP spec runs through the filter so it asserts the response the probes actually see. The k8s probes, Prometheus blackbox probe (`http_2xx` module), and ingress health check all read the status code; nothing parses the old error body. `test/kubernetes/kubernetes.e2e-spec.ts` runs against a healthy environment and still passes.

One side effect to be aware of: each failing readiness hit now also increments `unhandled_exceptions_total` and error-logs via the filter — a DB-down pod gets loud, which seems right for this failure.

Refs: om-ep1ej